### PR TITLE
feat: unify Quick Open across files, sessions, and folders

### DIFF
--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -17,7 +17,7 @@ never installs one until you click restart. See [Updates](updates.md).
 ## Ten minutes to a fleet of one
 
 1. Open Zeus. If no project is open, use **Open…** (`⌘O`) or **Quick Open**
-   (`⌘P`) and pick a repository.
+   (`⌘P`) and pick a repository from the Projects & Folders section.
 2. Press `⌘N`. Choose Claude Code, Codex, or whatever is installed, type the
    first prompt, and press Return. You can also press `⌘T` to launch your
    default agent in the current project with no prompt.

--- a/docs/src/keyboard.md
+++ b/docs/src/keyboard.md
@@ -12,7 +12,7 @@ is the backup for anything you forget.
 | `⌥⌘T` | New terminal (login shell) |
 | `⌘⇧N` | New Codex session |
 | `⌘O` | Open a project folder |
-| `⌘P` | Quick Open a folder, then spawn the default agent |
+| `⌘P` | Search project files, agent sessions, and folders |
 | `⌘W` | Close the selected session |
 | `⌘⇧T` | Reopen the last closed session |
 | `⌘⇧W` | Archive the selected session |

--- a/docs/src/settings.md
+++ b/docs/src/settings.md
@@ -4,8 +4,8 @@
 
 ## General
 
-**Default agent.** What `⌘T` and Quick Open launch. Used by the sidebar's
-primary New Agent hint as well.
+**Default agent.** What `⌘T` and a folder result in Quick Open launch. Used by
+the sidebar's primary New Agent hint as well.
 
 **Projects sidebar on the right.** Mirrors the chrome: projects on the
 trailing edge, inspector on the leading one.
@@ -26,8 +26,9 @@ memory pauses. Working sessions stay silent.
 six hours. Download and restart always wait for a click. See
 [Updates](updates.md).
 
-**Quick Open roots.** Extra folders, one per line, scanned four levels
-deep. Empty means the default folder plus parents of open projects.
+**Quick Open roots.** Extra entries for Quick Open's Projects & Folders
+section, one per line and scanned four levels deep. Empty means the default
+folder plus parents of open projects.
 
 ## Terminal
 

--- a/docs/src/workbench.md
+++ b/docs/src/workbench.md
@@ -98,8 +98,13 @@ back to the window.
 "New Claude Code in *this project*", "New Codex on *this host*", move the
 selected Claude session, sync prefs, settings, docs, updates.
 
-`⌘P` is folders. Type a directory. Return launches your default agent there.
-Add extra search roots in Settings → General.
+`⌘P` is the unified navigator. It searches files in the selected local
+session's project (or the first open project on the startup screen), every
+agent session, and indexed folders. Return opens a file in Code, switches to a
+session, or launches your default agent in a folder; `⌘Return` launches a
+terminal for a folder result. Add extra folder search roots in Settings →
+General. Remote sessions still appear, but their files are not indexed through
+the local filesystem.
 
 ## Layout
 

--- a/zeus/crates/zeus-app/src/code_intelligence.rs
+++ b/zeus/crates/zeus-app/src/code_intelligence.rs
@@ -322,6 +322,43 @@ impl CodeIntelligence {
         results
     }
 
