### PR TITLE
fix: MCP default agent and protected cwd handling

### DIFF
--- a/zeus/README.md
+++ b/zeus/README.md
@@ -57,9 +57,12 @@ cargo clippy --workspace -- -D warnings
 ```
 
 Run the app under development through `dev.sh`, which builds a throwaway app
-bundle with a commit-specific name, bundle id, window title, Dock icon, and
-in-window build marker. It also removes agent-session environment variables
-that would otherwise stop zeus from finding or launching the shared daemon:
+bundle with a commit-specific name, window title, Dock icon, and in-window
+build marker. Its bundle id is deliberately stable so macOS Files & Folders
+grants survive rebuilds, and the Engine/Holder/CLI helpers run from inside that
+signed bundle so they inherit the selected-folder identity. It also removes
+agent-session environment variables that would otherwise stop zeus from
+finding or launching the shared daemon:
 
 ```sh
 ./scripts/dev.sh
@@ -67,6 +70,11 @@ that would otherwise stop zeus from finding or launching the shared daemon:
 ./scripts/dev.sh --settings remote
 ./scripts/dev.sh -- --features audio-playback
 ```
+
+For protected Desktop/Documents projects, set `ZEUS_DEV_SIGN_IDENTITY` to a
+stable code-signing identity or run `../scripts/make-dev-cert.sh` once to
+install the repository's local `Zeus Dev` identity. `dev.sh` falls back to
+ad-hoc signing but warns that macOS grants may not survive the next rebuild.
 
 The dev and installed apps deliberately share the daemon, socket, sessions,
 preferences, and Application Support directory. That makes the dev build useful

--- a/zeus/crates/zeus-app/src/store/prefs.rs
+++ b/zeus/crates/zeus-app/src/store/prefs.rs
@@ -73,14 +73,7 @@ where
     D: Deserializer<'de>,
 {
     let saved = String::deserialize(deserializer)?;
-    Ok(match saved.as_str() {
-        "claudeCode" | AgentKind::CLAUDE_CODE_ID => AgentKind::CLAUDE_CODE,
-        "codex" => AgentKind::CODEX,
-        "cursor" => AgentKind::CURSOR,
-        "gemini" => AgentKind::GEMINI,
-        "shell" => AgentKind::SHELL,
-        _ => AgentKind::new(saved),
-    })
+    Ok(AgentKind::from_preference_id(saved))
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -198,7 +191,7 @@ impl Prefs {
     }
 
     pub fn path_in_home(home: &Path) -> PathBuf {
-        home.join("Library/Application Support/zeus/prefs.json")
+        zeus_proto::paths::ZeusPaths::preferences_file(home)
     }
 
     pub fn load(path: &Path) -> io::Result<Self> {

--- a/zeus/crates/zeus-cli/src/mcp.rs
+++ b/zeus/crates/zeus-cli/src/mcp.rs
@@ -7,9 +7,9 @@ use std::time::Duration;
 
 use serde_json::{Map, Value, json};
 use zeus_proto::{
-    EventsSubscribeParams, EventsWaitParams, Method, SendTextParams, SessionId, SessionIdParams,
-    SessionRecord, SessionSpawnParams, TestRunParams, WorktreeCreateParams, WorktreeListParams,
-    WorktreeRemoveParams,
+    AgentKind, EventsSubscribeParams, EventsWaitParams, Method, SendTextParams, SessionId,
+    SessionIdParams, SessionRecord, SessionSpawnParams, TestRunParams, WorktreeCreateParams,
+    WorktreeListParams, WorktreeRemoveParams,
 };
 
 use crate::catalog::{self, AgentCatalog};
@@ -137,7 +137,10 @@ fn initialize(params: &Value) -> Value {
              extra confirmation of intent needed.\n\nNever use the host agent's built-in \
              collaboration spawn_agent / subagents: those workers stay inside this terminal \
              and never appear in the Zeus sidebar. Always call this MCP spawn_agent so the \
-             child is a real Zeus tab.\n\nTypical orchestration flow: spawn_agent \
+             child is a real Zeus tab. Unless the user explicitly requests multiple agents, \
+             make exactly one spawn_agent call. When the user does not name an agent kind, omit \
+             kind so Zeus uses the configured default; never probe or fan out across kinds.\n\n\
+             Typical orchestration flow: spawn_agent \
              (optionally worktree:true and an initial prompt) → wait_for_agent(until:\"done\") \
              → read_output → send_prompt for follow-ups → release_agent when finished. \
              get_artifacts returns PR/Linear/preview URLs and listening ports a session has \
@@ -170,19 +173,19 @@ fn tool_definitions() -> Vec<Value> {
         tool(
             "spawn_agent",
             &format!(
-                "Open a NEW Zeus session tab nested under this one, running {names} — locally or on a configured remote host. This is the ONLY way spawned agents appear in the Zeus sidebar and terminal. Do NOT use built-in collaboration/subagent spawn — those stay hidden inside this PTY. USE THIS whenever the user asks to open/start/spawn/launch another agent, session, or terminal."
+                "Open ONE new Zeus session tab nested under this one, running {names} — locally or on a configured remote host. This is the ONLY way spawned agents appear in the Zeus sidebar and terminal. Do NOT use built-in collaboration/subagent spawn — those stay hidden inside this PTY. USE THIS whenever the user asks to open/start/spawn/launch another agent, session, or terminal. Unless the user explicitly requests multiple agents, call this exactly once. If the user does not name a kind, omit kind and Zeus will use the configured default; never guess, probe, or fan out across agent kinds."
             ),
             json!({
                 "type":"object",
                 "properties":{
-                    "kind":{"type":"string","enum":kinds,"description":"Which agent to run."},
+                    "kind":{"type":"string","enum":kinds,"description":"Which agent to run. Omit to use Zeus's configured default agent."},
                     "cwd":{"type":"string","description":"Working directory."},
                     "host":{"type":"string","description":"Host id from hosts.json."},
                     "worktree":{"type":"boolean","description":"Create a fresh git worktree off cwd and run there. Local only."},
                     "prompt":{"type":"string","description":"Initial prompt to send once the agent is ready."},
                     "name":{"type":"string","description":"Session title."}
                 },
-                "required":["kind","cwd"]
+                "required":["cwd"]
             }),
         ),
         tool(
@@ -340,7 +343,7 @@ fn fetch_sessions() -> Result<Vec<SessionRecord>, CliError> {
 }
 
 fn spawn_agent(args: &Value) -> Result<Value, CliError> {
-    let kind_str = require_string(args, "kind")?;
+    let kind_str = requested_spawn_kind(args);
     let descriptor = AgentCatalog::shared().resolve(&kind_str).ok_or_else(|| {
         let known = AgentCatalog::shared()
             .ordered
@@ -375,6 +378,37 @@ fn spawn_agent(args: &Value) -> Result<Value, CliError> {
     conn::with_conn(Duration::from_secs(60), |conn| {
         conn.request_value(Method::SESSION_SPAWN, &params, Duration::from_secs(60))
     })
+}
+
+fn requested_spawn_kind(args: &Value) -> String {
+    spawn_kind_with_default(args, configured_default_agent())
+}
+
+fn spawn_kind_with_default(args: &Value, configured: Option<String>) -> String {
+    if let Some(kind) = args
+        .get("kind")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|kind| !kind.is_empty())
+    {
+        return kind.to_owned();
+    }
+    configured.unwrap_or_else(|| AgentKind::CLAUDE_CODE_ID.to_owned())
+}
+
+fn configured_default_agent() -> Option<String> {
+    let home = env::var_os("HOME").map(PathBuf::from)?;
+    let bytes = std::fs::read(zeus_proto::paths::ZeusPaths::preferences_file(home)).ok()?;
+    let preferences: Value = serde_json::from_slice(&bytes).ok()?;
+    default_agent_from_preferences(&preferences)
+}
+
+fn default_agent_from_preferences(preferences: &Value) -> Option<String> {
+    let saved = preferences
+        .get("defaultAgent")
+        .and_then(Value::as_str)?
+        .trim();
+    (!saved.is_empty()).then(|| AgentKind::from_preference_id(saved).id().to_owned())
 }
 
 fn list_agents() -> Result<Value, CliError> {
@@ -1019,5 +1053,38 @@ mod tests {
             );
         }
         assert!(!names.contains(&"test_run"));
+    }
+
+    #[test]
+    fn spawn_agent_omits_kind_to_use_the_configured_default() {
+        let tools = tool_definitions();
+        let spawn = tools
+            .iter()
+            .find(|tool| tool["name"] == "spawn_agent")
+            .expect("spawn_agent");
+        let required = spawn["inputSchema"]["required"]
+            .as_array()
+            .expect("required");
+        assert!(!required.iter().any(|field| field == "kind"));
+        assert!(required.iter().any(|field| field == "cwd"));
+
+        assert_eq!(
+            default_agent_from_preferences(&json!({"defaultAgent": "codex"})).as_deref(),
+            Some("codex")
+        );
+        assert_eq!(
+            default_agent_from_preferences(&json!({"defaultAgent": "claudeCode"})).as_deref(),
+            Some("claude-code")
+        );
+        assert_eq!(requested_spawn_kind(&json!({"kind": "gemini"})), "gemini");
+        assert_eq!(
+            spawn_kind_with_default(&json!({}), Some("codex".into())),
+            "codex"
+        );
+        assert_eq!(
+            spawn_kind_with_default(&json!({"kind": "gemini"}), Some("codex".into())),
+            "gemini",
+            "an explicit kind must override the configured default"
+        );
     }
 }

--- a/zeus/crates/zeus-engine/src/control.rs
+++ b/zeus/crates/zeus-engine/src/control.rs
@@ -675,24 +675,25 @@ impl ControlServer {
             argv
         };
 
+        // Validate the requested checkout before invoking git. In particular,
+        // do not collapse a macOS TCC denial into git's generic spawn error.
+        let requested_cwd = PathBuf::from(&p.cwd);
+        crate::cwd::validate_directory(&requested_cwd).map_err(cwd_control_error)?;
+
         // A worktree spawn creates the checkout first, then lands in it.
         let mut cwd = p.cwd.clone();
         let mut worktree_path = None;
         let mut git_branch = None;
         if p.new_worktree.unwrap_or(false) {
             let info =
-                crate::git::create_worktree(Path::new(&p.cwd), p.worktree_branch.as_deref(), None)
+                crate::git::create_worktree(&requested_cwd, p.worktree_branch.as_deref(), None)
                     .map_err(io_control_error)?;
             git_branch.clone_from(&info.branch);
             cwd.clone_from(&info.path);
             worktree_path = Some(info.path);
         }
         let cwd_path = PathBuf::from(&cwd);
-        if !cwd_path.is_dir() {
-            return Err(ControlError::bad_request(format!(
-                "cwd {cwd:?} is not a directory"
-            )));
-        }
+        crate::cwd::validate_directory(&cwd_path).map_err(cwd_control_error)?;
 
         let mut registry = self.registry.lock().map_err(poisoned)?;
         let engine = registry.engine();
@@ -2224,12 +2225,14 @@ impl ControlServer {
 
     fn worktree_create(&self, params: Option<JsonValue>) -> Result<JsonValue, ControlError> {
         let p: zeus_proto::WorktreeCreateParams = decode(params)?;
+        crate::cwd::validate_directory(Path::new(&p.repo_path)).map_err(cwd_control_error)?;
         let info = crate::git::create_worktree(
             Path::new(&p.repo_path),
             p.branch.as_deref(),
             p.base.as_deref(),
         )
         .map_err(io_control_error)?;
+        crate::cwd::validate_directory(Path::new(&info.path)).map_err(cwd_control_error)?;
         self.events.publish(
             "worktree.created",
             json!({ "repoPath": p.repo_path, "path": info.path, "branch": info.branch }),
@@ -2464,6 +2467,10 @@ fn io_control_error(error: std::io::Error) -> ControlError {
         std::io::ErrorKind::NotFound => ControlError::not_found(error.to_string()),
         _ => ControlError::internal(error.to_string()),
     }
+}
+
+fn cwd_control_error(error: crate::cwd::CwdAccessError) -> ControlError {
+    ControlError::new(error.code, error.message)
 }
 
 fn history_entry_to_wire(entry: crate::history::HistoryEntry) -> zeus_proto::HistoryEntry {

--- a/zeus/crates/zeus-engine/src/cwd.rs
+++ b/zeus/crates/zeus-engine/src/cwd.rs
@@ -1,0 +1,139 @@
+//! Working-directory validation shared by the Engine and local Holder.
+//!
+//! `Path::is_dir()` deliberately erases every I/O error into `false`. That is
+//! wrong at a process boundary: a missing checkout and a macOS TCC denial need
+//! different remediation, and the latter was reaching the login shell as the
+//! misleading "Current directory does not exist".
+
+use std::fmt;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+pub const NOT_FOUND: &str = "cwd_not_found";
+pub const NOT_DIRECTORY: &str = "cwd_not_directory";
+pub const PERMISSION_DENIED: &str = "cwd_permission_denied";
+pub const UNREADABLE: &str = "cwd_unreadable";
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct CwdAccessError {
+    pub code: String,
+    pub message: String,
+}
+
+impl CwdAccessError {
+    fn new(code: &str, message: impl Into<String>) -> Self {
+        Self {
+            code: code.to_owned(),
+            message: message.into(),
+        }
+    }
+
+    fn from_io(path: &Path, error: std::io::Error) -> Self {
+        match error.kind() {
+            std::io::ErrorKind::NotFound => Self::new(
+                NOT_FOUND,
+                format!("working directory {:?} does not exist", path.display()),
+            ),
+            std::io::ErrorKind::NotADirectory => Self::new(
+                NOT_DIRECTORY,
+                format!(
+                    "working directory {:?} contains a component that is not a directory",
+                    path.display()
+                ),
+            ),
+            std::io::ErrorKind::PermissionDenied => Self::permission_denied(path, &error),
+            _ if matches!(error.raw_os_error(), Some(libc::EACCES | libc::EPERM)) => {
+                Self::permission_denied(path, &error)
+            }
+            _ => Self::new(
+                UNREADABLE,
+                format!(
+                    "Zeus could not read working directory {:?}: {error}",
+                    path.display()
+                ),
+            ),
+        }
+    }
+
+    fn permission_denied(path: &Path, error: &std::io::Error) -> Self {
+        #[cfg(target_os = "macos")]
+        let remedy = " Allow Zeus access in System Settings → Privacy & Security → Files & Folders, then restart Zeus.";
+        #[cfg(not(target_os = "macos"))]
+        let remedy = " Check the directory permissions for the user running Zeus.";
+        Self::new(
+            PERMISSION_DENIED,
+            format!(
+                "Zeus cannot read working directory {:?}: {error}.{remedy}",
+                path.display()
+            ),
+        )
+    }
+
+    #[must_use]
+    pub fn io_kind(&self) -> std::io::ErrorKind {
+        match self.code.as_str() {
+            NOT_FOUND => std::io::ErrorKind::NotFound,
+            NOT_DIRECTORY => std::io::ErrorKind::NotADirectory,
+            PERMISSION_DENIED => std::io::ErrorKind::PermissionDenied,
+            _ => std::io::ErrorKind::Other,
+        }
+    }
+}
+
+impl fmt::Display for CwdAccessError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for CwdAccessError {}
+
+impl From<CwdAccessError> for std::io::Error {
+    fn from(error: CwdAccessError) -> Self {
+        std::io::Error::new(error.io_kind(), error)
+    }
+}
+
+/// Confirms that `path` exists, is a directory, and can be enumerated by the
+/// current process. Opening `read_dir` is intentional: metadata commonly
+/// succeeds across a macOS TCC boundary while enumeration returns `EPERM`.
+pub fn validate_directory(path: &Path) -> Result<(), CwdAccessError> {
+    let metadata = std::fs::metadata(path).map_err(|error| CwdAccessError::from_io(path, error))?;
+    if !metadata.is_dir() {
+        return Err(CwdAccessError::new(
+            NOT_DIRECTORY,
+            format!("working directory {:?} is not a directory", path.display()),
+        ));
+    }
+    std::fs::read_dir(path)
+        .map(|_| ())
+        .map_err(|error| CwdAccessError::from_io(path, error))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_and_non_directory_paths_are_distinct() {
+        let temporary = tempfile::tempdir().expect("tempdir");
+        let missing = temporary.path().join("missing");
+        let error = validate_directory(&missing).expect_err("missing");
+        assert_eq!(error.code, NOT_FOUND);
+
+        let file = temporary.path().join("file");
+        std::fs::write(&file, b"not a directory").expect("fixture file");
+        let error = validate_directory(&file).expect_err("file");
+        assert_eq!(error.code, NOT_DIRECTORY);
+    }
+
+    #[test]
+    fn eperm_is_an_actionable_permission_error() {
+        let path = Path::new("/protected/project");
+        let error = CwdAccessError::from_io(path, std::io::Error::from_raw_os_error(libc::EPERM));
+        assert_eq!(error.code, PERMISSION_DENIED);
+        assert!(error.message.contains("/protected/project"));
+        assert_eq!(error.io_kind(), std::io::ErrorKind::PermissionDenied);
+    }
+}

--- a/zeus/crates/zeus-engine/src/holder/manager.rs
+++ b/zeus/crates/zeus-engine/src/holder/manager.rs
@@ -197,6 +197,12 @@ impl HolderManagerServer {
                 "session control paths are outside manager directory".into(),
             ));
         }
+        // This check intentionally runs in the detached Holder process, not
+        // only in the Engine. macOS can authorize the GUI/Engine while still
+        // denying a separately signed or stale Holder; metadata alone also
+        // succeeds in cases where directory enumeration returns EPERM.
+        crate::cwd::validate_directory(Path::new(&spec.cwd))
+            .map_err(|error| HolderError::Rejected(error.to_string()))?;
         Ok(())
     }
 
@@ -269,10 +275,11 @@ fn write_pid_file(path: &Path) -> HolderResult<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::time::Duration;
 
     use super::HolderManagerServer;
-    use crate::holder::{HolderManagerClient, HolderManagerPaths};
+    use crate::holder::{HolderLaunchSpec, HolderManagerClient, HolderManagerPaths, HolderPaths};
 
     #[test]
     fn an_idle_manager_accepts_immediate_graceful_shutdown() {
@@ -290,5 +297,36 @@ mod tests {
         client.shutdown_if_idle().expect("idle shutdown");
         worker.join().expect("manager thread").expect("manager run");
         assert!(!client.is_alive());
+    }
+
+    #[test]
+    fn launch_validation_distinguishes_a_missing_cwd() {
+        let temporary = tempfile::tempdir().expect("tempdir");
+        let directory = temporary.path().join("holders");
+        let paths = HolderPaths::new(&directory, "s_missing");
+        let server = HolderManagerServer::new(&directory, Duration::from_secs(30));
+        let spec = HolderLaunchSpec {
+            session_id: "s_missing".into(),
+            socket_path: paths.socket().to_string_lossy().into_owned(),
+            pid_file_path: paths.pid_file().to_string_lossy().into_owned(),
+            log_file_path: temporary
+                .path()
+                .join("s_missing.bin")
+                .to_string_lossy()
+                .into_owned(),
+            argv: vec!["/bin/true".into()],
+            cwd: temporary
+                .path()
+                .join("does-not-exist")
+                .to_string_lossy()
+                .into_owned(),
+            environment: HashMap::new(),
+            cols: 80,
+            rows: 24,
+            disk_capacity: crate::holder::protocol::DEFAULT_DISK_CAPACITY,
+        };
+
+        let error = server.validate(&spec).expect_err("missing cwd");
+        assert!(error.to_string().contains(crate::cwd::NOT_FOUND));
     }
 }

--- a/zeus/crates/zeus-engine/src/lib.rs
+++ b/zeus/crates/zeus-engine/src/lib.rs
@@ -24,6 +24,7 @@ pub mod attach;
 pub mod browser;
 pub mod checkpoint;
 pub mod control;
+pub mod cwd;
 pub mod detect;
 pub mod directories;
 pub mod events;

--- a/zeus/crates/zeus-engine/src/mcp/host.rs
+++ b/zeus/crates/zeus-engine/src/mcp/host.rs
@@ -9,7 +9,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use serde_json::{Value, json};
-use zeus_proto::{SessionId, SessionStatus};
+use zeus_proto::{AgentKind, SessionId, SessionStatus};
 
 use super::ToolHost;
 use crate::git;
@@ -31,6 +31,9 @@ pub struct RegistryHost {
     holder: Option<crate::session::HolderConfig>,
     /// The session calling these tools, when it identified itself.
     caller: Option<String>,
+    /// Used only when `spawn_agent.kind` is omitted. Explicit tool arguments
+    /// always win.
+    default_agent: String,
 }
 
 impl RegistryHost {
@@ -40,6 +43,8 @@ impl RegistryHost {
             logs_dir: logs_dir.into(),
             holder: None,
             caller: std::env::var(SESSION_ID_ENV).ok(),
+            default_agent: configured_default_agent()
+                .unwrap_or_else(|| AgentKind::CLAUDE_CODE_ID.to_owned()),
         }
     }
 
@@ -56,11 +61,28 @@ impl RegistryHost {
         self
     }
 
+    /// Overrides the configured default, primarily for deterministic tests.
+    pub fn with_default_agent(mut self, default_agent: impl Into<String>) -> Self {
+        self.default_agent = default_agent.into();
+        self
+    }
+
     fn registry(&self) -> Result<std::sync::MutexGuard<'_, Registry>, String> {
         self.registry
             .lock()
             .map_err(|_| "engine state is poisoned".to_string())
     }
+}
+
+fn configured_default_agent() -> Option<String> {
+    let home = std::env::var_os("HOME").map(PathBuf::from)?;
+    let bytes = std::fs::read(zeus_proto::paths::ZeusPaths::preferences_file(home)).ok()?;
+    let preferences: Value = serde_json::from_slice(&bytes).ok()?;
+    let saved = preferences
+        .get("defaultAgent")
+        .and_then(Value::as_str)?
+        .trim();
+    (!saved.is_empty()).then(|| AgentKind::from_preference_id(saved).id().to_owned())
 }
 
 fn required_str(arguments: &Value, key: &str) -> Result<String, String> {
@@ -202,7 +224,11 @@ impl ToolHost for RegistryHost {
                 let repo = required_str(arguments, "repo")?;
                 let branch = arguments.get("branch").and_then(Value::as_str);
                 let base = arguments.get("base").and_then(Value::as_str);
+                crate::cwd::validate_directory(Path::new(&repo))
+                    .map_err(|error| error.to_string())?;
                 let info = git::create_worktree(Path::new(&repo), branch, base)
+                    .map_err(|error| error.to_string())?;
+                crate::cwd::validate_directory(Path::new(&info.path))
                     .map_err(|error| error.to_string())?;
                 Ok(json!({ "path": info.path, "branch": info.branch }))
             }
@@ -300,15 +326,19 @@ impl RegistryHost {
     /// `wait_for_agent` then `send_prompt`. The pending prompt is returned so
     /// the caller knows it still owes it.
     fn spawn_agent(&self, arguments: &Value) -> Result<Value, String> {
-        let kind = required_str(arguments, "kind")?;
+        let kind = arguments
+            .get("kind")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|kind| !kind.is_empty())
+            .map(str::to_owned)
+            .unwrap_or_else(|| self.default_agent.clone());
         let cwd = required_str(arguments, "cwd")?;
         if let Some(host) = arguments.get("host").and_then(Value::as_str) {
             return self.spawn_agent_remote(arguments, &kind, &cwd, host);
         }
         let cwd_path = PathBuf::from(&cwd);
-        if !cwd_path.is_dir() {
-            return Err(format!("cwd {cwd:?} is not a directory"));
-        }
+        crate::cwd::validate_directory(&cwd_path).map_err(|error| error.to_string())?;
         let wants_worktree = arguments
             .get("worktree")
             .and_then(Value::as_bool)
@@ -332,6 +362,7 @@ impl RegistryHost {
         } else {
             (cwd_path, None, git::branch(Path::new(&cwd)))
         };
+        crate::cwd::validate_directory(&working_dir).map_err(|error| error.to_string())?;
 
         let mut registry = self.registry()?;
         let engine = registry.engine();

--- a/zeus/crates/zeus-engine/src/mcp/tools.rs
+++ b/zeus/crates/zeus-engine/src/mcp/tools.rs
@@ -43,22 +43,24 @@ pub fn tool_definitions_for(kinds: &[String]) -> Vec<ToolDefinition> {
     vec![
         tool(
             "spawn_agent",
-            "Open a NEW Zeus session tab nested under this one. This is the ONLY way \
+            "Open ONE new Zeus session tab nested under this one. This is the ONLY way \
              spawned agents appear in the Zeus sidebar and terminal. Do NOT use built-in \
              collaboration/subagent spawn — those stay hidden inside this PTY. USE THIS \
              whenever the user asks to open, start, spawn or launch another agent, session, \
              or terminal. Optionally create a fresh git worktree for it and give it an \
-             initial prompt.",
+             initial prompt. Unless the user explicitly requests multiple agents, call this \
+             exactly once. If the user does not name a kind, omit kind and Zeus will use the \
+             configured default; never guess, probe, or fan out across agent kinds.",
             json!({
                 "type": "object",
                 "properties": {
-                    "kind": { "type": "string", "enum": kind_enum, "description": "Which agent to run." },
+                    "kind": { "type": "string", "enum": kind_enum, "description": "Which agent to run. Omit to use Zeus's configured default agent." },
                     "cwd": { "type": "string", "description": "Working directory (a repo path when worktree is true)." },
                     "worktree": { "type": "boolean", "description": "Create a fresh git worktree off cwd and run there (local spawns only)." },
                     "prompt": { "type": "string", "description": "Initial prompt to send once the agent is ready." },
                     "name": { "type": "string", "description": "Session title." }
                 },
-                "required": ["kind", "cwd"]
+                "required": ["cwd"]
             }),
         ),
         tool(
@@ -246,6 +248,9 @@ mod tests {
             .filter_map(Value::as_str)
             .collect();
         assert_eq!(enumerated, vec!["opencode", "shell"]);
+        let required = spawn.input_schema["required"].as_array().expect("required");
+        assert!(!required.iter().any(|field| field == "kind"));
+        assert!(required.iter().any(|field| field == "cwd"));
     }
 
     #[test]

--- a/zeus/crates/zeus-engine/src/session.rs
+++ b/zeus/crates/zeus-engine/src/session.rs
@@ -855,13 +855,17 @@ impl Session {
                         rows: pty.rows,
                         disk_capacity: crate::holder::protocol::DEFAULT_DISK_CAPACITY,
                     };
-                    if HolderLauncher::launch(&holder.executable, &paths, &launch).is_err() {
-                        mark_launch_failed(&shared);
+                    if let Err(error) = HolderLauncher::launch(&holder.executable, &paths, &launch)
+                    {
+                        mark_launch_failed(&shared, &error.to_string());
                         return;
                     }
-                    let Ok(floor) = wait_for_holder(&client, &logs_dir, &id, pre_spawn_tail) else {
-                        mark_launch_failed(&shared);
-                        return;
+                    let floor = match wait_for_holder(&client, &logs_dir, &id, pre_spawn_tail) {
+                        Ok(floor) => floor,
+                        Err(error) => {
+                            mark_launch_failed(&shared, &error.to_string());
+                            return;
+                        }
                     };
                     if let Ok(stat) = client.stat() {
                         shared.child_pid.store(stat.child_pid, Ordering::SeqCst);
@@ -2554,9 +2558,18 @@ fn pump_held(
     shared.exited.store(true, Ordering::SeqCst);
 }
 
-/// Records a deferred launch that never produced a child: the session
-/// reports exit 127, the spawn-failure convention the app already knows.
-fn mark_launch_failed(shared: &Shared) {
+/// Records a deferred launch that never produced a child. The exact Holder
+/// diagnostic is written into the session screen before exit 127 so the UI
+/// and MCP `read_output` expose an actionable error instead of an empty tab.
+fn mark_launch_failed(shared: &Shared, error: &str) {
+    let output = format!("Zeus could not start this session.\r\n{error}\r\n");
+    let _ = shared.log.lock().expect("log").append(output.as_bytes());
+    shared
+        .screen
+        .lock()
+        .expect("screen")
+        .feed(output.as_bytes());
+    shared.grid_wake.notify();
     *shared.exit.lock().expect("exit") = Some(Exit::Code(127));
     let outcome = shared.reducer.lock().expect("reducer").reduce(
         StatusSignal::ProcessExit {

--- a/zeus/crates/zeus-engine/tests/mcp_tools.rs
+++ b/zeus/crates/zeus-engine/tests/mcp_tools.rs
@@ -407,7 +407,7 @@ fn spawn_agent_starts_a_session_owned_by_its_caller() {
         json!({ "kind": "claude-code", "cwd": "/no/such/dir" }),
     )
     .expect_err("bad cwd");
-    assert!(bad_cwd.contains("not a directory"), "got {bad_cwd}");
+    assert!(bad_cwd.contains("cwd_not_found"), "got {bad_cwd}");
 
     // Old clients may still send `host`; fail before cwd inspection, host
     // lookup, code sync, or session creation while the new transport is dark.
@@ -459,13 +459,15 @@ fn a_spawned_session_records_its_parent_and_appears_as_a_child() {
     )));
     let server = McpServer::new(
         tool_definitions(),
-        RegistryHost::new(Arc::clone(&registry), &logs).with_caller(Some("s_parent".to_string())),
+        RegistryHost::new(Arc::clone(&registry), &logs)
+            .with_caller(Some("s_parent".to_string()))
+            .with_default_agent("sleeper"),
     );
 
     let spawned = call(
         &server,
         "spawn_agent",
-        json!({ "kind": "sleeper", "cwd": "/tmp", "name": "worker one", "prompt": "do the thing" }),
+        json!({ "cwd": "/tmp", "name": "worker one", "prompt": "do the thing" }),
     )
     .expect("spawn");
 
@@ -482,6 +484,7 @@ fn a_spawned_session_records_its_parent_and_appears_as_a_child() {
         .expect("registry")
         .record(&id)
         .expect("spawned record");
+    assert_eq!(record.kind.id(), "sleeper");
     assert_eq!(record.workbench, Some(false));
     assert!(!record.is_workbench_terminal());
 

--- a/zeus/crates/zeus-proto/src/model.rs
+++ b/zeus/crates/zeus-proto/src/model.rs
@@ -108,6 +108,22 @@ impl AgentKind {
         }
     }
 
+    /// Decodes the plain-string id stored in `prefs.json`. The four legacy
+    /// spellings remain valid because preferences outlive protocol and
+    /// manifest migrations.
+    #[must_use]
+    pub fn from_preference_id(saved: impl Into<String>) -> Self {
+        let saved = saved.into();
+        match saved.as_str() {
+            "claudeCode" | Self::CLAUDE_CODE_ID => Self::CLAUDE_CODE,
+            Self::CODEX_ID => Self::CODEX,
+            Self::CURSOR_ID => Self::CURSOR,
+            Self::GEMINI_ID => Self::GEMINI,
+            Self::SHELL_ID => Self::SHELL,
+            _ => Self::new(saved),
+        }
+    }
+
     #[must_use]
     pub fn generic(command: impl Into<String>) -> Self {
         Self {

--- a/zeus/crates/zeus-proto/src/paths.rs
+++ b/zeus/crates/zeus-proto/src/paths.rs
@@ -14,6 +14,11 @@ pub const BIN_DIR_NAME: &str = "bin";
 pub const MANIFEST_OVERRIDES_RELATIVE_PATH: &str = "manifests/overrides";
 pub const DAEMON_LOG_FILE_NAME: &str = "zeusd.log";
 pub const HOSTS_CONFIG_FILE_NAME: &str = "hosts.json";
+/// Preferences predate the Engine's capitalized support directory. Keep this
+/// exact spelling: the default macOS volume is case-insensitive, but external
+/// and test homes do not have to be.
+pub const PREFERENCES_SUPPORT_RELATIVE_PATH: &str = "Library/Application Support/zeus";
+pub const PREFERENCES_FILE_NAME: &str = "prefs.json";
 
 pub const ENV_SESSION_ID: &str = "ZEUS_SESSION_ID";
 pub const ENV_SOCKET: &str = "ZEUS_SOCKET";
@@ -56,6 +61,12 @@ impl ZeusPaths {
 
     pub fn hosts_config_file(home: impl AsRef<Path>) -> PathBuf {
         Self::app_support(home).join(HOSTS_CONFIG_FILE_NAME)
+    }
+
+    pub fn preferences_file(home: impl AsRef<Path>) -> PathBuf {
+        home.as_ref()
+            .join(PREFERENCES_SUPPORT_RELATIVE_PATH)
+            .join(PREFERENCES_FILE_NAME)
     }
 }
 

--- a/zeus/scripts/dev.sh
+++ b/zeus/scripts/dev.sh
@@ -91,7 +91,10 @@ if ! git -C "${workspace_dir}" diff --quiet --ignore-submodules -- \
     dirty="+dirty"
 fi
 build_label="${branch}@${short_sha}${dirty}"
-bundle_id="com.zeus.zeus.dev.${short_sha}"
+# Stable on purpose: macOS TCC keys Files & Folders grants to the signed app
+# identity. The build label/window chrome still distinguishes commits without
+# invalidating Desktop/Documents access on every rebuild.
+bundle_id="com.zeus.zeus.dev.local"
 display_name="zeus dev ${short_sha}"
 
 mkdir -p "${target_dir}"
@@ -99,15 +102,20 @@ mkdir -p "${target_dir}"
 cd "${workspace_dir}"
 echo "==> Building ${display_name} (${profile})"
 # zeus-app does not pull the Engine or automation helpers into target/<profile>/.
-# Build all four so a clean checkout launches against this tree's binaries
-# instead of a missing or stale installed-app/debug helper.
+# Build the complete local process family so every process that touches a
+# selected folder can run from the signed app bundle. Launching zeusd-rs or
+# zeus-holder loose from target/ loses the app's macOS folder authorization.
 if (( ${#cargo_args[@]} > 0 )); then
     cargo build --package zeus-app --bin zeus --package zeus-engine --bin zeusd-rs \
+        --bin zeus-holder --bin zeus-ssh-askpass \
         --package zeus-cli --bin zeus-cli --package zeus-mcp --bin zeus-mcp \
+        --package zeus-remote --bin zeus-remote \
         "${cargo_args[@]}"
 else
     cargo build --package zeus-app --bin zeus --package zeus-engine --bin zeusd-rs \
-        --package zeus-cli --bin zeus-cli --package zeus-mcp --bin zeus-mcp
+        --bin zeus-holder --bin zeus-ssh-askpass \
+        --package zeus-cli --bin zeus-cli --package zeus-mcp --bin zeus-mcp \
+        --package zeus-remote --bin zeus-remote
 fi
 
 binary="${target_dir}/${profile}/zeus"
@@ -121,6 +129,17 @@ if [[ ! -x "${engine_bin}" ]]; then
     echo "error: cargo did not produce ${engine_bin}" >&2
     exit 1
 fi
+cli_bin="${target_dir}/${profile}/zeus-cli"
+mcp_bin="${target_dir}/${profile}/zeus-mcp"
+holder_bin="${target_dir}/${profile}/zeus-holder"
+askpass_bin="${target_dir}/${profile}/zeus-ssh-askpass"
+remote_bin="${target_dir}/${profile}/zeus-remote"
+for helper in "${cli_bin}" "${mcp_bin}" "${holder_bin}" "${askpass_bin}" "${remote_bin}"; do
+    if [[ ! -x "${helper}" ]]; then
+        echo "error: cargo did not produce ${helper}" >&2
+        exit 1
+    fi
+done
 
 # Every invocation gets a fresh bundle. Replacing a bundle beneath a still-
 # running process invalidates its code signature, which is especially easy to
@@ -128,9 +147,17 @@ fi
 bundle_root="$(mktemp -d "${target_dir}/zeus-dev-${short_sha}.XXXXXX")"
 app_path="${bundle_root}/${display_name}.app"
 contents="${app_path}/Contents"
-mkdir -p "${contents}/MacOS" "${contents}/Resources"
+app_bin_dir="${contents}/Resources/bin"
+mkdir -p "${contents}/MacOS" "${app_bin_dir}"
 cp "${binary}" "${contents}/MacOS/zeus"
 cp "${workspace_dir}/assets/dev-icon.icns" "${contents}/Resources/dev-icon.icns"
+cp "${engine_bin}" "${app_bin_dir}/zeusd-rs"
+cp "${cli_bin}" "${app_bin_dir}/zeus"
+cp "${mcp_bin}" "${app_bin_dir}/zeus-mcp"
+cp "${holder_bin}" "${app_bin_dir}/zeus-holder"
+cp "${askpass_bin}" "${app_bin_dir}/zeus-ssh-askpass"
+cp "${remote_bin}" "${app_bin_dir}/zeus-remote"
+cp -R "${workspace_dir}/crates/zeus-engine/manifests" "${app_bin_dir}/manifests"
 
 version="$(sed -n 's/^version = "\(.*\)"/\1/p' "${workspace_dir}/crates/zeus-app/Cargo.toml" | head -1)"
 cat > "${contents}/Info.plist" <<PLIST
@@ -155,9 +182,34 @@ cat > "${contents}/Info.plist" <<PLIST
 </plist>
 PLIST
 
-# A bundle assembled after Cargo's link step must be sealed as a unit. Ad-hoc
-# signing gives it coherent bundle metadata without ever resembling a release.
-codesign --force --sign - \
+# A stable development certificate keeps TCC grants across rebuilds. Prefer an
+# explicit identity, then the repository's optional "Zeus Dev" certificate;
+# ad-hoc remains a zero-setup fallback for contributors who do not need
+# protected Desktop/Documents folders.
+dev_sign_id="${ZEUS_DEV_SIGN_IDENTITY:-}"
+if [[ -z "${dev_sign_id}" ]] && security find-identity -v -p codesigning 2>/dev/null | grep -q '"Zeus Dev"'; then
+    dev_sign_id="Zeus Dev"
+fi
+if [[ -z "${dev_sign_id}" ]]; then
+    dev_sign_id="-"
+    echo "==> Warning: ad-hoc signing; Files & Folders grants may not survive rebuilds"
+    echo "    Run ../scripts/make-dev-cert.sh once, or set ZEUS_DEV_SIGN_IDENTITY."
+else
+    echo "==> Signing development bundle with: ${dev_sign_id}"
+fi
+
+# Sign nested executables first so the bundle seals a coherent helper family.
+for helper in \
+    "${app_bin_dir}/zeus" \
+    "${app_bin_dir}/zeus-mcp" \
+    "${app_bin_dir}/zeusd-rs" \
+    "${app_bin_dir}/zeus-holder" \
+    "${app_bin_dir}/zeus-ssh-askpass" \
+    "${app_bin_dir}/zeus-remote"
+do
+    codesign --force --sign "${dev_sign_id}" "${helper}"
+done
+codesign --force --sign "${dev_sign_id}" \
     --entitlements "${workspace_dir}/assets/zeus.entitlements" \
     --identifier "${bundle_id}" \
     "${app_path}"
@@ -168,24 +220,9 @@ if [[ -n "${settings_preview}" ]]; then
     launch_environment+=("ZEUS_SETTINGS_PREVIEW=${settings_preview}")
 fi
 
-# The Rust app fail-closes unless Hello reports engineKind=zeus-rust-engine.
-# Prefer a local cargo build of zeusd-rs, then the packaged Rust Engine in
-# an installed bundle. Never point at Swift `zeusd` — the client rejects it
-# and the UI comes up unable to spawn or list sessions.
-if [[ -z "${ZEUSD_PATH:-}" ]]; then
-    for candidate in \
-        "${target_dir}/${profile}/zeusd-rs" \
-        "${target_dir}/debug/zeusd-rs" \
-        "${target_dir}/release/zeusd-rs" \
-        "${HOME}/Applications/zeus.app/Contents/Resources/bin/zeusd-rs" \
-        "/Applications/zeus.app/Contents/Resources/bin/zeusd-rs"
-    do
-        if [[ -x "${candidate}" ]]; then
-            launch_environment+=("ZEUSD_PATH=${candidate}")
-            break
-        fi
-    done
-fi
+# The bundled Engine above is authoritative. An explicitly exported
+# ZEUSD_PATH remains a developer override, but this script no longer points a
+# signed app at loose target/ helpers that lack its folder authorization.
 
 echo "==> Launching ${display_name} (${build_label})"
 echo "    ${app_path}"


### PR DESCRIPTION
## Summary

- make MCP `spawn_agent.kind` optional and resolve omitted kinds from Zeus's configured default agent
- prevent unintended multi-agent fan-out through the MCP contract and instructions
- distinguish missing, non-directory, permission-denied, and unreadable working directories across Engine, worktree, and Holder launch paths
- render deferred Holder launch failures into terminal/MCP output
- bundle and sign the complete development helper family under a stable development app identity so macOS folder grants reach Engine and Holder processes

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (927 passed, 10 ignored)
- `cargo build --workspace --release`
- `bash -n scripts/dev.sh`

Closes #52
