### PR TITLE
release: correct version to 0.1.0

### DIFF
--- a/Casks/zeus.rb
+++ b/Casks/zeus.rb
@@ -1,5 +1,5 @@
 cask "zeus" do
-  version "0.0.1"
+  version "0.1.0"
   # Fail closed until the first Zeus release replaces this value with the
   # SHA-256 reported by GitHub. zeus/scripts/publish-homebrew-cask.sh owns it.
   sha256 "0000000000000000000000000000000000000000000000000000000000000000"

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ stop them, and an Engine restart can recover their conversations.
 
 ## Get Zeus
 
-Zeus requires macOS 15 or later. Version 0.0.1 is available only as a universal
-DMG from the [GitHub release](https://github.com/nnayz/zeus/releases/tag/v0.0.1).
+Zeus requires macOS 15 or later. Version 0.1.0 is available only as a universal
+DMG from the [GitHub release](https://github.com/nnayz/zeus/releases/tag/v0.1.0).
 Download it, move Zeus into Applications, then right-click the app and choose
 **Open**. The package supports both Apple silicon and Intel Macs.
 
@@ -26,7 +26,7 @@ The [illustrated macOS install guide](https://nnayz.github.io/zeus/install/)
 shows the complete one-time Gatekeeper flow, including the **Privacy &
 Security → Open Anyway** fallback.
 
-Version 0.0.1 is ad-hoc signed. It is not Developer ID signed or notarized, so
+Version 0.1.0 is ad-hoc signed. It is not Developer ID signed or notarized, so
 Gatekeeper may reject a normal double-click. It cannot be installed through
 Homebrew, and the built-in updater will not accept it. Read the
 [security notes](SECURITY.md) before installing.

--- a/docs/src/updates.md
+++ b/docs/src/updates.md
@@ -1,7 +1,7 @@
 # Updates
 
 The updater is disabled for the current ad-hoc-signed release. It rejects
-builds that are not Developer ID signed and notarized, including v0.0.1. Until
+builds that are not Developer ID signed and notarized, including v0.1.0. Until
 a qualifying release ships, download new versions manually from
 [GitHub Releases](https://github.com/nnayz/zeus/releases).
 

--- a/sidecar/package-lock.json
+++ b/sidecar/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zeus-test-sidecar",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zeus-test-sidecar",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "dependencies": {
         "playwright": "^1.62.1"
       },

--- a/sidecar/package.json
+++ b/sidecar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zeus-test-sidecar",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "private": true,
   "description": "Playwright browser pool driven by the Zeus daemon over a unix socket.",
   "type": "commonjs",

--- a/site/src/lib/releases.ts
+++ b/site/src/lib/releases.ts
@@ -16,17 +16,17 @@ export const SECURITY_EMAIL = 'hi@nasrul.info';
 
 export const releases: Release[] = [
   {
-    version: '0.0.1',
-    date: '2026-08-20',
+    version: '0.1.0',
+    date: '2026-08-21',
     summary: [
       'Zeus’s first public release gives coding agents a calm, native home on macOS. Run Claude Code, Codex, Cursor, Gemini, and other agents side by side, keep concurrent work isolated in Git worktrees, and see at a glance which sessions are working, waiting, or done.',
       'Every session runs in a real PTY managed by the Engine, so you can close the window, reopen the app, or recover from a restart without losing the process behind the conversation.',
       'Local projects and remote SSH hosts follow the same workflow, with a companion CLI for hooks, notifications, and automation. This is an early, ad-hoc-signed build, but the core promise is already here: your agents keep working, their state stays understandable, and you remain in control.'
     ],
     unsigned: true,
-    github: `${GITHUB}/releases/tag/v0.0.1`,
-    dmg: `${GITHUB}/releases/download/v0.0.1/zeus-0.0.1-universal.dmg`,
-    zip: `${GITHUB}/releases/download/v0.0.1/zeus-0.0.1-universal.zip`
+    github: `${GITHUB}/releases/tag/v0.1.0`,
+    dmg: `${GITHUB}/releases/download/v0.1.0/zeus-0.1.0-universal.dmg`,
+    zip: `${GITHUB}/releases/download/v0.1.0/zeus-0.1.0-universal.zip`
   }
 ];
 

--- a/zeus/Cargo.lock
+++ b/zeus/Cargo.lock
@@ -7275,7 +7275,7 @@ dependencies = [
 
 [[package]]
 name = "zeus-app"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "block2 0.6.2",
  "gpui",
@@ -7305,7 +7305,7 @@ dependencies = [
 
 [[package]]
 name = "zeus-cli"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "libc",
  "serde",
@@ -7315,7 +7315,7 @@ dependencies = [
 
 [[package]]
 name = "zeus-client"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "futures-core",
  "getrandom 0.4.3",
@@ -7328,7 +7328,7 @@ dependencies = [
 
 [[package]]
 name = "zeus-engine"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "alacritty_terminal",
  "base64 0.23.1",
@@ -7350,14 +7350,14 @@ dependencies = [
 
 [[package]]
 name = "zeus-mcp"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "serde_json",
 ]
 
 [[package]]
 name = "zeus-node"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "getrandom 0.4.3",
  "rusqlite",
@@ -7373,7 +7373,7 @@ dependencies = [
 
 [[package]]
 name = "zeus-proto"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7383,14 +7383,14 @@ dependencies = [
 
 [[package]]
 name = "zeus-pty"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "zeus-remote"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "getrandom 0.4.3",
  "libc",
@@ -7406,7 +7406,7 @@ dependencies = [
 
 [[package]]
 name = "zeus-term"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "gpui",
  "gpui_platform",
@@ -7415,7 +7415,7 @@ dependencies = [
 
 [[package]]
 name = "zeus-terminal-state"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "alacritty_terminal",
  "zeus-proto",
@@ -7423,7 +7423,7 @@ dependencies = [
 
 [[package]]
 name = "zeus-ui"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "gpui",
  "gpui_platform",
@@ -7431,7 +7431,7 @@ dependencies = [
 
 [[package]]
 name = "zeus-updater"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -7440,7 +7440,7 @@ dependencies = [
 
 [[package]]
 name = "zeus-usage"
-version = "0.0.1"
+version = "0.1.0"
 
 [[package]]
 name = "zmij"

--- a/zeus/crates/zeus-app/Cargo.toml
+++ b/zeus/crates/zeus-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeus-app"
-version = "0.0.1"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/zeus/crates/zeus-cli/Cargo.toml
+++ b/zeus/crates/zeus-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeus-cli"
-version = "0.0.1"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/zeus/crates/zeus-client/Cargo.toml
+++ b/zeus/crates/zeus-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeus-client"
-version = "0.0.1"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/zeus/crates/zeus-engine/Cargo.toml
+++ b/zeus/crates/zeus-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeus-engine"
-version = "0.0.1"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/zeus/crates/zeus-mcp/Cargo.toml
+++ b/zeus/crates/zeus-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeus-mcp"
-version = "0.0.1"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/zeus/crates/zeus-node/Cargo.toml
+++ b/zeus/crates/zeus-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeus-node"
-version = "0.0.1"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/zeus/crates/zeus-proto/Cargo.toml
+++ b/zeus/crates/zeus-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeus-proto"
-version = "0.0.1"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/zeus/crates/zeus-proto/tests/fixtures/hello_response.json
+++ b/zeus/crates/zeus-proto/tests/fixtures/hello_response.json
@@ -1,1 +1,1 @@
-{"id":1,"ok":{"build":"0.0.1","executableHash":"037fa1b1aa6468c47ad101f3db9208c81f9cec607af651fbc79c5eb25ea9d547","pid":33651,"proto":1}}
+{"id":1,"ok":{"build":"0.1.0","executableHash":"037fa1b1aa6468c47ad101f3db9208c81f9cec607af651fbc79c5eb25ea9d547","pid":33651,"proto":1}}

--- a/zeus/crates/zeus-pty/Cargo.toml
+++ b/zeus/crates/zeus-pty/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeus-pty"
-version = "0.0.1"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/zeus/crates/zeus-remote/Cargo.toml
+++ b/zeus/crates/zeus-remote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeus-remote"
-version = "0.0.1"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/zeus/crates/zeus-term/Cargo.toml
+++ b/zeus/crates/zeus-term/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeus-term"
-version = "0.0.1"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/zeus/crates/zeus-terminal-state/Cargo.toml
+++ b/zeus/crates/zeus-terminal-state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeus-terminal-state"
-version = "0.0.1"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/zeus/crates/zeus-ui/Cargo.toml
+++ b/zeus/crates/zeus-ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeus-ui"
-version = "0.0.1"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/zeus/crates/zeus-updater/Cargo.toml
+++ b/zeus/crates/zeus-updater/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeus-updater"
-version = "0.0.1"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/zeus/crates/zeus-usage/Cargo.toml
+++ b/zeus/crates/zeus-usage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zeus-usage"
-version = "0.0.1"
+version = "0.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/zeus/scripts/package.sh
+++ b/zeus/scripts/package.sh
@@ -9,7 +9,7 @@ app_path="${dist_dir}/zeus.app"
 # The updater compares against CARGO_PKG_VERSION, so artifact names have to come
 # from the same place rather than a hand-passed number that can drift from it.
 cargo_version="$(sed -n 's/^version = "\(.*\)"/\1/p' "${workspace_dir}/crates/zeus-app/Cargo.toml" | head -1)"
-version="${ZEUS_VERSION:-${cargo_version:-0.0.1}}"
+version="${ZEUS_VERSION:-${cargo_version:-0.1.0}}"
 dmg_path="${dist_dir}/zeus-${version}-universal.dmg"
 # Update artifact: a zip of the stapled bundle, which is what zeus's updater
 # downloads. See crates/zeus-updater/src/install.rs.


### PR DESCRIPTION
## Summary

- replace the mistaken 0.0.1 version with 0.1.0 across Rust crates and lockfile
- update release documentation, website downloads, sidecar metadata, and Homebrew cask metadata
- preserve the current ad-hoc-signed release status

## Verification

- ./scripts/check.sh (release guards, cargo fmt, clippy; sandbox-only socket failures in initial test invocation)
- cargo test --workspace (passed outside sandbox for Unix-socket fixtures)
- npm run build (site)