+    /// Rank only workspace file paths. The global Quick Open surface uses
+    /// this narrower view: symbols remain available in the code viewer's own
+    /// picker, while Cmd+P stays predictable and always opens a file.
+    pub fn search_files(&self, query: &str, limit: usize) -> Vec<SearchHit> {
+        if limit == 0 {
+            return Vec::new();
+        }
+
+        let query = query.trim();
+        let mut results = Vec::new();
+        for file in &self.index().files {
+            let score = if query.is_empty() {
+                Some(0)
+            } else {
+                path_score(query, &file.display_path)
+            };
+            if let Some(score) = score {
+                results.push(SearchHit {
+                    relative_path: file.relative_path.clone(),
+                    kind: SearchHitKind::File,
+                    line: None,
+                    preview: file.display_path.clone(),
+                    score,
+                });
+            }
+        }
+
+        results.sort_by(|left, right| {
+            right
+                .score
+                .cmp(&left.score)
+                .then_with(|| left.relative_path.cmp(&right.relative_path))
+        });
+        results.truncate(limit);
+        results
+    }
+
     fn resolve_workspace_file(
         &self,
         requested: &Path,
@@ -1465,6 +1502,17 @@ mod tests {
         let function = intelligence.search("render_viewer", 10);
         assert_eq!(function[0].kind, SearchHitKind::Symbol);
         assert_eq!(function[0].line, Some(2));
+
+        let files_only = intelligence.search_files("CodeIntelligence", 10);
+        assert!(
+            files_only
+                .iter()
+                .all(|hit| hit.kind == SearchHitKind::File && hit.line.is_none())
+        );
+        assert_eq!(
+            files_only[0].relative_path,
+            Path::new("src/code_intelligence.rs")
+        );
     }
 
     #[test]

--- a/zeus/crates/zeus-app/src/inspector.rs
+++ b/zeus/crates/zeus-app/src/inspector.rs
@@ -394,6 +394,13 @@ impl WorkbenchInspector {
         self.select_tab(InspectorTab::Code, cx);
     }
 
+    /// An explicit Code destination can stand on its own before an agent has
+    /// been selected. RootView uses this to let Cmd+P reveal a startup file
+    /// without weakening the normal session gate for Info/Review/Artifacts.
+    pub const fn is_code_destination(&self) -> bool {
+        matches!(self.selected_tab, InspectorTab::Code)
+    }
+
     fn selected_context(&self) -> Option<DiffContext> {
         let store = self
             .runtime

--- a/zeus/crates/zeus-app/src/navigation.rs
+++ b/zeus/crates/zeus-app/src/navigation.rs
@@ -4,6 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
+use crate::code_intelligence::{CodeIntelligence, SearchHit};
 use crate::fuzzy::{FuzzyMatcher, FuzzyQuery};
 use crate::macos::sf_symbols::{SymbolWeight, sf_symbol, sf_symbol_weighted};
 use crate::palette::{self, PaletteAction, PaletteCommand, Ranked};
@@ -23,24 +24,26 @@ use zeus_ui::{FloatingSurface, HairlineDivider, Palette, Radius, SemanticColors}
 
 actions!(zeus, [ToggleCommandPalette, ToggleQuickOpen]);
 
-/// The search field above the results, and the gap the surface keeps from the
-/// window edges. Everything else is measured against the live viewport so the
-/// list grows into a tall window and never overflows a short one.
+/// The command palette stays compact; Quick Open gets the roomier dialog
+/// treatment used by file palettes in editors.
 const SEARCH_HEIGHT: f32 = 34.0;
 const ROW_HEIGHT: f32 = 24.0;
-const QUICK_ROW_HEIGHT: f32 = 26.0;
+const QUICK_SEARCH_HEIGHT: f32 = 48.0;
+const QUICK_FOOTER_HEIGHT: f32 = 34.0;
+const QUICK_ROW_HEIGHT: f32 = 38.0;
 /// Quick Open rows that show a parent path stack two lines.
-const QUICK_ROW_HEIGHT_WITH_PATH: f32 = 33.0;
-const SECTION_HEADER_HEIGHT: f32 = 18.0;
+const QUICK_ROW_HEIGHT_WITH_PATH: f32 = 42.0;
+const SECTION_HEADER_HEIGHT: f32 = 24.0;
 const LIST_PADDING_X: f32 = 6.0;
-const LIST_PADDING_Y: f32 = 3.0;
+const LIST_PADDING_Y: f32 = 6.0;
 const ROW_PADDING_X: f32 = 10.0;
-const SURFACE_WIDTH: f32 = 540.0;
+const SURFACE_WIDTH: f32 = 720.0;
 const MIN_LIST_HEIGHT: f32 = 96.0;
-const MAX_LIST_HEIGHT: f32 = 600.0;
+const MAX_LIST_HEIGHT: f32 = 520.0;
 const MIN_TOP_INSET: f32 = 12.0;
-const MAX_TOP_INSET: f32 = 72.0;
+const MAX_TOP_INSET: f32 = 104.0;
 const BOTTOM_INSET: f32 = 16.0;
+const FILE_RESULT_LIMIT: usize = 32;
 
 /// Where the overlay sits and how tall its list may grow in this window.
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -53,7 +56,9 @@ struct OverlayLayout {
 impl OverlayLayout {
     fn for_viewport(viewport: gpui::Size<Pixels>) -> Self {
         let height = viewport.height.as_f32();
-        let chrome = SEARCH_HEIGHT + 1.0 + BOTTOM_INSET;
+        // Reserve the larger Quick Open chrome for both overlays. That keeps
+        // the layout safe when Cmd+K transitions into Quick Open in place.
+        let chrome = QUICK_SEARCH_HEIGHT + QUICK_FOOTER_HEIGHT + 2.0 + BOTTOM_INSET;
         // Float the surface a twelfth of the way down, but give the inset back
         // to the list before the list is allowed to fall below its minimum.
         let top = (height / 12.0)
@@ -80,13 +85,21 @@ enum CommandSelection {
     Session(SessionId),
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone)]
+enum QuickSelection {
+    File { cwd: PathBuf, reference: String },
+    Session(SessionId),
+    Folder(QuickOpenItem),
+}
+
+#[derive(Clone, Debug)]
 pub enum NavigationEvent {
     ToggleSidebar,
     OpenOverview,
     OpenWorktrees,
     OpenSettings,
     CheckForUpdates,
+    OpenFile { cwd: PathBuf, reference: String },
 }
 
 pub struct NavigationOverlay {
@@ -104,12 +117,20 @@ pub struct NavigationOverlay {
     directory_index: DirectoryIndex,
     quick_snapshot: QuickOpenSnapshot,
     ranked_items: Vec<RankedFolder>,
+    ranked_files: Vec<SearchHit>,
+    file_workspace: Option<PathBuf>,
+    file_root: Option<PathBuf>,
+    file_intelligence: Option<Arc<CodeIntelligence>>,
+    file_index_message: Option<SharedString>,
+    file_rank_generation: u64,
     scroll_handle: ScrollHandle,
     /// Separate slots: the disk-cache load and the filesystem scan both start
     /// at launch, and neither may cancel the other by sharing a `Task` slot.
     cache_task: Option<Task<()>>,
     scan_task: Option<Task<()>>,
     rank_task: Option<Task<()>>,
+    file_index_task: Option<Task<()>>,
+    file_rank_task: Option<Task<()>>,
     /// This view is `.cached()` in RootView, so ambient window redraws no
     /// longer reach it: store changes must notify it directly, or an open
     /// palette's session rows go stale.
@@ -127,7 +148,20 @@ impl NavigationOverlay {
             loop {
                 match changes.recv().await {
                     Ok(()) | Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
-                        if this.update(cx, |_, cx| cx.notify()).is_err() {
+                        if this
+                            .update(cx, |this, cx| {
+                                match this.overlay {
+                                    Some(Overlay::CommandPalette) => this.refresh_command_items(),
+                                    Some(Overlay::QuickOpen) => {
+                                        this.refresh_quick_sessions();
+                                        this.refresh_file_workspace(cx);
+                                    }
+                                    None => {}
+                                }
+                                cx.notify();
+                            })
+                            .is_err()
+                        {
                             return;
                         }
                     }
@@ -148,10 +182,18 @@ impl NavigationOverlay {
             directory_index: DirectoryIndex::default(),
             quick_snapshot: QuickOpenSnapshot::default(),
             ranked_items: Vec::new(),
+            ranked_files: Vec::new(),
+            file_workspace: None,
+            file_root: None,
+            file_intelligence: None,
+            file_index_message: None,
+            file_rank_generation: 0,
             scroll_handle: ScrollHandle::new(),
             cache_task: None,
             scan_task: None,
             rank_task: None,
+            file_index_task: None,
+            file_rank_task: None,
             _store_changes: Some(store_changes),
         };
         // Warm at launch, the way Zed's worktree scan does: the cache makes the
@@ -177,10 +219,18 @@ impl NavigationOverlay {
             directory_index: DirectoryIndex::default(),
             quick_snapshot: QuickOpenSnapshot::default(),
             ranked_items: Vec::new(),
+            ranked_files: Vec::new(),
+            file_workspace: None,
+            file_root: None,
+            file_intelligence: None,
+            file_index_message: None,
+            file_rank_generation: 0,
             scroll_handle: ScrollHandle::new(),
             cache_task: None,
             scan_task: None,
             rank_task: None,
+            file_index_task: None,
+            file_rank_task: None,
             _store_changes: None,
         }
     }
@@ -212,7 +262,6 @@ impl NavigationOverlay {
             self.close_overlay(cx);
         } else {
             self.open_overlay(Overlay::QuickOpen, window, cx);
-            self.refresh_directory_index(cx);
         }
     }
 
@@ -221,8 +270,14 @@ impl NavigationOverlay {
         self.query.clear();
         self.reset_selection();
         self.ranked_items.clear();
-        if overlay == Overlay::CommandPalette {
-            self.refresh_command_items();
+        match overlay {
+            Overlay::CommandPalette => self.refresh_command_items(),
+            Overlay::QuickOpen => {
+                self.refresh_quick_sessions();
+                self.refresh_file_workspace(cx);
+                self.schedule_file_rank(cx);
+                self.refresh_directory_index(cx);
+            }
         }
         let _ = window;
         cx.notify();
@@ -234,7 +289,10 @@ impl NavigationOverlay {
         self.highlight = 0;
         self.ranked_actions.clear();
         self.ranked_sessions.clear();
+        self.ranked_files.clear();
         self.rank_task = None;
+        self.file_rank_task = None;
+        self.file_rank_generation = self.file_rank_generation.wrapping_add(1);
         cx.notify();
     }
 
@@ -316,7 +374,7 @@ impl NavigationOverlay {
                 this.directory_index.finish_scan(entries, Instant::now());
                 this.quick_snapshot = snapshot;
                 if !this.query.text().trim().is_empty() {
-                    this.schedule_rank(cx);
+                    this.schedule_folder_rank(cx);
                 }
                 cx.notify();
             })
@@ -359,7 +417,7 @@ impl NavigationOverlay {
             .collect()
     }
 
-    fn schedule_rank(&mut self, cx: &mut Context<Self>) {
+    fn schedule_folder_rank(&mut self, cx: &mut Context<Self>) {
         self.rank_task = None;
         let query = self.query.text().trim().to_owned();
         if query.is_empty() {
@@ -375,7 +433,140 @@ impl NavigationOverlay {
                 .await;
             this.update(cx, |this, cx| {
                 this.ranked_items = ranked;
-                this.reset_selection();
+                this.clamp_highlight();
+                cx.notify();
+            })
+            .ok();
+        }));
+    }
+
+    fn refresh_quick_sessions(&mut self) {
+        let sessions = self
+            .store
+            .write()
+            .expect("session store lock poisoned")
+            .ordered_sessions();
+        let query = FuzzyQuery::new(self.query.text());
+        self.ranked_sessions = palette::rank_sessions(sessions, &query, &mut self.matcher);
+    }
+
+    /// Cmd+P searches files from the selected local session's workspace. The
+    /// expensive index is retained across opens and query edits; changing the
+    /// selected workspace invalidates it explicitly.
+    fn refresh_file_workspace(&mut self, cx: &mut Context<Self>) {
+        let (workspace, unavailable) = {
+            let mut store = self.store.write().expect("session store lock poisoned");
+            let selected = store
+                .selected_session()
+                .map(|session| (session.cwd.clone(), session.host.is_some()));
+            match selected {
+                Some((cwd, false)) => (Some(PathBuf::from(cwd)), None),
+                Some(_) => (
+                    None,
+                    Some(SharedString::from(
+                        "Project files are unavailable for remote sessions",
+                    )),
+                ),
+                None => store
+                    .sidebar_projection()
+                    .projects
+                    .first()
+                    .map(|entry| (Some(PathBuf::from(&entry.project.root)), None))
+                    .unwrap_or_else(|| {
+                        (
+                            None,
+                            Some(SharedString::from(
+                                "Open a project to search files from startup",
+                            )),
+                        )
+                    }),
+            }
+        };
+
+        if self.file_workspace == workspace {
+            return;
+        }
+
+        self.file_workspace = workspace.clone();
+        self.file_root = None;
+        self.file_intelligence = None;
+        self.ranked_files.clear();
+        self.file_index_message = unavailable;
+        self.file_index_task = None;
+        self.file_rank_task = None;
+        self.file_rank_generation = self.file_rank_generation.wrapping_add(1);
+
+        let Some(workspace) = workspace else {
+            self.clamp_highlight();
+            cx.notify();
+            return;
+        };
+        self.file_index_message = Some(SharedString::from("Indexing project files…"));
+        let requested = workspace.clone();
+        self.file_index_task = Some(cx.spawn(async move |this, cx| {
+            let build_workspace = requested.clone();
+            let built = cx
+                .background_spawn(async move {
+                    let intelligence = CodeIntelligence::for_session(&build_workspace)
+                        .map_err(|error| error.to_string())?;
+                    let initial = intelligence.search_files("", FILE_RESULT_LIMIT);
+                    Ok::<_, String>((Arc::new(intelligence), initial))
+                })
+                .await;
+            this.update(cx, |this, cx| {
+                if this.file_workspace.as_ref() != Some(&requested) {
+                    return;
+                }
+                this.file_index_task = None;
+                match built {
+                    Ok((intelligence, initial)) => {
+                        this.file_root = Some(intelligence.workspace_root().to_path_buf());
+                        this.file_intelligence = Some(intelligence);
+                        this.file_index_message = None;
+                        if this.query.text().trim().is_empty() {
+                            this.ranked_files = initial;
+                            this.clamp_highlight();
+                        } else {
+                            this.schedule_file_rank(cx);
+                        }
+                    }
+                    Err(_) => {
+                        this.file_index_message =
+                            Some(SharedString::from("Project files could not be indexed"));
+                        this.ranked_files.clear();
+                        this.clamp_highlight();
+                    }
+                }
+                cx.notify();
+            })
+            .ok();
+        }));
+        cx.notify();
+    }
+
+    fn schedule_file_rank(&mut self, cx: &mut Context<Self>) {
+        self.file_rank_task = None;
+        self.file_rank_generation = self.file_rank_generation.wrapping_add(1);
+        let generation = self.file_rank_generation;
+        let Some(intelligence) = self.file_intelligence.clone() else {
+            return;
+        };
+        let query = self.query.text().trim().to_owned();
+        self.file_rank_task = Some(cx.spawn(async move |this, cx| {
+            cx.background_executor().timer(RANK_DEBOUNCE).await;
+            let ranked = cx
+                .background_spawn(
+                    async move { intelligence.search_files(&query, FILE_RESULT_LIMIT) },
+                )
+                .await;
+            this.update(cx, |this, cx| {
+                if this.overlay != Some(Overlay::QuickOpen)
+                    || this.file_rank_generation != generation
+                {
+                    return;
+                }
+                this.ranked_files = ranked;
+                this.clamp_highlight();
                 cx.notify();
             })
             .ok();
@@ -434,7 +625,10 @@ impl NavigationOverlay {
     fn query_changed(&mut self, cx: &mut Context<Self>) {
         self.reset_selection();
         if self.overlay == Some(Overlay::QuickOpen) {
-            self.schedule_rank(cx);
+            self.refresh_quick_sessions();
+            self.schedule_folder_rank(cx);
+            self.schedule_file_rank(cx);
+            cx.notify();
         } else {
             self.refresh_command_items();
             cx.notify();
@@ -460,26 +654,58 @@ impl NavigationOverlay {
     /// Index of the highlighted row among the scroll container's children,
     /// which include the section headers.
     fn highlight_child(&self) -> usize {
-        let first_section = match self.overlay {
-            Some(Overlay::CommandPalette) => Some(self.ranked_actions.len()),
-            Some(Overlay::QuickOpen) if self.query.text().trim().is_empty() => {
-                Some(self.quick_snapshot.recent.len())
+        match self.overlay {
+            Some(Overlay::CommandPalette) => {
+                row_child_index(self.highlight, Some(self.ranked_actions.len()))
             }
-            // A searched Quick Open list is one flat section, no headers.
-            _ => None,
-        };
-        row_child_index(self.highlight, first_section)
+            Some(Overlay::QuickOpen) => {
+                sectioned_row_child_index(self.highlight, &self.quick_section_lengths())
+            }
+            None => self.highlight,
+        }
     }
 
     fn visible_count(&self) -> usize {
         match self.overlay {
             Some(Overlay::CommandPalette) => self.ranked_actions.len() + self.ranked_sessions.len(),
-            Some(Overlay::QuickOpen) if self.query.text().trim().is_empty() => {
-                self.quick_snapshot.recent.len() + self.quick_snapshot.folders.len()
-            }
-            Some(Overlay::QuickOpen) => self.ranked_items.len(),
+            Some(Overlay::QuickOpen) => self.quick_section_lengths().into_iter().sum(),
             None => 0,
         }
+    }
+
+    fn quick_section_lengths(&self) -> [usize; 3] {
+        [
+            self.ranked_sessions.len(),
+            self.ranked_files.len(),
+            self.quick_folder_count(),
+        ]
+    }
+
+    fn quick_folder_count(&self) -> usize {
+        if self.query.text().trim().is_empty() {
+            self.quick_snapshot.recent.len() + self.quick_snapshot.folders.len()
+        } else {
+            self.ranked_items.len()
+        }
+    }
+
+    fn quick_folder_at(&self, index: usize) -> Option<QuickOpenItem> {
+        if self.query.text().trim().is_empty() {
+            self.quick_snapshot
+                .recent
+                .iter()
+                .chain(&self.quick_snapshot.folders)
+                .nth(index)
+                .cloned()
+        } else {
+            self.ranked_items
+                .get(index)
+                .map(|folder| folder.item.clone())
+        }
+    }
+
+    fn clamp_highlight(&mut self) {
+        self.highlight = self.highlight.min(self.visible_count().saturating_sub(1));
     }
 
     fn run_highlighted(&mut self, secondary: bool, cx: &mut Context<Self>) {
@@ -500,24 +726,37 @@ impl NavigationOverlay {
                 }
             }
             Some(Overlay::QuickOpen) => {
-                if let Some(item) = self.current_quick_item() {
-                    let cwd = item.path.to_string_lossy().into_owned();
-                    if secondary {
-                        self.store
-                            .write()
-                            .expect("session store lock poisoned")
-                            .spawn_shell(SpawnOptions {
-                                cwd: Some(cwd.clone()),
-                                ..SpawnOptions::default()
-                            });
-                    } else {
-                        self.store
-                            .write()
-                            .expect("session store lock poisoned")
-                            .spawn_default(SpawnOptions {
-                                cwd: Some(cwd.clone()),
-                                ..SpawnOptions::default()
-                            });
+                if let Some(selection) = self.current_quick_selection() {
+                    match selection {
+                        QuickSelection::File { cwd, reference } => {
+                            cx.emit(NavigationEvent::OpenFile { cwd, reference });
+                        }
+                        QuickSelection::Session(id) => {
+                            self.store
+                                .write()
+                                .expect("session store lock poisoned")
+                                .select(id);
+                        }
+                        QuickSelection::Folder(item) if secondary => {
+                            let cwd = item.path.to_string_lossy().into_owned();
+                            self.store
+                                .write()
+                                .expect("session store lock poisoned")
+                                .spawn_shell(SpawnOptions {
+                                    cwd: Some(cwd),
+                                    ..SpawnOptions::default()
+                                });
+                        }
+                        QuickSelection::Folder(item) => {
+                            let cwd = item.path.to_string_lossy().into_owned();
+                            self.store
+                                .write()
+                                .expect("session store lock poisoned")
+                                .spawn_default(SpawnOptions {
+                                    cwd: Some(cwd),
+                                    ..SpawnOptions::default()
+                                });
+                        }
                     }
                     self.close_overlay(cx);
                 }
@@ -606,6 +845,9 @@ impl NavigationOverlay {
                 self.query.clear();
                 self.reset_selection();
                 self.ranked_items.clear();
+                self.refresh_quick_sessions();
+                self.refresh_file_workspace(cx);
+                self.schedule_file_rank(cx);
                 self.refresh_directory_index(cx);
                 cx.notify();
             }
@@ -673,19 +915,22 @@ impl NavigationOverlay {
         self.ranked_sessions = palette::rank_sessions(sessions, &query, &mut self.matcher);
     }
 
-    fn current_quick_item(&self) -> Option<QuickOpenItem> {
-        if self.query.text().trim().is_empty() {
-            self.quick_snapshot
-                .recent
-                .iter()
-                .chain(&self.quick_snapshot.folders)
-                .nth(self.highlight)
-                .cloned()
-        } else {
-            self.ranked_items
-                .get(self.highlight)
-                .map(|folder| folder.item.clone())
+    fn current_quick_selection(&self) -> Option<QuickSelection> {
+        let mut index = self.highlight;
+        if let Some(session) = self.ranked_sessions.get(index) {
+            return Some(QuickSelection::Session(session.item.id.clone()));
         }
+        index = index.saturating_sub(self.ranked_sessions.len());
+
+        if let Some(hit) = self.ranked_files.get(index) {
+            let cwd = self.file_root.clone()?;
+            return Some(QuickSelection::File {
+                cwd,
+                reference: hit.relative_path.to_string_lossy().into_owned(),
+            });
+        }
+        index = index.saturating_sub(self.ranked_files.len());
+        self.quick_folder_at(index).map(QuickSelection::Folder)
     }
 
     fn render_overlay(&mut self, layout: OverlayLayout, cx: &mut Context<Self>) -> AnyElement {
@@ -714,7 +959,7 @@ impl NavigationOverlay {
                     .absolute()
                     .inset_0()
                     .occlude()
-                    .bg(rgba(0x00000040))
+                    .bg(rgba(0x00000055))
                     .on_mouse_down(
                         MouseButton::Left,
                         cx.listener(|this, _, _, cx| {
@@ -887,80 +1132,270 @@ impl NavigationOverlay {
         cx: &mut Context<Self>,
     ) -> AnyElement {
         let searching = !self.query.text().trim().is_empty();
+        let sessions = self.ranked_sessions.clone();
+        let files = self.ranked_files.clone();
+        let session_count = sessions.len();
+        let file_count = files.len();
+        let folders: Vec<_> = if searching {
+            self.ranked_items
+                .iter()
+                .map(|folder| (folder.item.clone(), folder.name_matches.clone()))
+                .collect()
+        } else {
+            self.quick_snapshot
+                .recent
+                .iter()
+                .chain(&self.quick_snapshot.folders)
+                .cloned()
+                .map(|folder| (folder, Vec::new()))
+                .collect()
+        };
+        let folder_count = folders.len();
         let mut results = div()
             .id("quick-open-results")
             .track_scroll(&self.scroll_handle)
             .flex()
             .flex_col()
-            .max_h(layout.list_height)
+            .h(layout.list_height)
             .overflow_y_scroll()
             .px(px(LIST_PADDING_X))
             .py(px(LIST_PADDING_Y));
 
-        if searching {
-            let ranked = self.ranked_items.clone();
-            for (index, folder) in ranked.iter().enumerate() {
-                results = results.child(self.render_quick_row(
-                    folder.item.clone(),
-                    &folder.name_matches,
-                    index,
+        if !sessions.is_empty() {
+            results = results.child(section_header("Agent Sessions", colors));
+            for (index, session) in sessions.into_iter().enumerate() {
+                results = results.child(self.render_quick_session_row(session, index, colors, cx));
+            }
+        }
+        if !files.is_empty() {
+            results = results.child(section_header("Project Files", colors));
+            for (offset, file) in files.into_iter().enumerate() {
+                results =
+                    results.child(self.render_file_row(file, session_count + offset, colors, cx));
+            }
+        }
+        if !folders.is_empty() {
+            results = results.child(section_header("Projects & Folders", colors));
+            for (offset, (folder, matches)) in folders.into_iter().enumerate() {
+                results = results.child(self.render_quick_folder_row(
+                    folder,
+                    &matches,
+                    session_count + file_count + offset,
                     colors,
                     cx,
                 ));
             }
-            if ranked.is_empty() {
-                results = results.child(empty_label(
-                    if self.directory_index.is_scanning() {
-                        "Scanning…"
-                    } else {
-                        "No matches"
-                    },
-                    colors,
-                ));
-            }
-        } else {
-            let recent = self.quick_snapshot.recent.clone();
-            let folders = self.quick_snapshot.folders.clone();
-            if !recent.is_empty() {
-                results = results.child(section_header("Recent", colors));
-                for (index, item) in recent.iter().cloned().enumerate() {
-                    results = results.child(self.render_quick_row(item, &[], index, colors, cx));
-                }
-            }
-            if !folders.is_empty() {
-                results = results.child(section_header("Folders", colors));
-                for (offset, item) in folders.iter().cloned().enumerate() {
-                    results = results.child(self.render_quick_row(
-                        item,
-                        &[],
-                        recent.len() + offset,
-                        colors,
-                        cx,
-                    ));
-                }
-            }
-            if recent.is_empty() && folders.is_empty() {
-                results = results.child(empty_label(
-                    if self.directory_index.is_scanning() {
-                        "Scanning…"
-                    } else {
-                        "No folders indexed"
-                    },
-                    colors,
-                ));
-            }
         }
+        if session_count + file_count + folder_count == 0 {
+            let message = self.file_index_message.clone().unwrap_or_else(|| {
+                SharedString::from(if self.directory_index.is_scanning() {
+                    "Searching your workspace…"
+                } else {
+                    "No files, sessions, or folders match"
+                })
+            });
+            results = results.child(empty_message(message, colors));
+        }
+
+        let action = match self.current_quick_selection() {
+            Some(QuickSelection::File { .. }) => "Open file",
+            Some(QuickSelection::Session(_)) => "Switch session",
+            Some(QuickSelection::Folder(_)) => "Start agent",
+            None => "Open",
+        };
 
         div()
             .w(layout.width)
+            .rounded(px(Radius::PANEL))
+            .overflow_hidden()
             .text_color(colors.primary)
-            .child(self.render_search("Jump to a project or folder…", colors))
+            .child(self.render_quick_search(colors))
             .child(HairlineDivider::horizontal(colors))
             .child(results)
+            .child(HairlineDivider::horizontal(colors))
+            .child(quick_footer(action, colors))
             .into_any_element()
     }
 
-    fn render_quick_row(
+    fn render_quick_search(&self, colors: SemanticColors) -> AnyElement {
+        let query = if self.query.is_empty() {
+            div()
+                .text_color(colors.tertiary)
+                .child("Search project files or agent sessions…")
+                .into_any_element()
+        } else {
+            query_label(&self.query)
+        };
+        div()
+            .h(px(QUICK_SEARCH_HEIGHT))
+            .px(px(15.0))
+            .flex()
+            .flex_none()
+            .items_center()
+            .gap(px(10.0))
+            .cursor_text()
+            .child(sf_symbol("magnifyingglass", 13.0, colors.secondary))
+            .child(
+                div()
+                    .min_w_0()
+                    .flex_1()
+                    .text_size(px(14.0))
+                    .text_color(colors.primary)
+                    .child(query),
+            )
+            .child(
+                div()
+                    .flex_none()
+                    .text_size(px(10.5))
+                    .text_color(colors.tertiary)
+                    .child("files  ·  sessions  ·  folders"),
+            )
+            .into_any_element()
+    }
+
+    fn render_quick_session_row(
+        &mut self,
+        ranked: Ranked<SessionRecord>,
+        index: usize,
+        colors: SemanticColors,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let session = ranked.item;
+        let dot_color = attention_color(session.attention(), colors);
+        let kind = kind_label(session.effective_kind());
+        let location = session.host.as_ref().map_or_else(
+            || abbreviated_path(Path::new(&session.cwd)),
+            |host| format!("{host}  ·  {}", session.cwd),
+        );
+        div()
+            .id(("quick-session-row", index))
+            .flex()
+            .flex_none()
+            .items_center()
+            .justify_between()
+            .h(px(QUICK_ROW_HEIGHT))
+            .px(px(ROW_PADDING_X))
+            .rounded(px(Radius::ROW))
+            .bg(quick_row_fill(index == self.highlight, colors))
+            .cursor_pointer()
+            .hover(move |row| row.bg(colors.primary.alpha(0.07)))
+            .child(
+                div()
+                    .min_w_0()
+                    .flex_1()
+                    .flex()
+                    .items_center()
+                    .gap(px(10.0))
+                    .child(
+                        div()
+                            .w(px(18.0))
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .child(div().size(px(7.0)).rounded_full().bg(dot_color)),
+                    )
+                    .child(
+                        div()
+                            .min_w_0()
+                            .flex()
+                            .items_baseline()
+                            .gap(px(8.0))
+                            .text_size(px(13.0))
+                            .child(highlighted_label(session.title, &ranked.title_matches))
+                            .child(
+                                div()
+                                    .min_w_0()
+                                    .truncate()
+                                    .text_size(px(11.0))
+                                    .text_color(colors.tertiary)
+                                    .child(location),
+                            ),
+                    ),
+            )
+            .child(chip(kind, colors))
+            .on_hover(cx.listener(move |this, hovered: &bool, _, cx| {
+                if *hovered {
+                    this.highlight = index;
+                    cx.notify();
+                }
+            }))
+            .on_click(cx.listener(move |this, _, _, cx| {
+                this.highlight = index;
+                this.run_highlighted(false, cx);
+            }))
+            .into_any_element()
+    }
+
+    fn render_file_row(
+        &mut self,
+        hit: SearchHit,
+        index: usize,
+        colors: SemanticColors,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let name = hit
+            .relative_path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| hit.preview.clone());
+        let parent = hit
+            .relative_path
+            .parent()
+            .map(|path| path.to_string_lossy().into_owned())
+            .filter(|path| !path.is_empty());
+        div()
+            .id(("quick-file-row", index))
+            .flex()
+            .flex_none()
+            .items_center()
+            .gap(px(9.0))
+            .h(px(QUICK_ROW_HEIGHT))
+            .px(px(ROW_PADDING_X))
+            .rounded(px(Radius::ROW))
+            .bg(quick_row_fill(index == self.highlight, colors))
+            .cursor_pointer()
+            .hover(move |row| row.bg(colors.primary.alpha(0.07)))
+            .child(
+                div()
+                    .w(px(18.0))
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .child(sf_symbol("doc.text", 12.0, colors.secondary)),
+            )
+            .child(
+                div()
+                    .min_w_0()
+                    .flex_1()
+                    .flex()
+                    .items_baseline()
+                    .gap(px(7.0))
+                    .text_size(px(13.0))
+                    .child(name)
+                    .when_some(parent, |row, parent| {
+                        row.child(
+                            div()
+                                .truncate()
+                                .text_size(px(11.0))
+                                .text_color(colors.tertiary)
+                                .child(parent),
+                        )
+                    }),
+            )
+            .on_hover(cx.listener(move |this, hovered: &bool, _, cx| {
+                if *hovered {
+                    this.highlight = index;
+                    cx.notify();
+                }
+            }))
+            .on_click(cx.listener(move |this, _, _, cx| {
+                this.highlight = index;
+                this.run_highlighted(false, cx);
+            }))
+            .into_any_element()
+    }
+
+    fn render_quick_folder_row(
         &mut self,
         item: QuickOpenItem,
         name_matches: &[Range<usize>],
@@ -968,22 +1403,14 @@ impl NavigationOverlay {
         colors: SemanticColors,
         cx: &mut Context<Self>,
     ) -> AnyElement {
-        let path = item.path.clone();
         let parent = relative_parent(&item.path);
         let icon_color = if item.is_git_repo {
             Palette::CLAY
         } else {
             colors.secondary
         };
-        let default_name = {
-            let store = self.store.read().expect("session store lock poisoned");
-            crate::agent_catalog::display_name(
-                &store.preferences().default_agent,
-                store.agent_catalog(),
-            )
-        };
         let row = div()
-            .id(format!("quick-row-{index}"))
+            .id(("quick-folder-row", index))
             .flex()
             .flex_none()
             .items_center()
@@ -995,12 +1422,9 @@ impl NavigationOverlay {
             }))
             .px(px(ROW_PADDING_X))
             .rounded(px(Radius::ROW))
-            .bg(if index == self.highlight {
-                colors.primary.alpha(0.10)
-            } else {
-                colors.primary.alpha(0.0)
-            })
+            .bg(quick_row_fill(index == self.highlight, colors))
             .cursor_pointer()
+            .hover(move |row| row.bg(colors.primary.alpha(0.07)))
             .child(
                 div()
                     .flex()
@@ -1041,15 +1465,6 @@ impl NavigationOverlay {
                             }),
                     ),
             )
-            .when(index == self.highlight, |row| {
-                row.child(
-                    div()
-                        .flex()
-                        .gap(px(5.0))
-                        .child(chip(format!("⏎ {}", default_name.to_lowercase()), colors))
-                        .child(chip("⌘⏎ term", colors)),
-                )
-            })
             .on_hover(cx.listener(move |this, hovered: &bool, _, cx| {
                 if *hovered {
                     this.highlight = index;
@@ -1057,15 +1472,8 @@ impl NavigationOverlay {
                 }
             }))
             .on_click(cx.listener(move |this, _, _, cx| {
-                let cwd = path.to_string_lossy().into_owned();
-                this.store
-                    .write()
-                    .expect("session store lock poisoned")
-                    .spawn_default(SpawnOptions {
-                        cwd: Some(cwd.clone()),
-                        ..SpawnOptions::default()
-                    });
-                this.close_overlay(cx);
+                this.highlight = index;
+                this.run_highlighted(false, cx);
             }));
         row.into_any_element()
     }
@@ -1128,6 +1536,69 @@ fn empty_label(text: &'static str, colors: SemanticColors) -> AnyElement {
         .into_any_element()
 }
 
+fn empty_message(text: impl Into<SharedString>, colors: SemanticColors) -> AnyElement {
+    div()
+        .min_h(px(88.0))
+        .flex_1()
+        .flex()
+        .items_center()
+        .justify_center()
+        .text_size(px(12.0))
+        .text_color(colors.tertiary)
+        .child(text.into())
+        .into_any_element()
+}
+
+fn quick_row_fill(highlighted: bool, colors: SemanticColors) -> gpui::Rgba {
+    if highlighted {
+        colors.primary.alpha(0.12)
+    } else {
+        colors.primary.alpha(0.0)
+    }
+}
+
+fn quick_footer(action: &'static str, colors: SemanticColors) -> AnyElement {
+    div()
+        .h(px(QUICK_FOOTER_HEIGHT))
+        .px(px(14.0))
+        .flex()
+        .flex_none()
+        .items_center()
+        .justify_between()
+        .text_size(px(10.5))
+        .text_color(colors.tertiary)
+        .child(
+            div()
+                .flex()
+                .items_center()
+                .gap(px(14.0))
+                .child(footer_hint("↑↓", "Navigate", colors))
+                .child(footer_hint("↵", action, colors)),
+        )
+        .child(footer_hint("esc", "Close", colors))
+        .into_any_element()
+}
+
+fn footer_hint(key: &'static str, label: &'static str, colors: SemanticColors) -> AnyElement {
+    div()
+        .flex()
+        .items_center()
+        .gap(px(5.0))
+        .child(
+            div()
+                .px(px(4.0))
+                .py(px(1.0))
+                .rounded(px(Radius::CHIP))
+                .border_1()
+                .border_color(colors.primary.alpha(0.08))
+                .bg(colors.primary.alpha(0.035))
+                .text_color(colors.secondary)
+                .child(key),
+        )
+        .child(label)
+        .into_any_element()
+}
+
 /// Rows and section headers are siblings in the scroll container, so scrolling
 /// to row N means scrolling to child N plus every header above it. `sections`
 /// is the size of the first section, or `None` for a headerless flat list.
@@ -1137,6 +1608,24 @@ const fn row_child_index(row: usize, first_section: Option<usize>) -> usize {
     };
     // Each non-empty section above the row contributes one header child.
     row + (first > 0) as usize + (row >= first) as usize
+}
+
+/// Quick Open has three independently filtered sections. Each non-empty
+/// section contributes one header before its selectable rows.
+fn sectioned_row_child_index(row: usize, sections: &[usize]) -> usize {
+    let mut consumed = 0;
+    let mut headers = 0;
+    for &length in sections {
+        if length == 0 {
+            continue;
+        }
+        headers += 1;
+        if row < consumed + length {
+            return row + headers;
+        }
+        consumed += length;
+    }
+    row + headers
 }
 
 /// A static caret. Blinking would need an autonomous frame timer, which is
@@ -1294,6 +1783,19 @@ fn relative_parent(path: &Path) -> String {
         .map_or(parent.clone(), |suffix| format!("~/{suffix}"))
 }
 
+fn abbreviated_path(path: &Path) -> String {
+    let path = path.to_string_lossy().into_owned();
+    let Some(home) = std::env::var_os("HOME") else {
+        return path;
+    };
+    let home = PathBuf::from(home).to_string_lossy().into_owned();
+    if path == home {
+        return "~".into();
+    }
+    path.strip_prefix(&format!("{home}/"))
+        .map_or(path.clone(), |suffix| format!("~/{suffix}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1323,8 +1825,15 @@ mod tests {
         assert_eq!(row_child_index(5, Some(5)), 7);
         // No actions matched: only the "Sessions" header sits above row 0.
         assert_eq!(row_child_index(0, Some(0)), 1);
-        // A searched Quick Open list has no headers at all.
+        // A headerless flat list remains useful for command-style lists.
         assert_eq!(row_child_index(3, None), 3);
+
+        // Quick Open skips empty sections and counts each visible header.
+        assert_eq!(sectioned_row_child_index(0, &[3, 4, 2]), 1);
+        assert_eq!(sectioned_row_child_index(2, &[3, 4, 2]), 3);
+        assert_eq!(sectioned_row_child_index(3, &[3, 4, 2]), 5);
+        assert_eq!(sectioned_row_child_index(7, &[3, 4, 2]), 10);
+        assert_eq!(sectioned_row_child_index(3, &[0, 4, 0]), 4);
     }
 
     fn layout(width: f32, height: f32) -> OverlayLayout {
@@ -1340,7 +1849,9 @@ mod tests {
             (600.0, 360.0),
         ] {
             let layout = layout(width, height);
-            let total = layout.top_inset + px(SEARCH_HEIGHT + 1.0) + layout.list_height;
+            let total = layout.top_inset
+                + px(QUICK_SEARCH_HEIGHT + QUICK_FOOTER_HEIGHT + 2.0)
+                + layout.list_height;
             assert!(
                 total <= px(height),
                 "{width}x{height} overflows by {:?}",

--- a/zeus/crates/zeus-app/src/palette.rs
+++ b/zeus/crates/zeus-app/src/palette.rs
@@ -135,7 +135,7 @@ pub fn actions_for_default_host(
             detail: None,
             enabled: true,
             command: PaletteCommand::OpenQuickOpen,
-            keywords: "folder project directory jump goto find".into(),
+            keywords: "file folder project directory session agent jump goto find".into(),
         },
         PaletteAction {
             id: "session-overview".into(),
@@ -883,7 +883,10 @@ mod tests {
 
         assert_eq!(top("term").as_deref(), Some("new-terminal"));
         assert_eq!(top("ncc").as_deref(), Some("new-default"));
-        assert_eq!(top("mldrills").as_deref(), Some("new-default-in-/work/mldrills"));
+        assert_eq!(
+            top("mldrills").as_deref(),
+            Some("new-default-in-/work/mldrills")
+        );
         // Synonyms nobody put in a title: "preferences" is only a keyword.
         assert_eq!(top("preferences").as_deref(), Some("settings"));
         assert_eq!(top("shell").as_deref(), Some("new-terminal"));

--- a/zeus/crates/zeus-app/src/root.rs
+++ b/zeus/crates/zeus-app/src/root.rs
@@ -344,6 +344,15 @@ impl RootView {
                 NavigationEvent::CheckForUpdates => {
                     this.services.updates.check(true);
                 }
+                NavigationEvent::OpenFile { cwd, reference } => {
+                    let inspector = this.inspector.clone();
+                    this.reveal_inspector(cx);
+                    if let Some(inspector) = inspector {
+                        inspector.update(cx, |inspector, cx| {
+                            inspector.open_file_reference(cwd.clone(), reference.clone(), cx);
+                        });
+                    }
+                }
             })
             .detach();
         }
@@ -1910,12 +1919,18 @@ impl Render for RootView {
             .inspector_width
             .max(self.inspector_min_width())
             .min(self.inspector_max_width);
-        let inspector_width =
-            if self.inspector_open && !startup_welcome_visible && has_selected_session {
-                inspector_panel_width
-            } else {
-                0.0
-            };
+        let inspector_has_standalone_destination = self
+            .inspector
+            .as_ref()
+            .is_some_and(|inspector| inspector.read(cx).is_code_destination());
+        let inspector_width = if self.inspector_open
+            && (inspector_has_standalone_destination
+                || (!startup_welcome_visible && has_selected_session))
+        {
+            inspector_panel_width
+        } else {
+            0.0
+        };
         let now = Instant::now();
         self.sidebar_seam =
             advance_seam(&mut self.sidebar_slide, occupied_sidebar_width, now, window);

--- a/zeus/crates/zeus-app/src/surface_shell.rs
+++ b/zeus/crates/zeus-app/src/surface_shell.rs
@@ -1548,7 +1548,7 @@ impl UtilitySurfaces {
                     "New sessions",
                     setting_row(
                         "Default agent",
-                        "Used by ⌘T and Quick Open.",
+                        "Used by ⌘T and folder results in Quick Open.",
                         self.default_agent_dropdown(cx),
                         colors,
                     ),


### PR DESCRIPTION
## Summary
- Turn `⌘P` into a unified navigator that searches project files, agent sessions, and indexed folders.
- Open a file in Code, switch sessions, or launch the default agent (⌘Return for a folder terminal) from one palette.
- Update the user manual to match the new Quick Open behavior, including remote-session file search limits.

## Test plan
- [ ] `⌘P` from a local session lists files from that project, plus sessions and folders
- [ ] Return on a file opens it in Code; Return on a session switches; Return on a folder launches the default agent
- [ ] `⌘Return` on a folder launches a terminal
- [ ] Remote sessions still appear, but their files are not indexed locally
- [ ] Startup screen can search files from the first open project and open Code without a selected agent