### PR TITLE
feat: Add inspector word wrap and default terminal font to 16pt

### DIFF
--- a/zeus/crates/zeus-app/src/code_viewer.rs
+++ b/zeus/crates/zeus-app/src/code_viewer.rs
@@ -72,9 +72,18 @@ struct SourceRowContext {
     focused: bool,
     extension: String,
     content_width: f32,
+    word_wrap: bool,
     colors: SemanticColors,
     editor: gpui::Entity<CodeViewer>,
     caret_epoch: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct SourceVisualRow {
+    line_index: usize,
+    range: Range<usize>,
+    first: bool,
+    last: bool,
 }
 
 impl SourceDocument {
@@ -277,6 +286,81 @@ fn normalize_line_endings(text: &str, line_ending: &str) -> String {
     }
 }
 
+/// Splits one logical line into display ranges while preserving every byte.
+/// Whitespace is preferred as a boundary, but long tokens still wrap so code
+/// cannot recreate a horizontal scrolling surface while wrapping is enabled.
+pub(crate) fn word_wrap_ranges(text: &str, columns: usize) -> Vec<Range<usize>> {
+    let columns = columns.max(1);
+    if text.is_empty() {
+        return std::iter::once(0..0).collect();
+    }
+
+    let mut ranges = Vec::new();
+    let mut start = 0;
+    while start < text.len() {
+        let mut end = start;
+        let mut boundary = None;
+        let mut used_columns = 0;
+        let mut seen_non_whitespace = false;
+        for (offset, character) in text[start..].char_indices() {
+            let character_columns = if character == '\t' { 4 } else { 1 };
+            if used_columns > 0 && used_columns + character_columns > columns {
+                break;
+            }
+            end = start + offset + character.len_utf8();
+            used_columns += character_columns;
+            if character.is_whitespace() {
+                if seen_non_whitespace {
+                    boundary = Some(end);
+                }
+            } else {
+                seen_non_whitespace = true;
+            }
+        }
+        if end == text.len() {
+            ranges.push(start..end);
+            break;
+        }
+        let split = boundary.filter(|boundary| *boundary > start).unwrap_or(end);
+        ranges.push(start..split);
+        start = split;
+    }
+    ranges
+}
+
+fn source_visual_rows(document: &SourceDocument, columns: usize) -> Vec<SourceVisualRow> {
+    let mut rows = Vec::new();
+    for (line_index, line) in document.lines.iter().enumerate() {
+        let source = document.editor.text()[line.range.clone()].trim_end_matches(['\r', '\n']);
+        let ranges = word_wrap_ranges(source, columns);
+        let last = ranges.len().saturating_sub(1);
+        rows.extend(
+            ranges
+                .into_iter()
+                .enumerate()
+                .map(|(index, range)| SourceVisualRow {
+                    line_index,
+                    range,
+                    first: index == 0,
+                    last: index == last,
+                }),
+        );
+    }
+    rows
+}
+
+fn source_visual_index(document: &SourceDocument, line_index: usize, columns: usize) -> usize {
+    document
+        .lines
+        .iter()
+        .take(line_index)
+        .map(|line| {
+            let source = document.editor.text()[line.range.clone()].trim_end_matches(['\r', '\n']);
+            word_wrap_ranges(source, columns).len()
+        })
+        .sum()
+}
+
 pub struct CodeViewer {
     tokio: tokio::runtime::Handle,
     focus: FocusHandle,
@@ -301,10 +385,17 @@ pub struct CodeViewer {
     /// caret back visibly before the next blink cycle begins.
     caret_epoch: u64,
     selection_dragging: bool,
+    word_wrap: bool,
+    viewport_width: f32,
 }
 
 impl CodeViewer {
-    pub fn new(tokio: tokio::runtime::Handle, cx: &mut Context<Self>) -> Self {
+    pub fn new(
+        tokio: tokio::runtime::Handle,
+        word_wrap: bool,
+        viewport_width: f32,
+        cx: &mut Context<Self>,
+    ) -> Self {
         Self {
             tokio,
             focus: cx.focus_handle(),
@@ -326,7 +417,50 @@ impl CodeViewer {
             pending_transition: None,
             caret_epoch: 0,
             selection_dragging: false,
+            word_wrap,
+            viewport_width,
         }
+    }
+
+    pub fn set_word_wrap(&mut self, word_wrap: bool, cx: &mut Context<Self>) {
+        if self.word_wrap == word_wrap {
+            return;
+        }
+        self.word_wrap = word_wrap;
+        self.recenter_scroll();
+        cx.notify();
+    }
+
+    pub fn set_viewport_width(&mut self, width: f32, cx: &mut Context<Self>) {
+        if (self.viewport_width - width).abs() < 0.5 {
+            return;
+        }
+        self.viewport_width = width;
+        if self.word_wrap {
+            self.recenter_scroll();
+            cx.notify();
+        }
+    }
+
+    fn recenter_scroll(&mut self) {
+        let logical_line = match &self.state {
+            ViewerState::Ready(document) => document.line_index_for_cursor(),
+            _ => 0,
+        };
+        let item = match &self.state {
+            ViewerState::Ready(document) if self.word_wrap => {
+                source_visual_index(document, logical_line, self.wrap_columns())
+            }
+            _ => logical_line,
+        };
+        self.scroll = UniformListScrollHandle::new();
+        self.scroll.scroll_to_item(item, ScrollStrategy::Center);
+    }
+
+    fn wrap_columns(&self) -> usize {
+        ((self.viewport_width - SOURCE_GUTTER_WIDTH - 24.0) / 7.1)
+            .floor()
+            .max(8.0) as usize
     }
 
     fn reveal_caret(&mut self) {
@@ -763,11 +897,17 @@ impl CodeViewer {
                                 this.history_index = this.history.len().saturating_sub(1);
                             }
                         }
-                        this.state = ViewerState::Ready(Box::new(SourceDocument::new(snapshot)));
+                        let document = SourceDocument::new(snapshot);
                         if let Some(line) = target_line {
-                            this.scroll
-                                .scroll_to_item(line.saturating_sub(1), ScrollStrategy::Center);
+                            let logical_line = line.saturating_sub(1);
+                            let item = if this.word_wrap {
+                                source_visual_index(&document, logical_line, this.wrap_columns())
+                            } else {
+                                logical_line
+                            };
+                            this.scroll.scroll_to_item(item, ScrollStrategy::Center);
                         }
+                        this.state = ViewerState::Ready(Box::new(document));
                     }
                     Err(message) => {
                         this.state = ViewerState::Error { reference, message };
@@ -1094,10 +1234,43 @@ impl CodeViewer {
             focused,
             extension,
             content_width: content_width.max(320.0),
+            word_wrap: self.word_wrap,
             colors,
             editor: editor.clone(),
             caret_epoch: self.caret_epoch,
         };
+        if self.word_wrap {
+            let visual_rows = Arc::new(source_visual_rows(document, self.wrap_columns()));
+            let visual_row_count = visual_rows.len();
+            return uniform_list(
+                "code-viewer-source-wrapped",
+                visual_row_count,
+                move |range, window, cx| {
+                    let viewer = editor.read(cx);
+                    let ViewerState::Ready(document) = &viewer.state else {
+                        return Vec::new();
+                    };
+                    let target = document.snapshot.target.map(|target| target.line);
+                    range
+                        .map(|display_index| {
+                            let visual = &visual_rows[display_index];
+                            source_row(
+                                document,
+                                display_index,
+                                visual,
+                                target == Some(visual.line_index + 1),
+                                &row_context,
+                                window,
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                },
+            )
+            .track_scroll(&self.scroll)
+            .size_full()
+            .into_any_element();
+        }
+
         uniform_list("code-viewer-source", rows, move |range, window, cx| {
             let viewer = editor.read(cx);
             let ViewerState::Ready(document) = &viewer.state else {
@@ -1106,9 +1279,19 @@ impl CodeViewer {
             let target = document.snapshot.target.map(|target| target.line);
             range
                 .map(|index| {
+                    let source_len = document.editor.text()[document.lines[index].range.clone()]
+                        .trim_end_matches(['\r', '\n'])
+                        .len();
+                    let visual = SourceVisualRow {
+                        line_index: index,
+                        range: 0..source_len,
+                        first: true,
+                        last: true,
+                    };
                     source_row(
                         document,
                         index,
+                        &visual,
                         target == Some(index + 1),
                         &row_context,
                         window,
@@ -1410,23 +1593,40 @@ fn source_offset_at_x(source: &str, x: gpui::Pixels, color: gpui::Rgba, window: 
 
 fn source_row(
     document: &SourceDocument,
-    index: usize,
+    display_index: usize,
+    visual: &SourceVisualRow,
     targeted: bool,
     context: &SourceRowContext,
     window: &Window,
 ) -> AnyElement {
-    let line = &document.lines[index];
-    let source = document.editor.text()[line.range.clone()]
+    let line_index = visual.line_index;
+    let visual_range = visual.range.clone();
+    let first = visual.first;
+    let last = visual.last;
+    let line = &document.lines[line_index];
+    let full_source = document.editor.text()[line.range.clone()]
         .trim_end_matches(['\r', '\n'])
         .to_owned();
     let selection = document.editor.selection().and_then(|selection| {
         let start = selection.start.max(line.range.start);
         let end = selection.end.min(line.range.end);
-        (start < end).then_some(start - line.range.start..end - line.range.start)
+        if start >= end {
+            return None;
+        }
+        let logical = start - line.range.start..end - line.range.start;
+        let start = logical.start.max(visual_range.start);
+        let end = logical.end.min(visual_range.end);
+        (start < end).then_some(start..end)
     });
-    let caret =
-        (context.focused && selection.is_none() && document.line_index_for_cursor() == index)
-            .then_some(document.editor.cursor().saturating_sub(line.range.start));
+    let logical_caret = document.editor.cursor().saturating_sub(line.range.start);
+    let caret_in_range = logical_caret >= visual_range.start
+        && (logical_caret < visual_range.end || last && logical_caret == visual_range.end);
+    let caret = (context.focused
+        && selection.is_none()
+        && document.line_index_for_cursor() == line_index
+        && caret_in_range)
+        .then_some(logical_caret.saturating_sub(visual_range.start));
+    let source = full_source[visual_range.clone()].to_owned();
     let caret_x = caret.map(|caret| {
         if source.is_empty() {
             return px(0.0);
@@ -1442,19 +1642,30 @@ fn source_row(
             .shape_line(source.clone().into(), px(11.5), &[run], None)
             .x_for_index(caret.min(source.len()))
     });
-    let styled = highlighted_source(source, &context.extension, selection);
+    let styled = highlighted_source_range(
+        &full_source,
+        visual_range.clone(),
+        &context.extension,
+        selection,
+    );
     let bounds_slot = Rc::new(Cell::new(None));
     let paint_bounds = Rc::clone(&bounds_slot);
     let click_bounds = Rc::clone(&bounds_slot);
     let drag_bounds = Rc::clone(&bounds_slot);
     let click_editor = context.editor.clone();
     let drag_editor = context.editor.clone();
+    let click_range = visual_range.clone();
+    let drag_range = visual_range;
     let colors = context.colors;
     div()
-        .id(index)
+        .id(display_index)
         .relative()
         .h(px(SOURCE_ROW_HEIGHT))
-        .min_w(px(context.content_width))
+        .min_w(px(if context.word_wrap {
+            0.0
+        } else {
+            context.content_width
+        }))
         .w_full()
         .flex()
         .items_center()
@@ -1485,15 +1696,21 @@ fn source_row(
                 } else {
                     colors.primary.alpha(0.26)
                 })
-                .child(line.number.to_string()),
+                .child(if first {
+                    line.number.to_string()
+                } else {
+                    String::new()
+                }),
         )
         .child(
             div()
                 .h_full()
                 .min_w(px(0.0))
+                .flex_1()
                 .pl(px(10.0))
                 .flex()
                 .items_center()
+                .whitespace_nowrap()
                 .font_family(crate::fonts::mono_family())
                 .text_size(px(11.5))
                 .text_color(rgba(0xd8dee9ff))
@@ -1531,18 +1748,21 @@ fn source_row(
                     let ViewerState::Ready(document) = &viewer.state else {
                         return;
                     };
-                    let Some(line) = document.lines.get(index) else {
+                    let Some(line) = document.lines.get(line_index) else {
                         return;
                     };
-                    document.editor.text()[line.range.clone()].to_owned()
+                    let source =
+                        document.editor.text()[line.range.clone()].trim_end_matches(['\r', '\n']);
+                    source[click_range.clone()].to_owned()
                 };
                 let x = event.position.x - bounds.left() - px(SOURCE_GUTTER_WIDTH) - px(10.0);
-                let local_offset = source_offset_at_x(&source, x, colors.primary, window);
+                let local_offset =
+                    click_range.start + source_offset_at_x(&source, x, colors.primary, window);
                 click_editor.update(cx, |this, cx| {
                     window.focus(&this.focus, cx);
                     this.selection_dragging = true;
                     this.place_cursor(
-                        index,
+                        line_index,
                         local_offset,
                         event.modifiers.shift,
                         event.click_count,
@@ -1567,15 +1787,18 @@ fn source_row(
                 let ViewerState::Ready(document) = &viewer.state else {
                     return;
                 };
-                let Some(line) = document.lines.get(index) else {
+                let Some(line) = document.lines.get(line_index) else {
                     return;
                 };
-                document.editor.text()[line.range.clone()].to_owned()
+                let source =
+                    document.editor.text()[line.range.clone()].trim_end_matches(['\r', '\n']);
+                source[drag_range.clone()].to_owned()
             };
             let x = event.position.x - bounds.left() - px(SOURCE_GUTTER_WIDTH) - px(10.0);
-            let local_offset = source_offset_at_x(&source, x, colors.primary, window);
+            let local_offset =
+                drag_range.start + source_offset_at_x(&source, x, colors.primary, window);
             drag_editor.update(cx, |this, cx| {
-                this.place_cursor(index, local_offset, true, 1, cx);
+                this.place_cursor(line_index, local_offset, true, 1, cx);
             });
             cx.stop_propagation();
         })
@@ -1590,13 +1813,23 @@ fn source_row(
         .into_any_element()
 }
 
-fn highlighted_source(
-    source: String,
+fn highlighted_source_range(
+    source: &str,
+    visual_range: Range<usize>,
     extension: &str,
     selection: Option<Range<usize>>,
 ) -> AnyElement {
-    let mut ranges = lexical_highlights(&source, extension);
+    let mut ranges = lexical_highlights(source, extension);
+    ranges = ranges
+        .into_iter()
+        .filter_map(|(range, style)| {
+            let start = range.start.max(visual_range.start);
+            let end = range.end.min(visual_range.end);
+            (start < end).then_some((start - visual_range.start..end - visual_range.start, style))
+        })
+        .collect();
     if let Some(selection) = selection {
+        let selection = selection.start - visual_range.start..selection.end - visual_range.start;
         ranges.retain(|(range, _)| range.end <= selection.start || range.start >= selection.end);
         ranges.push((
             selection,
@@ -1607,6 +1840,7 @@ fn highlighted_source(
         ));
         ranges.sort_by_key(|(range, _)| range.start);
     }
+    let source = source[visual_range].to_owned();
     if ranges.is_empty() {
         return div().child(source).into_any_element();
     }
@@ -1852,6 +2086,60 @@ mod tests {
         let source = "alpha  +  beta";
         assert_eq!(word_range_at(source, 7), None);
         assert_eq!(word_range_at(source, 8), None);
+    }
+
+    #[test]
+    fn word_wrap_ranges_preserve_text_and_utf8_boundaries() {
+        let source = "alpha beta café_and_a_very_long_token";
+        let ranges = word_wrap_ranges(source, 8);
+        let rebuilt = ranges
+            .iter()
+            .map(|range| &source[range.clone()])
+            .collect::<String>();
+
+        assert_eq!(rebuilt, source);
+        assert!(ranges.len() > 1);
+        assert!(
+            ranges
+                .iter()
+                .all(|range| source.is_char_boundary(range.start))
+        );
+        assert!(
+            ranges
+                .iter()
+                .all(|range| source.is_char_boundary(range.end))
+        );
+        assert!(
+            ranges
+                .iter()
+                .all(|range| source[range.clone()].chars().count() <= 8)
+        );
+    }
+
+    #[test]
+    fn word_wrap_keeps_indentation_with_the_first_code_fragment() {
+        let source = "        alpha_beta_gamma";
+        let ranges = word_wrap_ranges(source, 12);
+
+        assert!(ranges.len() > 1);
+        assert_ne!(&source[ranges[0].clone()], "        ");
+        assert_eq!(
+            ranges
+                .iter()
+                .map(|range| &source[range.clone()])
+                .collect::<String>(),
+            source
+        );
+    }
+
+    #[test]
+    fn wrapped_source_rows_keep_logical_line_identity() {
+        let document = document("let short = 1;\nlet longer = alpha_beta_gamma;", None);
+        let rows = source_visual_rows(&document, 10);
+
+        assert_eq!(rows[0].line_index, 0);
+        assert!(rows.iter().filter(|row| row.line_index == 1).count() > 1);
+        assert_eq!(source_visual_index(&document, 1, 10), 2);
     }
 
     #[test]

--- a/zeus/crates/zeus-app/src/inspector.rs
+++ b/zeus/crates/zeus-app/src/inspector.rs
@@ -26,7 +26,7 @@ use zeus_ui::{
     SemanticColors, Typo,
 };
 
-use crate::code_viewer::CodeViewer;
+use crate::code_viewer::{CodeViewer, word_wrap_ranges};
 use crate::diff::{
     DiffFile, DiffHunk, DiffLayer, DiffRow, DiffRowKind, DiffSnapshot, load_local_diff,
     snapshot_from_read_diff,
@@ -84,6 +84,7 @@ struct ScrollbarMetrics {
 #[derive(Clone, Debug)]
 pub enum InspectorEvent {
     Close,
+    OpenSettings,
     AddRemoteHost,
     Update(UpdateCommand),
 }
@@ -170,6 +171,8 @@ pub struct WorkbenchInspector {
     focus: FocusHandle,
     visible: bool,
     selected_tab: InspectorTab,
+    word_wrap: bool,
+    panel_width: f32,
     tab_direction: f32,
     tab_transition_generation: u64,
     context: Option<DiffContext>,
@@ -222,7 +225,16 @@ impl WorkbenchInspector {
         cx: &mut Context<Self>,
     ) -> Self {
         let tokio = tokio_owner.handle().clone();
-        let code_viewer = cx.new(|cx| CodeViewer::new(tokio.clone(), cx));
+        let (selected_tab, word_wrap, panel_width) = {
+            let store = runtime.store.read().expect("session store lock poisoned");
+            let preferences = store.preferences();
+            (
+                preferences.inspector_tab,
+                preferences.inspector_word_wrap,
+                preferences.inspector_width,
+            )
+        };
+        let code_viewer = cx.new(|cx| CodeViewer::new(tokio.clone(), word_wrap, panel_width, cx));
         let focus = cx.focus_handle();
         let mut changes = runtime.changes();
         let store_changes = cx.spawn(async move |this, cx| {
@@ -240,12 +252,6 @@ impl WorkbenchInspector {
                 }
             }
         });
-        let selected_tab = runtime
-            .store
-            .read()
-            .expect("session store lock poisoned")
-            .preferences()
-            .inspector_tab;
         Self {
             runtime,
             _tokio_owner: tokio_owner,
@@ -255,6 +261,8 @@ impl WorkbenchInspector {
             focus,
             visible: false,
             selected_tab,
+            word_wrap,
+            panel_width,
             tab_direction: 1.0,
             tab_transition_generation: 0,
             context: None,
@@ -318,6 +326,17 @@ impl WorkbenchInspector {
 
     pub fn set_preview_account(&mut self, preview: bool) {
         self.preview_account = preview;
+    }
+
+    pub fn set_panel_width(&mut self, width: f32, cx: &mut Context<Self>) {
+        if (self.panel_width - width).abs() < 0.5 {
+            return;
+        }
+        self.panel_width = width;
+        self.reset_diff_scroll();
+        self.code_viewer
+            .update(cx, |viewer, cx| viewer.set_viewport_width(width, cx));
+        cx.notify();
     }
 
     pub fn set_usage(&mut self, snapshot: UsageSnapshot, cx: &mut Context<Self>) {
@@ -432,6 +451,27 @@ impl WorkbenchInspector {
         }
         self.reconcile_diff_polling(cx);
         cx.notify();
+    }
+
+    pub(crate) fn set_word_wrap(&mut self, word_wrap: bool, cx: &mut Context<Self>) {
+        if self.word_wrap == word_wrap {
+            return;
+        }
+        self.word_wrap = word_wrap;
+        self.reset_diff_scroll();
+        self.code_viewer
+            .update(cx, |viewer, cx| viewer.set_word_wrap(self.word_wrap, cx));
+        cx.notify();
+    }
+
+    pub(crate) fn word_wrap_enabled(&self) -> bool {
+        self.word_wrap
+    }
+
+    fn reset_diff_scroll(&mut self) {
+        self.scroll = UniformListScrollHandle::new();
+        self.scrollbar_interaction = ScrollbarInteraction::default();
+        self.scrollbar_layout_primed = false;
     }
 
     fn select_comparison(&mut self, comparison: SessionDiffBase, cx: &mut Context<Self>) {
@@ -1000,6 +1040,35 @@ impl WorkbenchInspector {
             )
             .child(div().mt(px(8.0)).h(px(1.0)).bg(colors.primary.alpha(0.06)))
             .child(account_section_label("Account", colors))
+            .child(
+                div()
+                    .id("inspector-open-settings")
+                    .debug_selector(|| "INSPECTOR_OPEN_SETTINGS".to_owned())
+                    .mx(px(6.0))
+                    .px(px(8.0))
+                    .h(px(30.0))
+                    .flex()
+                    .items_center()
+                    .gap(px(8.0))
+                    .rounded(px(Radius::ROW))
+                    .cursor_pointer()
+                    .hover(move |element| element.bg(colors.primary.alpha(0.06)))
+                    .text_size(px(Typo::ROW.size))
+                    .text_color(colors.primary)
+                    .child(sf_symbol("gearshape", 11.0, colors.secondary))
+                    .child(div().flex_1().child("Settings"))
+                    .child(
+                        div()
+                            .text_size(px(Typo::META.size))
+                            .text_color(colors.tertiary)
+                            .child("⌘,"),
+                    )
+                    .on_click(cx.listener(|this, _, _, cx| {
+                        this.account_open = false;
+                        cx.emit(InspectorEvent::OpenSettings);
+                        cx.notify();
+                    })),
+            )
             .child(
                 div()
                     .id("inspector-account-active")
@@ -1885,26 +1954,49 @@ impl WorkbenchInspector {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let row_count = snapshot.rows.len();
         let content_width =
             (GUTTER_WIDTH + 28.0 + snapshot.max_text_columns as f32 * 7.1).clamp(320.0, 3700.0);
         let inspector = cx.entity();
         let repo_root = snapshot.repo_root.clone();
         let armed_hunk = self.armed_hunk;
-        let list = uniform_list("inspector-diff", row_count, move |range, _, _| {
-            render_rows(
-                &snapshot,
-                range,
-                content_width,
-                colors,
-                inspector.clone(),
-                &repo_root,
-                armed_hunk,
-            )
-        })
-        .with_horizontal_sizing_behavior(ListHorizontalSizingBehavior::Unconstrained)
-        .track_scroll(&self.scroll)
-        .size_full();
+        let list = if self.word_wrap {
+            let columns = ((self.panel_width - GUTTER_WIDTH - 28.0) / 7.1)
+                .floor()
+                .max(8.0) as usize;
+            let visual_rows = Arc::new(diff_visual_rows(&snapshot, columns));
+            let row_count = visual_rows.len();
+            uniform_list("inspector-diff-wrapped", row_count, move |range, _, _| {
+                render_wrapped_rows(
+                    &snapshot,
+                    &visual_rows,
+                    range,
+                    colors,
+                    inspector.clone(),
+                    &repo_root,
+                    armed_hunk,
+                )
+            })
+            .track_scroll(&self.scroll)
+            .size_full()
+            .into_any_element()
+        } else {
+            let row_count = snapshot.rows.len();
+            uniform_list("inspector-diff", row_count, move |range, _, _| {
+                render_rows(
+                    &snapshot,
+                    range,
+                    content_width,
+                    colors,
+                    inspector.clone(),
+                    &repo_root,
+                    armed_hunk,
+                )
+            })
+            .with_horizontal_sizing_behavior(ListHorizontalSizingBehavior::Unconstrained)
+            .track_scroll(&self.scroll)
+            .size_full()
+            .into_any_element()
+        };
         let scrollbar = self.render_scrollbar(colors, cx);
 
         // The list's scroll bounds are available after its first layout pass.
@@ -4361,11 +4453,53 @@ fn relative_time(milliseconds: f64) -> String {
 #[derive(Clone)]
 struct DiffRowRenderContext {
     content_width: f32,
+    word_wrap: bool,
     colors: SemanticColors,
     inspector: Entity<WorkbenchInspector>,
     repo_root: PathBuf,
     layer: DiffLayer,
     armed_hunk: Option<u64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct DiffVisualRow {
+    source_index: usize,
+    range: Range<usize>,
+    first: bool,
+}
+
+fn diff_visual_rows(snapshot: &DiffSnapshot, columns: usize) -> Vec<DiffVisualRow> {
+    let mut visual_rows = Vec::new();
+    for (source_index, row) in snapshot.rows.iter().enumerate() {
+        let prefix_columns = match row.kind {
+            DiffRowKind::File => 4,
+            DiffRowKind::Addition | DiffRowKind::Deletion => 1,
+            _ => 0,
+        };
+        let first_columns = columns.saturating_sub(prefix_columns).max(1);
+        let first = word_wrap_ranges(&row.text, first_columns)
+            .into_iter()
+            .next()
+            .unwrap_or(0..0);
+        let first_end = first.end;
+        visual_rows.push(DiffVisualRow {
+            source_index,
+            range: first,
+            first: true,
+        });
+        if first_end < row.text.len() {
+            visual_rows.extend(
+                word_wrap_ranges(&row.text[first_end..], columns)
+                    .into_iter()
+                    .map(|range| DiffVisualRow {
+                        source_index,
+                        range: first_end + range.start..first_end + range.end,
+                        first: false,
+                    }),
+            );
+        }
+    }
+    visual_rows
 }
 
 fn render_rows(
@@ -4379,6 +4513,7 @@ fn render_rows(
 ) -> Vec<AnyElement> {
     let context = DiffRowRenderContext {
         content_width,
+        word_wrap: false,
         colors,
         inspector,
         repo_root: repo_root.to_path_buf(),
@@ -4405,7 +4540,70 @@ fn render_rows(
                     })
                 })
                 .flatten();
-            render_row(index, &snapshot.rows[index], &context, file, hunk)
+            render_row(
+                index,
+                &DiffVisualRow {
+                    source_index: index,
+                    range: 0..snapshot.rows[index].text.len(),
+                    first: true,
+                },
+                &snapshot.rows[index],
+                &context,
+                file,
+                hunk,
+            )
+        })
+        .collect()
+}
+
+fn render_wrapped_rows(
+    snapshot: &DiffSnapshot,
+    visual_rows: &[DiffVisualRow],
+    range: Range<usize>,
+    colors: SemanticColors,
+    inspector: Entity<WorkbenchInspector>,
+    repo_root: &Path,
+    armed_hunk: Option<u64>,
+) -> Vec<AnyElement> {
+    let context = DiffRowRenderContext {
+        content_width: 0.0,
+        word_wrap: true,
+        colors,
+        inspector,
+        repo_root: repo_root.to_path_buf(),
+        layer: snapshot.layer,
+        armed_hunk,
+    };
+    range
+        .map(|display_index| {
+            let visual = &visual_rows[display_index];
+            let source_index = visual.source_index;
+            let owning_file = snapshot
+                .file_diffs
+                .iter()
+                .find(|file| file.row_range.contains(&source_index));
+            let file = (visual.first && snapshot.rows[source_index].kind == DiffRowKind::File)
+                .then(|| owning_file.cloned())
+                .flatten();
+            let hunk = (visual.first && snapshot.rows[source_index].kind == DiffRowKind::Hunk)
+                .then(|| {
+                    owning_file.and_then(|file| {
+                        file.hunks
+                            .iter()
+                            .find(|hunk| hunk.row_range.start == source_index)
+                            .cloned()
+                            .map(|hunk| (file.path.clone(), hunk))
+                    })
+                })
+                .flatten();
+            render_row(
+                display_index,
+                visual,
+                &snapshot.rows[source_index],
+                &context,
+                file,
+                hunk,
+            )
         })
         .collect()
 }
@@ -4425,12 +4623,16 @@ fn patch_creates_file(patch: &[u8]) -> bool {
 }
 
 fn render_row(
-    index: usize,
+    display_index: usize,
+    visual: &DiffVisualRow,
     row: &DiffRow,
     context: &DiffRowRenderContext,
     file: Option<DiffFile>,
     hunk: Option<(PathBuf, DiffHunk)>,
 ) -> AnyElement {
+    let source_index = visual.source_index;
+    let text_range = visual.range.clone();
+    let first = visual.first;
     let content_width = context.content_width;
     let colors = context.colors;
     let inspector = context.inspector.clone();
@@ -4446,10 +4648,11 @@ fn render_row(
         DiffRowKind::Meta => (rgba(0x00000000), rgba(0xffffff66), ""),
     };
     let line_number = |line: Option<u32>| line.map_or_else(String::new, |line| line.to_string());
+    let marker = if first { marker } else { "" };
     let text = if row.kind == DiffRowKind::File {
-        SharedString::from(row.text.clone())
+        SharedString::from(row.text[text_range.clone()].to_owned())
     } else {
-        SharedString::from(format!("{marker}{}", row.text))
+        SharedString::from(format!("{marker}{}", &row.text[text_range]))
     };
 
     let reference = row.text.clone();
@@ -4482,7 +4685,7 @@ fn render_row(
         };
         actions = actions.child(
             div()
-                .id(("ask-diff-file", index))
+                .id(("ask-diff-file", source_index))
                 .h_full()
                 .px(px(5.0))
                 .flex()
@@ -4509,7 +4712,7 @@ fn render_row(
                 let path = file.path.clone();
                 actions = actions.child(
                     div()
-                        .id(("stage-diff-file", index))
+                        .id(("stage-diff-file", source_index))
                         .h_full()
                         .px(px(5.0))
                         .flex()
@@ -4535,7 +4738,7 @@ fn render_row(
                 let path = file.path.clone();
                 actions = actions.child(
                     div()
-                        .id(("unstage-diff-file", index))
+                        .id(("unstage-diff-file", source_index))
                         .h_full()
                         .px(px(5.0))
                         .flex()
@@ -4572,7 +4775,7 @@ fn render_row(
         };
         actions = actions.child(
             div()
-                .id(("ask-diff-hunk", index))
+                .id(("ask-diff-hunk", source_index))
                 .h_full()
                 .px(px(5.0))
                 .flex()
@@ -4600,7 +4803,7 @@ fn render_row(
                 let stage_patch = patch.clone();
                 actions = actions.child(
                     div()
-                        .id(("stage-diff-hunk", index))
+                        .id(("stage-diff-hunk", source_index))
                         .h_full()
                         .px(px(5.0))
                         .flex()
@@ -4632,7 +4835,7 @@ fn render_row(
                     let armed = armed_hunk == Some(fingerprint);
                     actions = actions.child(
                         div()
-                            .id(("discard-diff-hunk", index))
+                            .id(("discard-diff-hunk", source_index))
                             .h_full()
                             .px(px(5.0))
                             .flex()
@@ -4677,7 +4880,7 @@ fn render_row(
                 let unstage_inspector = inspector.clone();
                 actions = actions.child(
                     div()
-                        .id(("unstage-diff-hunk", index))
+                        .id(("unstage-diff-hunk", source_index))
                         .h_full()
                         .px(px(5.0))
                         .flex()
@@ -4709,25 +4912,30 @@ fn render_row(
 
     let has_actions = file.is_some() || hunk.is_some();
     div()
-        .id(index)
+        .id(display_index)
         .relative()
         .h(px(DIFF_ROW_HEIGHT))
-        .min_w(px(content_width))
+        .min_w(px(if context.word_wrap {
+            0.0
+        } else {
+            content_width
+        }))
         .w_full()
         .flex()
         .items_center()
         .bg(background)
         .when(row.kind == DiffRowKind::File, |line| {
-            line.border_t_1()
-                .border_color(colors.primary.alpha(0.08))
-                .cursor_pointer()
-                .hover(move |line| line.bg(colors.primary.alpha(0.07)))
-                .on_click(move |_, _, cx| {
-                    open_inspector.update(cx, |inspector, cx| {
-                        inspector.open_file_reference(cwd.clone(), reference.clone(), cx);
-                    });
-                    cx.stop_propagation();
-                })
+            line.when(first, |line| {
+                line.border_t_1().border_color(colors.primary.alpha(0.08))
+            })
+            .cursor_pointer()
+            .hover(move |line| line.bg(colors.primary.alpha(0.07)))
+            .on_click(move |_, _, cx| {
+                open_inspector.update(cx, |inspector, cx| {
+                    inspector.open_file_reference(cwd.clone(), reference.clone(), cx);
+                });
+                cx.stop_propagation();
+            })
         })
         .child(
             div()
@@ -4744,14 +4952,25 @@ fn render_row(
                 .font_family(crate::fonts::mono_family())
                 .text_size(px(10.5))
                 .text_color(colors.primary.alpha(0.25))
-                .child(line_number(row.old_line))
-                .child(line_number(row.new_line)),
+                .child(if first {
+                    line_number(row.old_line)
+                } else {
+                    String::new()
+                })
+                .child(if first {
+                    line_number(row.new_line)
+                } else {
+                    String::new()
+                }),
         )
         .child(
             div()
                 .h_full()
+                .min_w(px(0.0))
+                .flex_1()
                 .flex()
                 .items_center()
+                .whitespace_nowrap()
                 .pl(px(if row.kind == DiffRowKind::File {
                     10.0
                 } else {
@@ -4766,7 +4985,7 @@ fn render_row(
                     FontWeight::NORMAL
                 })
                 .text_color(foreground)
-                .when(row.kind == DiffRowKind::File, |content| {
+                .when(first && row.kind == DiffRowKind::File, |content| {
                     content.child(sf_symbol(
                         "chevron.left.forwardslash.chevron.right",
                         13.0,
@@ -4813,6 +5032,43 @@ mod tests {
         assert_eq!(compact_duration(540), "9m");
     }
 
+    #[test]
+    fn wrapped_diff_rows_preserve_logical_rows_and_text() {
+        let snapshot = DiffSnapshot {
+            rows: vec![
+                DiffRow {
+                    kind: DiffRowKind::File,
+                    old_line: None,
+                    new_line: None,
+                    text: "src/a_very_long_filename.rs".to_owned(),
+                },
+                DiffRow {
+                    kind: DiffRowKind::Addition,
+                    old_line: None,
+                    new_line: Some(1),
+                    text: "let value = alpha_beta_gamma;".to_owned(),
+                },
+            ],
+            ..DiffSnapshot::default()
+        };
+        let rows = diff_visual_rows(&snapshot, 10);
+
+        for source_index in 0..snapshot.rows.len() {
+            let rebuilt = rows
+                .iter()
+                .filter(|row| row.source_index == source_index)
+                .map(|row| &snapshot.rows[source_index].text[row.range.clone()])
+                .collect::<String>();
+            assert_eq!(rebuilt, snapshot.rows[source_index].text);
+            assert_eq!(
+                rows.iter()
+                    .filter(|row| row.source_index == source_index && row.first)
+                    .count(),
+                1
+            );
+        }
+    }
+
     #[gpui::test]
     fn account_avatar_opens_the_account_menu(cx: &mut TestAppContext) {
         let runtime = Arc::new(StoreRuntime::inert());
@@ -4840,6 +5096,7 @@ mod tests {
         let inspector = harness.read_with(cx, |harness, _| harness.inspector.clone());
         assert!(inspector.read_with(cx, |inspector, _| inspector.account_open));
         assert!(cx.debug_bounds("INSPECTOR_ADD_REMOTE_HOST").is_some());
+        assert!(cx.debug_bounds("INSPECTOR_OPEN_SETTINGS").is_some());
     }
 
     #[test]

--- a/zeus/crates/zeus-app/src/root.rs
+++ b/zeus/crates/zeus-app/src/root.rs
@@ -299,11 +299,6 @@ impl RootView {
             if let SidebarEvent::Update(command) = event {
                 this.services.updates.send(command.clone());
             }
-            if matches!(event, SidebarEvent::OpenSettings)
-                && let Some(surfaces) = &this.utility_surfaces
-            {
-                surfaces.update(cx, |surfaces, cx| surfaces.open_settings(cx));
-            }
             if matches!(event, SidebarEvent::AddRemoteHost)
                 && let Some(surfaces) = &this.utility_surfaces
             {
@@ -349,6 +344,11 @@ impl RootView {
                 window,
                 |this, _, event, window, cx| match event {
                     InspectorEvent::Close => this.set_inspector_open(false, cx),
+                    InspectorEvent::OpenSettings => {
+                        if let Some(surfaces) = &this.utility_surfaces {
+                            surfaces.update(cx, |surfaces, cx| surfaces.open_settings(cx));
+                        }
+                    }
                     InspectorEvent::AddRemoteHost => {
                         if let Some(surfaces) = &this.utility_surfaces {
                             surfaces.update(cx, |surfaces, cx| {
@@ -1415,6 +1415,11 @@ impl RootView {
         };
         let width = dragged_panel_width(base_width, pointer_x - origin_x, self.sidebar_on_right());
         self.inspector_width = width.clamp(self.inspector_min_width(), self.inspector_max_width);
+        if let Some(inspector) = &self.inspector {
+            inspector.update(cx, |inspector, cx| {
+                inspector.set_panel_width(self.inspector_width, cx)
+            });
+        }
         cx.notify();
     }
 
@@ -1423,6 +1428,9 @@ impl RootView {
             return;
         }
         let width = self.inspector_width;
+        if let Some(inspector) = &self.inspector {
+            inspector.update(cx, |inspector, cx| inspector.set_panel_width(width, cx));
+        }
         if let Err(error) = self
             .services
             .store
@@ -1950,14 +1958,25 @@ impl Render for RootView {
             .terminal
             .as_ref()
             .is_some_and(|terminal| terminal.read(cx).is_startup_welcome_visible());
-        let has_selected_session = self
-            .services
-            .store
-            .store
-            .read()
-            .expect("session store lock poisoned")
-            .selected_session_id()
-            .is_some();
+        let (has_selected_session, inspector_word_wrap) = {
+            let store = self
+                .services
+                .store
+                .store
+                .read()
+                .expect("session store lock poisoned");
+            (
+                store.selected_session_id().is_some(),
+                store.preferences().inspector_word_wrap,
+            )
+        };
+        if let Some(inspector) = &self.inspector
+            && inspector.read(cx).word_wrap_enabled() != inspector_word_wrap
+        {
+            inspector.update(cx, |inspector, cx| {
+                inspector.set_word_wrap(inspector_word_wrap, cx)
+            });
+        }
         let window_width = f32::from(window.inner_window_bounds().get_bounds().size.width);
         let occupied_sidebar_width = if sidebar_visible { sidebar_width } else { 0.0 };
         self.inspector_max_width =

--- a/zeus/crates/zeus-app/src/sidebar/view.rs
+++ b/zeus/crates/zeus-app/src/sidebar/view.rs
@@ -37,15 +37,12 @@ use super::{
 const SIDEBAR_TITLE_SIZE: f32 = 14.0;
 const SIDEBAR_SUBTITLE_SIZE: f32 = 12.0;
 const SIDEBAR_ROW_HEIGHT: f32 = 28.0;
-const SIDEBAR_NEW_AGENT_HEIGHT: f32 = 40.0;
+const SIDEBAR_NEW_AGENT_HEIGHT: f32 = 48.0;
 
 #[derive(Clone, Debug)]
 pub enum SidebarEvent {
     VisibilityChanged,
     WidthChanged,
-    /// The title-bar gear is a settings affordance. RootView owns the settings
-    /// surface, so the sidebar requests it instead of opening its account menu.
-    OpenSettings,
     /// One-click path from the footer menu into the Remote host editor.
     AddRemoteHost,
     /// A plain click (or shortcut) selected a session: hand keyboard focus
@@ -542,13 +539,14 @@ impl Sidebar {
         };
         div()
             .id("new-agent")
+            .debug_selector(|| "SIDEBAR_NEW_AGENT".to_owned())
             .mx(px(Space::INSET))
             .mb(px(3.0))
             .px(px(Space::ROW_H))
             .h(px(SIDEBAR_NEW_AGENT_HEIGHT))
             .flex()
             .items_center()
-            .gap(px(6.0))
+            .gap(px(9.0))
             .rounded(px(Radius::ROW))
             .bg(Fill::hover(colors, hovering))
             .cursor_pointer()
@@ -564,24 +562,18 @@ impl Sidebar {
             }))
             .child(
                 div()
-                    .w(px(16.0))
-                    .flex()
-                    .items_center()
-                    .justify_center()
-                    .child(sf_symbol("square.and.pencil", 13.0, colors.secondary)),
-            )
-            .child(
-                div()
+                    .debug_selector(|| "SIDEBAR_NEW_AGENT_COPY".to_owned())
                     .min_w(px(0.0))
                     .flex_1()
                     .flex()
                     .flex_col()
-                    .gap(px(2.0))
+                    .gap(px(1.0))
                     .child(
                         div()
                             .whitespace_nowrap()
                             .overflow_hidden()
                             .text_ellipsis()
+                            .line_height(px(18.0))
                             .child("New Agent"),
                     )
                     .child(
@@ -590,6 +582,7 @@ impl Sidebar {
                             .overflow_hidden()
                             .text_ellipsis()
                             .text_size(px(SIDEBAR_SUBTITLE_SIZE))
+                            .line_height(px(16.0))
                             .text_color(colors.tertiary)
                             .child(format!("{agent} · {location}")),
                     ),
@@ -604,7 +597,6 @@ impl Sidebar {
     }
 
     fn top_bar(&self, colors: SemanticColors, cx: &mut Context<Self>) -> AnyElement {
-        let settings_hover = self.ui.hovered_control == Some("settings");
         let toggle_hover = self.ui.hovered_control == Some("sidebar-toggle");
         let toggle_icon = if self
             .store
@@ -625,20 +617,6 @@ impl Sidebar {
             .justify_end()
             .pr(px(Metrics::TOOLBAR_EDGE_INSET))
             .gap(px(Metrics::TOOLBAR_COMPACT_GAP))
-            .child(icon_button(
-                "settings",
-                "gearshape",
-                settings_hover,
-                colors,
-                cx.listener(|this, _, _, cx| {
-                    this.ui.popover = None;
-                    cx.emit(SidebarEvent::OpenSettings);
-                }),
-                cx.listener(|this, hovered: &bool, _, cx| {
-                    this.ui.hovered_control = hovered.then_some("settings");
-                    cx.notify();
-                }),
-            ))
             .child(icon_button(
                 "sidebar-toggle",
                 toggle_icon,

--- a/zeus/crates/zeus-app/src/store/prefs.rs
+++ b/zeus/crates/zeus-app/src/store/prefs.rs
@@ -115,6 +115,8 @@ pub struct Prefs {
     pub inspector_width: f32,
     /// Last selected tab in the trailing workbench inspector.
     pub inspector_tab: InspectorTab,
+    /// Shared soft-wrap preference for the inspector's Review and Code tabs.
+    pub inspector_word_wrap: bool,
     /// Fraction of the terminal workbench reserved for the primary pane when
     /// the lower terminal is open.
     pub workbench_primary_fraction: f32,
@@ -145,7 +147,7 @@ impl Default for Prefs {
             hibernate_after_minutes: 15,
             memory_hard_limit_gb: 6,
             terminal_theme: DEFAULT_THEME.to_owned(),
-            terminal_font_size: 13.0,
+            terminal_font_size: 16.0,
             window_placement: None,
             sidebar_visible: true,
             sidebar_width: 220.0,
@@ -154,6 +156,7 @@ impl Default for Prefs {
             inspector_open: true,
             inspector_width: 400.0,
             inspector_tab: InspectorTab::Info,
+            inspector_word_wrap: false,
             workbench_primary_fraction: crate::workbench::DEFAULT_PRIMARY_FRACTION,
             quick_open_roots: String::new(),
             sidebar_project_order: Vec::new(),
@@ -216,12 +219,12 @@ impl Prefs {
     }
 
     pub fn reset_terminal_zoom(&mut self) {
-        self.terminal_font_size = 13.0;
+        self.terminal_font_size = 16.0;
     }
 
     pub fn normalize(&mut self) {
         if !self.terminal_font_size.is_finite() {
-            self.terminal_font_size = 13.0;
+            self.terminal_font_size = 16.0;
         }
         self.terminal_font_size = self
             .terminal_font_size

--- a/zeus/crates/zeus-app/src/store/tests.rs
+++ b/zeus/crates/zeus-app/src/store/tests.rs
@@ -1180,6 +1180,7 @@ fn prefs_round_trip_and_zoom_clamp() {
         sidebar_width: 284.0,
         inspector_width: 516.0,
         inspector_tab: InspectorTab::Artifacts,
+        inspector_word_wrap: true,
         last_selected_session: Some(id("s")),
         quick_open_roots: "~/fun\n~/src".to_owned(),
         sidebar_project_order: vec![pid("p")],
@@ -1195,7 +1196,7 @@ fn prefs_round_trip_and_zoom_clamp() {
     store.zoom_terminal(-100.0).unwrap();
     assert_eq!(store.prefs.terminal_font_size, 10.0);
     store.reset_terminal_zoom().unwrap();
-    assert_eq!(Prefs::load(&path).unwrap().terminal_font_size, 13.0);
+    assert_eq!(Prefs::load(&path).unwrap().terminal_font_size, 16.0);
 }
 
 #[test]

--- a/zeus/crates/zeus-app/src/surface_shell.rs
+++ b/zeus/crates/zeus-app/src/surface_shell.rs
@@ -1576,6 +1576,24 @@ impl UtilitySurfaces {
                     colors,
                 ))
                 .child(setting_section(
+                    "Review and code",
+                    toggle_row(
+                        "Word wrap",
+                        "Wrap long lines in Review and Code instead of scrolling horizontally.",
+                        self.prefs.inspector_word_wrap,
+                        "toggle-inspector-word-wrap",
+                        colors,
+                        cx,
+                        |this, cx| {
+                            this.prefs.inspector_word_wrap = !this.prefs.inspector_word_wrap;
+                            this.persist_prefs();
+                            cx.refresh_windows();
+                            cx.notify();
+                        },
+                    ),
+                    colors,
+                ))
+                .child(setting_section(
                     "Behavior",
                     div()
                         .flex()
@@ -3184,6 +3202,7 @@ fn toggle_row(
 ) -> impl IntoElement {
     div()
         .id(id)
+        .debug_selector(move || id.to_owned())
         .min_h(px(SETTINGS_ROW_HEIGHT))
         .px(px(12.0))
         .flex()
@@ -4075,6 +4094,47 @@ mod tests {
         assert_eq!(dialog.center(), root.center());
         assert!(dialog.top() >= root.top());
         assert!(dialog.bottom() <= root.bottom());
+    }
+
+    #[gpui::test]
+    fn settings_word_wrap_toggle_persists_the_shared_inspector_preference(cx: &mut TestAppContext) {
+        let runtime = Arc::new(StoreRuntime::inert());
+        let runtime_for_view = Arc::clone(&runtime);
+        let tokio = Arc::new(
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("test runtime"),
+        );
+        let updates = crate::updates::inert();
+        let (view, cx) = cx.add_window_view(move |window, cx| {
+            let surfaces = cx.new(|cx| {
+                let mut surfaces =
+                    UtilitySurfaces::new(runtime_for_view, tokio, updates, window, cx);
+                surfaces.open_settings(cx);
+                surfaces
+            });
+            SettingsModalHarness {
+                surfaces,
+                background_events: Arc::new(AtomicUsize::new(0)),
+            }
+        });
+        let surfaces = view.read_with(cx, |harness, _| harness.surfaces.clone());
+        let toggle = cx
+            .debug_bounds("toggle-inspector-word-wrap")
+            .expect("word-wrap setting");
+
+        cx.simulate_click(toggle.center(), Modifiers::default());
+
+        assert!(surfaces.read_with(cx, |surfaces, _| surfaces.prefs.inspector_word_wrap));
+        assert!(
+            runtime
+                .store
+                .read()
+                .expect("session store lock poisoned")
+                .preferences()
+                .inspector_word_wrap
+        );
     }
 
     #[gpui::test]

--- a/zeus/crates/zeus-engine/src/bin/zeusd-rs.rs
+++ b/zeus/crates/zeus-engine/src/bin/zeusd-rs.rs
@@ -478,10 +478,17 @@ fn copy_dir(source: &Path, dest: &Path) -> std::io::Result<()> {
 
 #[cfg(unix)]
 fn cli_helper_sources(exe_dir: &Path, name: &str) -> Vec<PathBuf> {
-    let mut sources = vec![exe_dir.join(name)];
+    let mut sources = Vec::new();
     if name == "zeus" {
+        // A loose Cargo build puts the desktop app at `target/*/zeus` and the
+        // automation CLI at `target/*/zeus-cli`. The stable helper must be the
+        // latter: zeus-mcp invokes it with `mcp-tools` / `mcp-call`, while the
+        // desktop binary enters its GPUI event loop and leaves `tools/list`
+        // unanswered. Packaged layouts name the CLI itself `zeus`, so the
+        // ordinary sibling remains the fallback immediately below.
         sources.push(exe_dir.join("zeus-cli"));
     }
+    sources.push(exe_dir.join(name));
     if let Ok(home) = std::env::var("HOME") {
         sources.push(
             Path::new(&home)
@@ -682,6 +689,29 @@ mod tests {
         running.read_to_string(&mut old).expect("old inode");
         assert_eq!(old, "old");
         assert_eq!(std::fs::read_to_string(&dest).expect("new path"), "new");
+    }
+
+    #[test]
+    fn cli_helper_install_prefers_cargo_cli_over_sibling_desktop_app() {
+        let temporary = tempfile::tempdir().expect("temp");
+        let executables = temporary.path().join("target/debug");
+        let app_support = temporary.path().join("app-support");
+        std::fs::create_dir_all(&executables).expect("executables");
+
+        let desktop = executables.join("zeus");
+        let cli = executables.join("zeus-cli");
+        std::fs::write(&desktop, b"desktop-app").expect("desktop");
+        std::fs::write(&cli, b"automation-cli").expect("cli");
+        set_executable(&desktop);
+        set_executable(&cli);
+
+        let installed = install_cli_helpers(&executables, &app_support);
+
+        assert_eq!(installed, app_support.join("bin/zeus"));
+        assert_eq!(
+            std::fs::read(installed).expect("installed helper"),
+            b"automation-cli"
+        );
     }
 
     #[test]

--- a/zeus/crates/zeus-mcp/src/main.rs
+++ b/zeus/crates/zeus-mcp/src/main.rs
@@ -245,15 +245,39 @@ mod tests {
     #[test]
     fn serves_mcp_without_a_resident_tool_runtime() {
         let mut backend = Fake;
+        let initialized = handle_message(
+            json!({
+                "jsonrpc":"2.0",
+                "id":1,
+                "method":"initialize",
+                "params":{
+                    "protocolVersion":"2025-06-18",
+                    "capabilities":{},
+                    "clientInfo":{"name":"codex","version":"test"}
+                }
+            }),
+            &mut backend,
+        )
+        .unwrap();
+        assert_eq!(initialized["result"]["protocolVersion"], "2025-06-18");
+        assert_eq!(initialized["result"]["capabilities"], json!({"tools":{}}));
+        assert!(
+            handle_message(
+                json!({"jsonrpc":"2.0","method":"notifications/initialized","params":{}}),
+                &mut backend,
+            )
+            .is_none()
+        );
+
         let listed = handle_message(
-            json!({"jsonrpc":"2.0","id":1,"method":"tools/list"}),
+            json!({"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}),
             &mut backend,
         )
         .unwrap();
         assert_eq!(listed["result"]["tools"][0]["name"], "list_agents");
 
         let called = handle_message(
-            json!({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_agents","arguments":{}}}),
+            json!({"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_agents","arguments":{}}}),
             &mut backend,
         )
         .unwrap();

--- a/zeus/crates/zeus-term/src/element.rs
+++ b/zeus/crates/zeus-term/src/element.rs
@@ -340,7 +340,7 @@ impl TerminalElement {
             }),
             theme: TermTheme::default(),
             font: terminal_font,
-            font_size: px(13.0),
+            font_size: px(16.0),
             focus_handle: None,
             text_input: None,
             ime_state: Arc::new(Mutex::new(TerminalImeState::default())),

--- a/zeus/scripts/dev.sh
+++ b/zeus/scripts/dev.sh
@@ -98,15 +98,16 @@ mkdir -p "${target_dir}"
 
 cd "${workspace_dir}"
 echo "==> Building ${display_name} (${profile})"
-# zeus-app does not pull zeusd-rs into target/<profile>/; build both so a
-# clean checkout launches against this tree's Engine instead of a missing or
-# stale binary (installed app / leftover debug build).
+# zeus-app does not pull the Engine or automation helpers into target/<profile>/.
+# Build all four so a clean checkout launches against this tree's binaries
+# instead of a missing or stale installed-app/debug helper.
 if (( ${#cargo_args[@]} > 0 )); then
     cargo build --package zeus-app --bin zeus --package zeus-engine --bin zeusd-rs \
-        --package zeus-cli --bin zeus-cli "${cargo_args[@]}"
+        --package zeus-cli --bin zeus-cli --package zeus-mcp --bin zeus-mcp \
+        "${cargo_args[@]}"
 else
     cargo build --package zeus-app --bin zeus --package zeus-engine --bin zeusd-rs \
-        --package zeus-cli --bin zeus-cli
+        --package zeus-cli --bin zeus-cli --package zeus-mcp --bin zeus-mcp
 fi
 
 binary="${target_dir}/${profile}/zeus"


### PR DESCRIPTION
## Summary
- Wrap Review and Code on a shared inspector preference instead of horizontal scrolling.
- Default and reset terminal font size is now 16pt.
- Open settings from the inspector; restyle the sidebar New Agent row.
- Install the Cargo `zeus-cli` helper instead of the desktop `zeus` binary, and build `zeus-mcp` from `dev.sh`.

## Test plan
- [x] `cargo test -p zeus-app prefs_round_trip_and_zoom_clamp`
- [x] `cargo test -p zeus-term --lib history_cache`
- [ ] Toggle Word wrap in Settings and confirm Review/Code wrap and persist
- [ ] Reset terminal zoom and confirm 16pt