### PR TITLE
build(deps): bump the actions group across 1 directory with 4 updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       run:
         working-directory: zeus
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Install target
         run: rustup target add "${{ matrix.target }}"
       - name: Install native musl linker
@@ -131,7 +131,7 @@ jobs:
       run:
         working-directory: zeus
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Start disposable ordinary-user SSH endpoint
         run: |
           sudo apt-get update

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,11 +20,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5.0.0
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           languages: rust
           build-mode: none
       - name: Analyze
-        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
           category: /language:rust

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install mdBook
         env:
@@ -68,7 +68,7 @@ jobs:
           path: book
 
       - name: Setup Node
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
 


### PR DESCRIPTION
Replaces closed Dependabot PR #11 after its branch was deleted.

Bumps the actions group with 4 updates in the `/` directory:

- `actions/checkout` from 5 to 7
- `github/codeql-action/init` from 4.37.6 to 4.37.7
- `github/codeql-action/analyze` from 4.37.6 to 4.37.7
- `actions/setup-node` from 6.5.0 to 7.0.0