### PR TITLE
feat: complete terminal mouse and input modes

### DIFF
--- a/zeus/Cargo.lock
+++ b/zeus/Cargo.lock
@@ -7411,6 +7411,7 @@ dependencies = [
  "gpui",
  "gpui_platform",
  "zeus-proto",
+ "zeus-pty",
 ]
 
 [[package]]

--- a/zeus/REMOTE_PORT.md
+++ b/zeus/REMOTE_PORT.md
@@ -427,9 +427,16 @@ are a future enhancement and are not part of the completed baseline.
 
 ## Wire protocol
 
-`zeus-proto::remote_pty` is the versioned protocol authority. Protocol 1.2
+`zeus-proto::remote_pty` is the versioned protocol authority. Protocol 1.5
 declares terminal, session management, environment capture, directory listing,
-persistence probing, and atomic activation as required capabilities.
+persistence probing, atomic activation, and complete terminal input modes as
+required capabilities. Full Snapshots and grid deltas carry application-cursor,
+bracketed-paste, alternate-screen, alternate-scroll, focus-reporting, and
+detailed mouse-reporting state (click, drag, motion, SGR, and UTF-8 formats) so
+local and remote attachments encode the same input after initial attach and
+reconnect. The 1.5 extended-mode byte is appended after the grid payload, which
+keeps the 1.4 grid offset stable and lets older readers ignore the additive
+state while current readers continue attaching to live 1.4 Holders.
 
 The protocol includes:
 

--- a/zeus/crates/zeus-app/src/inspector.rs
+++ b/zeus/crates/zeus-app/src/inspector.rs
@@ -55,9 +55,13 @@ const TRAFFIC_LIGHT_LANE: f32 =
 const INSPECTOR_HEADER_LEADING_INSET: f32 = 8.0;
 const ACCOUNT_MENU_WIDTH: f32 = 244.0;
 
-/// Narrowest width that still fits the tab strip, panel toggle, and account avatar.
-pub fn min_width(mirrored: bool) -> f32 {
-    300.0 + if mirrored { TRAFFIC_LIGHT_LANE } else { 0.0 }
+/// Narrowest width that still fits the tab strip, panel toggle, account avatar,
+/// and (when mirrored) the macOS window-button lane.
+///
+/// Both orientations use the conservative width so flipping the workbench can
+/// never change the center terminal's allocation.
+pub fn min_width() -> f32 {
+    300.0 + TRAFFIC_LIGHT_LANE
 }
 
 #[derive(Clone, Copy)]
@@ -1159,14 +1163,11 @@ impl WorkbenchInspector {
             );
 
         let x = if self.mirrored() {
-            let width = self
-                .runtime
-                .store
-                .read()
-                .expect("session store lock poisoned")
-                .preferences()
-                .inspector_width
-                .max(min_width(true));
+            // RootView keeps `panel_width` synchronized with the horizontal
+            // solver, including automatic compact clamps. Anchor floating
+            // inspector chrome to that rendered width rather than the wider
+            // persisted preference.
+            let width = self.panel_width.max(min_width());
             width - Metrics::TOOLBAR_EDGE_INSET
         } else {
             f32::from(window.viewport_size().width) - Metrics::TOOLBAR_EDGE_INSET
@@ -5025,7 +5026,7 @@ mod tests {
     impl Render for InspectorHarness {
         fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
             div()
-                .w(px(min_width(false)))
+                .w(px(min_width()))
                 .h_full()
                 .overflow_hidden()
                 .child(self.inspector.clone())
@@ -5343,7 +5344,7 @@ mod tests {
             px(Metrics::TOOLBAR_COMPACT_GAP),
             "the account avatar should sit directly after the right-aligned tabs"
         );
-        assert!(avatar.right() <= px(min_width(false)));
+        assert!(avatar.right() <= px(min_width()));
 
         cx.simulate_click(changes.center(), Modifiers::none());
         let inspector = harness.read_with(cx, |harness, _| harness.inspector.clone());

--- a/zeus/crates/zeus-app/src/root.rs
+++ b/zeus/crates/zeus-app/src/root.rs
@@ -25,7 +25,10 @@ use crate::store::SpawnOptions;
 use crate::surface_shell::UtilitySurfaces;
 use crate::terminal_pane::{ShellChrome, TerminalPane, TerminalPaneEvent, TerminalViewport};
 use crate::updates::UpdatePhase;
-use crate::workbench::WorkbenchLayout;
+use crate::workbench::{
+    HorizontalLayout, HorizontalLayoutInput, MAX_INSPECTOR_WIDTH, MIN_TERMINAL_WIDTH,
+    WorkbenchLayout, solve_horizontal_layout,
+};
 
 const WINDOW_BOUNDS_SAVE_DELAY: Duration = Duration::from_millis(150);
 
@@ -159,7 +162,6 @@ pub struct RootView {
     terminal_available_height: f32,
     inspector_open: bool,
     inspector_width: f32,
-    inspector_max_width: f32,
     inspector_resize_origin: Option<(f32, f32)>,
     /// The inspector's mirror of `sidebar_slide` / `sidebar_seam`.
     inspector_slide: Option<SeamSlide>,
@@ -630,7 +632,6 @@ impl RootView {
             terminal_available_height: 0.0,
             inspector_open,
             inspector_width,
-            inspector_max_width: 720.0,
             inspector_slide: None,
             inspector_seam,
             inspector_toggled_at: None,
@@ -701,11 +702,11 @@ impl RootView {
         crate::app_theme::colors(&store.preferences().terminal_theme)
     }
 
-    /// Narrowest useful inspector. A mirrored panel also carries the macOS
-    /// window-button lane in its toolbar, so it needs that much more before the
-    /// tab strip starts clipping.
+    /// Narrowest useful inspector in either orientation. The shared horizontal
+    /// solver uses the conservative mirrored width for both arrangements so a
+    /// flip changes placement, never the terminal allocation.
     fn inspector_min_width(&self) -> f32 {
-        crate::inspector::min_width(self.sidebar_on_right()).min(self.inspector_max_width)
+        crate::inspector::min_width()
     }
 
     /// Mirrored workbench: sidebar trailing, inspector leading. Read from
@@ -1191,7 +1192,8 @@ impl RootView {
     /// terminal is told about, so a slide costs no PTY resizes.
     fn settled_inspector_seam(&self) -> f32 {
         if self.inspector_open {
-            self.inspector_width.min(self.inspector_max_width)
+            self.inspector_width
+                .clamp(self.inspector_min_width(), MAX_INSPECTOR_WIDTH)
         } else {
             0.0
         }
@@ -1437,7 +1439,7 @@ impl RootView {
                             if event.click_count == 2 {
                                 this.inspector_width = 400.0_f32
                                     .max(this.inspector_min_width())
-                                    .min(this.inspector_max_width);
+                                    .min(MAX_INSPECTOR_WIDTH);
                             }
                             this.finish_inspector_resize(cx);
                         }),
@@ -1455,7 +1457,7 @@ impl RootView {
             return;
         };
         let width = dragged_panel_width(base_width, pointer_x - origin_x, self.sidebar_on_right());
-        self.inspector_width = width.clamp(self.inspector_min_width(), self.inspector_max_width);
+        self.inspector_width = width.clamp(self.inspector_min_width(), MAX_INSPECTOR_WIDTH);
         if let Some(inspector) = &self.inspector {
             inspector.update(cx, |inspector, cx| {
                 inspector.set_panel_width(self.inspector_width, cx)
@@ -1522,38 +1524,26 @@ impl RootView {
         .into_any_element()
     }
 
-    /// `visible_sidebar` and `inspector_width` are the settled layout and drive
-    /// everything the terminal is *told* -- viewport geometry, and whether its
-    /// chrome offers a "show sidebar" button. The two `*_seam` widths are what
-    /// is being painted this frame and drive only the card's own top corners,
-    /// so each radius appears the moment its panel finishes clearing rather
-    /// than at the start of the slide. Keeping the two apart is what stops a
-    /// 260ms slide from firing a PTY resize on every frame of it.
+    /// `layout` is the settled allocation and drives everything the terminal is
+    /// *told* -- viewport geometry and resolved panel visibility. The two
+    /// `*_seam` widths are what is being painted this frame and drive only the
+    /// card's own top corners, so each radius appears the moment its panel
+    /// finishes clearing rather than at the start of the slide. Keeping the two
+    /// apart is what stops a 260ms slide from firing a PTY resize on every frame.
     fn terminal_card(
         &mut self,
         visible_sidebar: bool,
+        layout: HorizontalLayout,
         seam: f32,
-        inspector_width: f32,
         inspector_seam: f32,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> AnyElement {
         let terminal = self.colors();
-        let bounds = window.inner_window_bounds().get_bounds();
-        let sidebar_width = if visible_sidebar {
-            self.sidebar.read(cx).width()
-        } else {
-            0.0
-        };
-        let card_width = (f32::from(bounds.size.width) - sidebar_width - inspector_width).max(0.0);
-        let card_height = f32::from(bounds.size.height).max(0.0);
+        let card_width = layout.terminal_width;
+        let card_height = f32::from(window.viewport_size().height).max(0.0);
         let mirrored = self.sidebar_on_right();
-        // Window-space origin of the card: whichever panel sits to its left.
-        let card_x = if mirrored {
-            inspector_width
-        } else {
-            sidebar_width
-        };
+        let card_x = layout.terminal_x;
         // Corner radii follow the painted seams of whatever panel is on that
         // side this frame, so mirroring only has to swap which seam is which.
         let (leading_seam, trailing_seam) = if mirrored {
@@ -1563,7 +1553,7 @@ impl RootView {
         };
         let chrome = ShellChrome {
             sidebar_visible: visible_sidebar,
-            inspector_open: self.inspector_open,
+            inspector_open: layout.inspector_chrome_open(),
             // Nothing to the card's left means the macOS window buttons land
             // on its own toolbar.
             traffic_light_lane: card_x <= 0.0,
@@ -1933,35 +1923,68 @@ impl Render for RootView {
                 inspector.set_word_wrap(inspector_word_wrap, cx)
             });
         }
-        let window_width = f32::from(window.inner_window_bounds().get_bounds().size.width);
-        let occupied_sidebar_width = if sidebar_visible { sidebar_width } else { 0.0 };
-        self.inspector_max_width =
-            (window_width - occupied_sidebar_width - 320.0).clamp(0.0, 720.0);
-        // The inspector's own width, whether or not it is currently shown --
-        // the panel keeps painting at full width while it slides away.
-        let inspector_panel_width = self
-            .inspector_width
-            .max(self.inspector_min_width())
-            .min(self.inspector_max_width);
+        let window_width = f32::from(window.viewport_size().width);
+        let mirrored = self.sidebar_on_right();
         let inspector_has_standalone_destination = self
             .inspector
             .as_ref()
             .is_some_and(|inspector| inspector.read(cx).is_code_destination());
-        let inspector_width = if self.inspector_open
-            && (inspector_has_standalone_destination
-                || (!startup_welcome_visible && has_selected_session))
-        {
-            inspector_panel_width
+        let inspector_available = inspector_has_standalone_destination
+            || (!startup_welcome_visible && has_selected_session);
+        let requested_inspector_width = self
+            .inspector_width
+            .clamp(self.inspector_min_width(), MAX_INSPECTOR_WIDTH);
+        let layout_input = HorizontalLayoutInput {
+            window_width,
+            sidebar_visible,
+            sidebar_width,
+            inspector_visible: self.inspector_open && inspector_available,
+            requested_inspector_width,
+            inspector_min_width: self.inspector_min_width(),
+            terminal_min_width: MIN_TERMINAL_WIDTH,
+            mirrored,
+        };
+        let layout = solve_horizontal_layout(layout_input);
+        // Keep the panel's own wrapping/code viewport on the same resolved
+        // width as its wrapper. When the user closes it, solve the still-open
+        // panel as well so the fixed-width child can slide away without being
+        // squeezed by the shrinking seam.
+        let inspector_panel_width = if layout.inspector_width > 0.0 {
+            layout.inspector_width
+        } else if inspector_available {
+            // Keep the child at a useful width while the seam clips it, so a
+            // close or Narrow collapse slides the panel away instead of
+            // squeezing its contents. Re-solving as open recovers Compact's
+            // clamped width; Narrow has no visible width, so fall back to the
+            // user's requested size.
+            let open_width = solve_horizontal_layout(HorizontalLayoutInput {
+                inspector_visible: true,
+                ..layout_input
+            })
+            .inspector_width;
+            if open_width > 0.0 {
+                open_width
+            } else {
+                requested_inspector_width
+            }
         } else {
             0.0
         };
+        if inspector_panel_width > 0.0
+            && let Some(inspector) = &self.inspector
+        {
+            inspector.update(cx, |inspector, cx| {
+                inspector.set_panel_width(inspector_panel_width, cx)
+            });
+        }
+        let occupied_sidebar_width = layout.sidebar_width;
+        let inspector_width = layout.inspector_width;
         let now = Instant::now();
         self.sidebar_seam =
             advance_seam(&mut self.sidebar_slide, occupied_sidebar_width, now, window);
         self.inspector_seam = advance_seam(&mut self.inspector_slide, inspector_width, now, window);
         let seam = self.sidebar_seam;
         let inspector_seam = self.inspector_seam;
-        let mirrored = self.sidebar_on_right();
         // Each panel keeps its full width and is pinned to the window edge it
         // lives against -- so narrowing a wrapper slides its panel out under
         // the clip instead of squeezing every row's contents down with it.
@@ -2063,8 +2086,8 @@ impl Render for RootView {
             }
             root = root.child(self.terminal_card(
                 sidebar_visible,
+                layout,
                 seam,
-                inspector_width,
                 inspector_seam,
                 window,
                 cx,
@@ -2080,8 +2103,8 @@ impl Render for RootView {
             }
             root = root.child(self.terminal_card(
                 sidebar_visible,
+                layout,
                 seam,
-                inspector_width,
                 inspector_seam,
                 window,
                 cx,

--- a/zeus/crates/zeus-app/src/store/prefs.rs
+++ b/zeus/crates/zeus-app/src/store/prefs.rs
@@ -102,6 +102,11 @@ pub struct Prefs {
     pub memory_hard_limit_gb: u64,
     pub terminal_theme: String,
     pub terminal_font_size: f32,
+    /// Treat Option plus a printable key as Meta (ESC prefix) instead of
+    /// preserving the character produced by the macOS keyboard layout.
+    pub terminal_option_as_meta: bool,
+    /// Copy a completed local terminal selection to the clipboard.
+    pub terminal_copy_on_select: bool,
     /// Last size, position, and presentation mode of the main window.
     pub window_placement: Option<WindowPlacement>,
     /// Whether the leading sidebar was mounted when the app last ran.
@@ -155,6 +160,8 @@ impl Default for Prefs {
             memory_hard_limit_gb: 6,
             terminal_theme: DEFAULT_THEME.to_owned(),
             terminal_font_size: 16.0,
+            terminal_option_as_meta: false,
+            terminal_copy_on_select: false,
             window_placement: None,
             sidebar_visible: true,
             sidebar_width: 220.0,

--- a/zeus/crates/zeus-app/src/surface_shell.rs
+++ b/zeus/crates/zeus-app/src/surface_shell.rs
@@ -1976,6 +1976,42 @@ impl UtilitySurfaces {
                         colors,
                     ),
                     colors,
+                ))
+                .child(setting_section(
+                    "Input",
+                    div()
+                        .flex()
+                        .flex_col()
+                        .child(toggle_row(
+                            "Option as Meta",
+                            "Send Option-key combinations with an Escape prefix instead of typing macOS-composed characters.",
+                            self.prefs.terminal_option_as_meta,
+                            "toggle-terminal-option-as-meta",
+                            colors,
+                            cx,
+                            |this, cx| {
+                                this.prefs.terminal_option_as_meta =
+                                    !this.prefs.terminal_option_as_meta;
+                                this.persist_prefs();
+                                cx.notify();
+                            },
+                        ))
+                        .child(setting_divider(colors))
+                        .child(toggle_row(
+                            "Copy on select",
+                            "Copy terminal text when a local mouse selection is completed.",
+                            self.prefs.terminal_copy_on_select,
+                            "toggle-terminal-copy-on-select",
+                            colors,
+                            cx,
+                            |this, cx| {
+                                this.prefs.terminal_copy_on_select =
+                                    !this.prefs.terminal_copy_on_select;
+                                this.persist_prefs();
+                                cx.notify();
+                            },
+                        )),
+                    colors,
                 )),
             colors,
         )

--- a/zeus/crates/zeus-app/src/terminal_pane.rs
+++ b/zeus/crates/zeus-app/src/terminal_pane.rs
@@ -11,12 +11,13 @@ use gpui::{
     AnyElement, App, ClickEvent, ClipboardEntry, ClipboardItem, Context, Entity, EventEmitter,
     FocusHandle, KeyBinding, KeyDownEvent, KeyUpEvent, ModifiersChangedEvent, MouseButton,
     PathBuilder, PathPromptOptions, Render, Rgba, ScrollDelta, ScrollHandle, ScrollWheelEvent,
-    SharedString, StatefulInteractiveElement, Task, Window, actions, canvas, div, font, point,
-    prelude::*, px, rgba,
+    SharedString, StatefulInteractiveElement, Subscription, Task, Window, actions, canvas, div,
+    font, point, prelude::*, px, rgba,
 };
 use tokio::runtime::Handle;
 use tokio::sync::mpsc;
 use zeus_client::attachment::{SessionAttachment, TerminalChunk};
+use zeus_proto::frames::TerminalModes as WireTerminalModes;
 use zeus_proto::grid::{ChangedRow, GridUpdate};
 use zeus_proto::{
     AgentKind as ProtoAgentKind, ArtifactKind, ExitReason, PrCheck, Project, PullRequestStatus,
@@ -27,9 +28,13 @@ use zeus_term::element::{SharedGridBuffer, TerminalElement, TerminalReference};
 use zeus_term::find::{FindSnapshot, SearchRequest, TerminalFindModel};
 use zeus_term::keys::{
     Key as TermKey, KeyEvent as TermKeyEvent, Modifiers as TermModifiers, NamedKey, TermInputModes,
-    encode_key, paste,
+    alternate_scroll, encode_key, paste,
 };
 use zeus_term::metrics::CellMetrics;
+use zeus_term::mouse::{
+    MouseButton as TermMouseButton, MouseModes, MouseModifiers, motion_report, press_report,
+    release_report, wheel_reports,
+};
 use zeus_term::repaint::{RepaintAction, RepaintPacer};
 use zeus_term::scrollback::{WheelDelta, WheelEvent, WheelRoute};
 use zeus_term::theme::TermTheme;
@@ -401,12 +406,6 @@ enum AttachmentState {
 enum AttachmentCommand {
     Input(Vec<u8>),
     Resize(u16, u16),
-    Scroll {
-        direction: u8,
-        lines: u16,
-        col: u16,
-        row: u16,
-    },
     Close,
 }
 
@@ -438,15 +437,6 @@ impl AttachmentControl {
         let _ = self.tx.send(AttachmentCommand::Resize(cols, rows));
     }
 
-    fn scroll(&self, direction: u8, lines: u16, col: u16, row: u16) {
-        let _ = self.tx.send(AttachmentCommand::Scroll {
-            direction,
-            lines,
-            col,
-            row,
-        });
-    }
-
     fn close(&self) {
         let _ = self.tx.send(AttachmentCommand::Close);
     }
@@ -466,6 +456,15 @@ struct ResidentTerminal {
     element: TerminalElement,
     attachment: AttachmentControl,
     attachment_state: AttachmentState,
+    input_modes: TermInputModes,
+    mouse_modes: MouseModes,
+    /// Suppresses a release/motion sequence when a platform-click was consumed
+    /// locally to open a reference instead of being pressed in the TUI.
+    suppress_left_report: bool,
+    reported_button_down: Option<TermMouseButton>,
+    /// Mouse-tracking applications care about cell transitions, not every
+    /// subpixel pointer event GPUI produces inside the same cell.
+    last_reported_mouse: Option<(usize, usize, Option<TermMouseButton>)>,
     find: Option<TerminalFindModel>,
     /// The editable text behind `find`'s query, so ⌘F gets the same caret,
     /// selection, and readline keys as the other query fields.
@@ -587,6 +586,7 @@ pub struct TerminalPane {
     local_clipboard_images: Vec<StagedClipboardImage>,
     _pane_events: Task<()>,
     _store_changes: Task<()>,
+    _focus_subscriptions: Vec<Subscription>,
 }
 
 impl EventEmitter<TerminalPaneEvent> for TerminalPane {}
@@ -653,6 +653,12 @@ impl TerminalPane {
         if matches!(session_source, SessionSource::FollowSelection) {
             window.focus(&focus, cx);
         }
+        let focus_in = cx.on_focus_in(&focus, window, |this, _window, cx| {
+            this.report_terminal_focus(true, cx);
+        });
+        let focus_out = cx.on_focus_out(&focus, window, |this, _event, _window, cx| {
+            this.report_terminal_focus(false, cx);
+        });
         let (pane_tx, mut pane_rx) = mpsc::unbounded_channel();
         let pane_events = cx.spawn_in(window, async move |this, cx| {
             let mut batch = Vec::new();
@@ -741,6 +747,7 @@ impl TerminalPane {
             local_clipboard_images: Vec::new(),
             _pane_events: pane_events,
             _store_changes: store_changes,
+            _focus_subscriptions: vec![focus_in, focus_out],
         };
         pane.reconcile_residency();
         pane.sync_status_glyphs(pane.current_colors(), window, cx);
@@ -854,6 +861,11 @@ impl TerminalPane {
                     element,
                     attachment,
                     attachment_state,
+                    input_modes: TermInputModes::default(),
+                    mouse_modes: MouseModes::default(),
+                    suppress_left_report: false,
+                    reported_button_down: None,
+                    last_reported_mouse: None,
                     find: None,
                     find_query: QueryEditor::default(),
                     last_size: (0, 0),
@@ -873,7 +885,17 @@ impl TerminalPane {
                     .cloned()
             })
             .flatten();
-        let selection_changed = selected_id != self.observed_selected_id;
+        let previous_id = self.observed_selected_id.clone();
+        let selection_changed = selected_id != previous_id;
+        let was_focused = self.focus.is_focused(window);
+        if selection_changed
+            && was_focused
+            && let Some(previous) = previous_id.as_ref()
+            && let Some(resident) = self.residents.get(previous)
+            && resident.input_modes.focus_reporting
+        {
+            resident.attachment.input(b"\x1b[O".to_vec());
+        }
         self.observed_selected_id = selected_id.clone();
 
         self.reconcile_residency();
@@ -883,8 +905,16 @@ impl TerminalPane {
         // successful spawns select their daemon-assigned id on the async store
         // path. Following the selection here covers both RPC/event orderings
         // and avoids trying to focus a terminal before its id exists.
-        if selection_changed && selected_id.is_some() {
-            window.focus(&self.focus, cx);
+        if selection_changed && let Some(selected_id) = selected_id {
+            if was_focused {
+                if let Some(resident) = self.residents.get(&selected_id)
+                    && resident.input_modes.focus_reporting
+                {
+                    resident.attachment.input(b"\x1b[I".to_vec());
+                }
+            } else {
+                window.focus(&self.focus, cx);
+            }
         }
         cx.notify();
     }
@@ -908,6 +938,21 @@ impl TerminalPane {
 
     pub fn focus(&self, window: &mut Window, cx: &mut Context<Self>) {
         window.focus(&self.focus, cx);
+    }
+
+    fn report_terminal_focus(&mut self, focused: bool, cx: &mut Context<Self>) {
+        let Some(id) = self.selected_id() else {
+            return;
+        };
+        let Some(resident) = self.residents.get_mut(&id) else {
+            return;
+        };
+        if resident.input_modes.focus_reporting {
+            resident
+                .attachment
+                .input(if focused { b"\x1b[I" } else { b"\x1b[O" }.to_vec());
+        }
+        cx.notify();
     }
 
     pub fn show_startup_welcome(&mut self) {
@@ -1020,17 +1065,32 @@ impl TerminalPane {
                 }
                 self.apply_grid_updates(id, [update], window, cx);
             }
-            PaneEvent::Chunk(
-                id,
-                TerminalChunk::Modes {
-                    alt_screen,
-                    mouse_reporting,
-                },
-            ) => {
+            PaneEvent::Chunk(id, TerminalChunk::Modes(modes)) => {
+                let selected = self.selected_id().as_ref() == Some(&id);
+                let pane_focused = self.focus.is_focused(window);
                 if let Some(resident) = self.residents.get_mut(&id) {
-                    resident.element.set_modes(alt_screen, mouse_reporting);
+                    let previously_reported_focus = resident.input_modes.focus_reporting;
+                    resident.element.set_modes(
+                        modes.alt_screen,
+                        modes.mouse_reporting,
+                        modes.alternate_scroll,
+                    );
+                    resident.input_modes = terminal_input_modes(modes);
+                    resident.mouse_modes = terminal_mouse_modes(modes);
+                    if !modes.mouse_reporting {
+                        resident.suppress_left_report = false;
+                        resident.reported_button_down = None;
+                        resident.last_reported_mouse = None;
+                    }
+                    if selected
+                        && pane_focused
+                        && !previously_reported_focus
+                        && modes.focus_reporting
+                    {
+                        resident.attachment.input(b"\x1b[I".to_vec());
+                    }
                 }
-                if self.selected_id().as_ref() == Some(&id) {
+                if selected {
                     cx.notify();
                 }
             }
@@ -1071,7 +1131,9 @@ impl TerminalPane {
             PaneEvent::ClipboardUploadFinished(id, result) => match result {
                 Ok(remote_path) => {
                     if let Some(resident) = self.residents.get(&id) {
-                        resident.attachment.input(paste(&remote_path, false));
+                        resident
+                            .attachment
+                            .input(paste(&remote_path, resident.input_modes.bracketed_paste));
                     }
                 }
                 Err(error) => eprintln!("zeus: clipboard image upload failed: {error}"),
@@ -1615,10 +1677,12 @@ impl TerminalPane {
         // An overflowing grid is bottom-anchored (see render_grid_and_overlays),
         // so its first row sits above the surface -- selection has to follow it
         // or clicks land on the wrong line while a resize is in flight.
-        let grid_rows = self
-            .selected_id()
-            .and_then(|id| self.residents.get(&id))
-            .map_or(0, |resident| resident.element.grid_rows());
+        let resident = self.selected_id().and_then(|id| self.residents.get(&id))?;
+        let grid_cols = resident.element.grid_cols();
+        let grid_rows = resident.element.grid_rows();
+        if grid_cols == 0 || grid_rows == 0 {
+            return None;
+        }
         let anchor = self
             .grid_row_overflow(grid_rows, font_size, window)
             .map_or(0.0, |grid_height| self.grid_inner_height() - grid_height);
@@ -1629,7 +1693,10 @@ impl TerminalPane {
         let row = ((f32::from(position.y) - grid_y) / f32::from(metrics.line_height))
             .floor()
             .max(0.0) as usize;
-        Some((col, row))
+        Some((
+            col.min(usize::from(grid_cols - 1)),
+            row.min(usize::from(grid_rows - 1)),
+        ))
     }
 
     /// The height the mirrored grid needs when the daemon's screen is taller
@@ -1713,7 +1780,7 @@ impl TerminalPane {
         let Some(id) = self.selected_id() else {
             return;
         };
-        let Some(resident) = self.residents.get(&id) else {
+        let Some(resident) = self.residents.get_mut(&id) else {
             return;
         };
         let text = resident.element.selected_text();
@@ -1771,7 +1838,9 @@ impl TerminalPane {
             } else {
                 let local_path = staged.path().to_string_lossy().into_owned();
                 if let Some(resident) = self.residents.get(&id) {
-                    resident.attachment.input(paste(&local_path, false));
+                    resident
+                        .attachment
+                        .input(paste(&local_path, resident.input_modes.bracketed_paste));
                 }
                 self.local_clipboard_images.push(staged);
                 if self.local_clipboard_images.len() > 32 {
@@ -1796,7 +1865,9 @@ impl TerminalPane {
             find.set_query(query, now);
             self.schedule_find(id, Duration::from_millis(200), window, cx);
         } else {
-            resident.attachment.input(paste(&text, false));
+            resident
+                .attachment
+                .input(paste(&text, resident.input_modes.bracketed_paste));
         }
         cx.stop_propagation();
         cx.notify();
@@ -1975,7 +2046,16 @@ impl TerminalPane {
             alt: event.keystroke.modifiers.alt,
             cmd: event.keystroke.modifiers.platform,
         };
-        let bytes = encode_key(&term_event, modifiers, TermInputModes::default());
+        let option_as_meta = self
+            .runtime
+            .store
+            .read()
+            .expect("session store lock poisoned")
+            .preferences()
+            .terminal_option_as_meta;
+        let mut input_modes = resident.input_modes;
+        input_modes.option_as_meta = option_as_meta;
+        let bytes = encode_key(&term_event, modifiers, input_modes);
         if bytes.is_empty() {
             cx.propagate();
         } else {
@@ -2044,6 +2124,54 @@ impl TerminalPane {
         });
     }
 
+    fn report_mouse_button(
+        &mut self,
+        position: gpui::Point<gpui::Pixels>,
+        modifiers: gpui::Modifiers,
+        button: TermMouseButton,
+        pressed: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(id) = self.selected_id() else {
+            return;
+        };
+        let Some((col, row)) = self.grid_cell_at(position, window) else {
+            return;
+        };
+        let Some(resident) = self.residents.get_mut(&id) else {
+            return;
+        };
+        let continuing_report = resident.reported_button_down == Some(button);
+        if !resident.mouse_modes.reporting || (modifiers.shift && !continuing_report) {
+            return;
+        }
+        let report = if pressed {
+            press_report(
+                col,
+                row,
+                button,
+                terminal_mouse_modifiers(modifiers),
+                resident.mouse_modes,
+            )
+        } else {
+            release_report(
+                col,
+                row,
+                button,
+                terminal_mouse_modifiers(modifiers),
+                resident.mouse_modes,
+            )
+        };
+        if let Some(bytes) = report {
+            resident.attachment.input(bytes);
+        }
+        resident.reported_button_down = pressed.then_some(button);
+        resident.last_reported_mouse = pressed.then_some((col, row, Some(button)));
+        window.focus(&self.focus, cx);
+        cx.stop_propagation();
+    }
+
     fn handle_scroll(
         &mut self,
         event: &ScrollWheelEvent,
@@ -2062,15 +2190,11 @@ impl TerminalPane {
             .terminal_font_size;
         let font = font(crate::fonts::mono_family());
         let metrics = CellMetrics::measure(window.text_system(), &font, px(font_size));
-        let viewport = self.viewport.unwrap_or_default();
-        let grid_x = viewport.x + GRID_HORIZONTAL_PADDING / 2.0;
-        let grid_y = viewport.y + Metrics::TITLE_BAR + self.lineage_chrome_height() + 2.0;
-        let col = ((f32::from(event.position.x) - grid_x) / f32::from(metrics.cell_width))
-            .floor()
-            .max(0.0) as u16;
-        let row = ((f32::from(event.position.y) - grid_y) / f32::from(metrics.line_height))
-            .floor()
-            .max(0.0) as u16;
+        let Some((col, row)) = self.grid_cell_at(event.position, window) else {
+            return;
+        };
+        let col = u16::try_from(col).unwrap_or(u16::MAX);
+        let row = u16::try_from(row).unwrap_or(u16::MAX);
         let delta = match event.delta {
             ScrollDelta::Pixels(point) => WheelDelta::PrecisePoints(f32::from(point.y)),
             ScrollDelta::Lines(point) => WheelDelta::Lines(point.y),
@@ -2087,12 +2211,29 @@ impl TerminalPane {
             line_height: f32::from(metrics.line_height),
         });
         match route {
-            Some(WheelRoute::Daemon {
-                direction,
+            Some(WheelRoute::Mouse {
+                up,
                 lines,
                 col,
                 row,
-            }) => resident.attachment.scroll(direction, lines, col, row),
+            }) => {
+                let reports = wheel_reports(
+                    usize::from(col),
+                    usize::from(row),
+                    up,
+                    usize::from(lines),
+                    terminal_mouse_modifiers(event.modifiers),
+                    resident.mouse_modes,
+                );
+                if let Some(reports) = reports {
+                    resident.attachment.input(reports.flatten().collect());
+                }
+            }
+            Some(WheelRoute::AlternateScroll { up, lines }) => {
+                resident
+                    .attachment
+                    .input(alternate_scroll(up, usize::from(lines)));
+            }
             Some(WheelRoute::Local { .. }) => {
                 self.pump_scrollback_fetch(&id, usize::from(visible_rows));
             }
@@ -2114,12 +2255,12 @@ impl TerminalPane {
             .preferences()
             .terminal_font_size;
         let viewport = self.viewport.unwrap_or_else(|| {
-            let bounds = window.inner_window_bounds().get_bounds();
+            let size = window.viewport_size();
             TerminalViewport {
                 x: 0.0,
                 y: 0.0,
-                width: f32::from(bounds.size.width),
-                height: f32::from(bounds.size.height),
+                width: f32::from(size.width),
+                height: f32::from(size.height),
             }
         });
         let metrics = CellMetrics::measure(
@@ -2171,9 +2312,6 @@ impl TerminalPane {
             self.reflow_preview_grid(window, cx);
             return;
         }
-        let Some(session) = self.selected_session() else {
-            return;
-        };
         let font_size = self
             .runtime
             .store
@@ -2182,12 +2320,12 @@ impl TerminalPane {
             .preferences()
             .terminal_font_size;
         let viewport = self.viewport.unwrap_or_else(|| {
-            let bounds = window.inner_window_bounds().get_bounds();
+            let size = window.viewport_size();
             TerminalViewport {
                 x: 0.0,
                 y: 0.0,
-                width: f32::from(bounds.size.width),
-                height: f32::from(bounds.size.height),
+                width: f32::from(size.width),
+                height: f32::from(size.height),
             }
         });
         let metrics = CellMetrics::measure(
@@ -2202,6 +2340,17 @@ impl TerminalPane {
             self.lineage_chrome_height(),
             metrics,
         );
+        self.apply_grid_size(size, window, cx);
+    }
+
+    /// Resize the selected session's PTY to `size`, coalesced by the existing
+    /// drag cadence. The settled viewport estimate is the only source: measuring
+    /// the painted box as well disagreed by a few chrome pixels and ping-ponged
+    /// the PTY, which flickered the grid with full snapshots.
+    fn apply_grid_size(&mut self, size: (u16, u16), window: &mut Window, cx: &mut Context<Self>) {
+        let Some(session) = self.selected_session() else {
+            return;
+        };
         if let Some(resident) = self.residents.get_mut(&session.id)
             && resident.last_size != size
         {
@@ -3118,36 +3267,69 @@ impl TerminalPane {
                     let Some((col, row)) = this.grid_cell_at(event.position, window) else {
                         return;
                     };
-                    let Some(resident) = this.residents.get(&id) else {
+                    if event.modifiers.platform {
+                        let reference = this
+                            .residents
+                            .get(&id)
+                            .and_then(|resident| resident.element.reference_at(col, row));
+                        if let Some(reference) = reference {
+                            if let Some(resident) = this.residents.get_mut(&id) {
+                                resident.suppress_left_report =
+                                    resident.mouse_modes.reporting && !event.modifiers.shift;
+                                resident.reported_button_down = None;
+                                resident.last_reported_mouse = None;
+                            }
+                            match reference {
+                                TerminalReference::Url(url) => cx.open_url(&url),
+                                TerminalReference::File(reference) => {
+                                    let Some(session) = this.selected_session() else {
+                                        return;
+                                    };
+                                    cx.emit(TerminalPaneEvent::OpenFileReference {
+                                        reference,
+                                        cwd: session.cwd.clone(),
+                                        session_id: session.id.clone(),
+                                    });
+                                }
+                            }
+                            cx.stop_propagation();
+                            return;
+                        }
+                    }
+                    let Some(resident) = this.residents.get_mut(&id) else {
                         return;
                     };
-                    if event.modifiers.platform {
-                        match resident.element.reference_at(col, row) {
-                            Some(TerminalReference::Url(url)) => cx.open_url(&url),
-                            Some(TerminalReference::File(reference)) => {
-                                let Some(session) = this.selected_session() else {
-                                    return;
-                                };
-                                cx.emit(TerminalPaneEvent::OpenFileReference {
-                                    reference,
-                                    cwd: session.cwd.clone(),
-                                    session_id: session.id.clone(),
-                                });
-                            }
-                            None => {}
+                    if resident.mouse_modes.reporting && !event.modifiers.shift {
+                        resident.suppress_left_report = false;
+                        resident.reported_button_down = Some(TermMouseButton::Left);
+                        resident.last_reported_mouse =
+                            Some((col, row, Some(TermMouseButton::Left)));
+                        if let Some(bytes) = press_report(
+                            col,
+                            row,
+                            TermMouseButton::Left,
+                            terminal_mouse_modifiers(event.modifiers),
+                            resident.mouse_modes,
+                        ) {
+                            resident.attachment.input(bytes);
                         }
+                        cx.stop_propagation();
                         return;
                     }
-                    // Mouse-reporting programs (Claude Code, vim) would
-                    // normally own the pointer, but clicks are not forwarded
-                    // to the PTY yet -- suppressing local selection here
-                    // bought nothing and made text un-copyable. Revisit when
-                    // click forwarding lands (then: plain drag to the app,
-                    // option-drag for local selection, per terminal
-                    // convention).
-                    match event.click_count {
-                        1 => resident.element.begin_selection(col, row),
-                        _ => resident.element.select_word(col, row),
+                    resident.suppress_left_report = false;
+                    resident.reported_button_down = None;
+                    resident.last_reported_mouse = None;
+                    // Shift is the same local-selection escape hatch Zed uses
+                    // while a full-screen program owns ordinary mouse input.
+                    if event.modifiers.shift && event.click_count == 1 {
+                        resident.element.extend_selection(col, row);
+                    } else {
+                        match event.click_count {
+                            1 => resident.element.begin_selection(col, row),
+                            2 => resident.element.select_word(col, row),
+                            3 => resident.element.select_line(row),
+                            _ => {}
+                        }
                     }
                     // notify, never window.refresh(): refresh() flags the
                     // whole frame as caching-disabled, repainting every cached
@@ -3157,20 +3339,154 @@ impl TerminalPane {
             )
             .on_mouse_move(
                 cx.listener(|this, event: &gpui::MouseMoveEvent, window, cx| {
-                    if event.pressed_button != Some(MouseButton::Left) {
-                        return;
-                    }
                     let Some(id) = this.selected_id() else {
                         return;
                     };
                     let Some((col, row)) = this.grid_cell_at(event.position, window) else {
                         return;
                     };
-                    let Some(resident) = this.residents.get(&id) else {
+                    let Some(resident) = this.residents.get_mut(&id) else {
                         return;
                     };
+                    if resident.mouse_modes.reporting
+                        && (!event.modifiers.shift || resident.reported_button_down.is_some())
+                    {
+                        let pressed_button = resident
+                            .reported_button_down
+                            .or_else(|| event.pressed_button.and_then(terminal_mouse_button));
+                        if resident.suppress_left_report
+                            && pressed_button == Some(TermMouseButton::Left)
+                        {
+                            cx.stop_propagation();
+                            return;
+                        }
+                        let position = (col, row, pressed_button);
+                        if resident.last_reported_mouse == Some(position) {
+                            return;
+                        }
+                        resident.last_reported_mouse = Some(position);
+                        if let Some(bytes) = motion_report(
+                            col,
+                            row,
+                            pressed_button,
+                            terminal_mouse_modifiers(event.modifiers),
+                            resident.mouse_modes,
+                        ) {
+                            resident.attachment.input(bytes);
+                            cx.stop_propagation();
+                        }
+                        return;
+                    }
+                    if event.pressed_button != Some(MouseButton::Left) {
+                        return;
+                    }
                     resident.element.drag_selection(col, row);
                     cx.notify();
+                }),
+            )
+            .on_mouse_up(
+                MouseButton::Left,
+                cx.listener(|this, event: &gpui::MouseUpEvent, window, cx| {
+                    let Some(id) = this.selected_id() else {
+                        return;
+                    };
+                    let Some((col, row)) = this.grid_cell_at(event.position, window) else {
+                        return;
+                    };
+                    let Some(resident) = this.residents.get_mut(&id) else {
+                        return;
+                    };
+                    if resident.mouse_modes.reporting
+                        && (!event.modifiers.shift
+                            || resident.reported_button_down == Some(TermMouseButton::Left))
+                    {
+                        resident.last_reported_mouse = None;
+                        if std::mem::take(&mut resident.suppress_left_report) {
+                            resident.reported_button_down = None;
+                            cx.stop_propagation();
+                            return;
+                        }
+                        if let Some(bytes) = release_report(
+                            col,
+                            row,
+                            TermMouseButton::Left,
+                            terminal_mouse_modifiers(event.modifiers),
+                            resident.mouse_modes,
+                        ) {
+                            resident.attachment.input(bytes);
+                        }
+                        resident.reported_button_down = None;
+                        cx.stop_propagation();
+                        return;
+                    }
+                    resident.suppress_left_report = false;
+                    resident.reported_button_down = None;
+                    resident.last_reported_mouse = None;
+                    let copy_on_select = this
+                        .runtime
+                        .store
+                        .read()
+                        .expect("session store lock poisoned")
+                        .preferences()
+                        .terminal_copy_on_select;
+                    if copy_on_select {
+                        let text = resident.element.selected_text();
+                        if !text.is_empty() {
+                            cx.write_to_clipboard(ClipboardItem::new_string(text));
+                        }
+                    }
+                }),
+            )
+            .on_mouse_down(
+                MouseButton::Middle,
+                cx.listener(|this, event: &gpui::MouseDownEvent, window, cx| {
+                    this.report_mouse_button(
+                        event.position,
+                        event.modifiers,
+                        TermMouseButton::Middle,
+                        true,
+                        window,
+                        cx,
+                    );
+                }),
+            )
+            .on_mouse_up(
+                MouseButton::Middle,
+                cx.listener(|this, event: &gpui::MouseUpEvent, window, cx| {
+                    this.report_mouse_button(
+                        event.position,
+                        event.modifiers,
+                        TermMouseButton::Middle,
+                        false,
+                        window,
+                        cx,
+                    );
+                }),
+            )
+            .on_mouse_down(
+                MouseButton::Right,
+                cx.listener(|this, event: &gpui::MouseDownEvent, window, cx| {
+                    this.report_mouse_button(
+                        event.position,
+                        event.modifiers,
+                        TermMouseButton::Right,
+                        true,
+                        window,
+                        cx,
+                    );
+                }),
+            )
+            .on_mouse_up(
+                MouseButton::Right,
+                cx.listener(|this, event: &gpui::MouseUpEvent, window, cx| {
+                    this.report_mouse_button(
+                        event.position,
+                        event.modifiers,
+                        TermMouseButton::Right,
+                        false,
+                        window,
+                        cx,
+                    );
                 }),
             )
             .on_scroll_wheel(cx.listener(Self::handle_scroll))
@@ -4029,6 +4345,43 @@ fn chip_tint_color(tint: ChipTint) -> gpui::Rgba {
     }
 }
 
+fn terminal_input_modes(modes: WireTerminalModes) -> TermInputModes {
+    TermInputModes {
+        application_cursor_keys: modes.application_cursor_keys,
+        bracketed_paste: modes.bracketed_paste,
+        alternate_scroll: modes.alternate_scroll,
+        focus_reporting: modes.focus_reporting,
+        ..TermInputModes::default()
+    }
+}
+
+fn terminal_mouse_modes(modes: WireTerminalModes) -> MouseModes {
+    MouseModes {
+        reporting: modes.mouse_reporting,
+        sgr: modes.mouse_sgr,
+        utf8: modes.mouse_utf8,
+        drag: modes.mouse_drag,
+        motion: modes.mouse_motion,
+    }
+}
+
+fn terminal_mouse_button(button: MouseButton) -> Option<TermMouseButton> {
+    match button {
+        MouseButton::Left => Some(TermMouseButton::Left),
+        MouseButton::Middle => Some(TermMouseButton::Middle),
+        MouseButton::Right => Some(TermMouseButton::Right),
+        MouseButton::Navigate(_) => None,
+    }
+}
+
+fn terminal_mouse_modifiers(modifiers: gpui::Modifiers) -> MouseModifiers {
+    MouseModifiers {
+        shift: modifiers.shift,
+        alt: modifiers.alt,
+        control: modifiers.control,
+    }
+}
+
 fn terminal_key_event(event: &KeyDownEvent) -> Option<TermKeyEvent> {
     let named = match event.keystroke.key.as_str() {
         "up" => Some(NamedKey::ArrowUp),
@@ -4057,6 +4410,14 @@ fn terminal_key_event(event: &KeyDownEvent) -> Option<TermKeyEvent> {
         "f10" => Some(NamedKey::F10),
         "f11" => Some(NamedKey::F11),
         "f12" => Some(NamedKey::F12),
+        "f13" => Some(NamedKey::F13),
+        "f14" => Some(NamedKey::F14),
+        "f15" => Some(NamedKey::F15),
+        "f16" => Some(NamedKey::F16),
+        "f17" => Some(NamedKey::F17),
+        "f18" => Some(NamedKey::F18),
+        "f19" => Some(NamedKey::F19),
+        "f20" => Some(NamedKey::F20),
         _ => None,
     };
     if let Some(named) = named {
@@ -4133,9 +4494,6 @@ fn spawn_attachment(
                                 last_resize = Some((cols, rows));
                                 let _ = writer.resize(cols, rows);
                             }
-                            Some(AttachmentCommand::Scroll { direction, lines, col, row }) => {
-                                let _ = writer.scroll(direction, lines, col, row);
-                            }
                             Some(AttachmentCommand::Close) | None => break true,
                         }
                     }
@@ -4169,7 +4527,7 @@ async fn wait_for_retry(
             command = commands.recv() => match command {
                 Some(AttachmentCommand::Resize(cols, rows)) => *last_resize = Some((cols, rows)),
                 Some(AttachmentCommand::Close) | None => return true,
-                Some(AttachmentCommand::Input(_)) | Some(AttachmentCommand::Scroll { .. }) => {}
+                Some(AttachmentCommand::Input(_)) => {}
             }
         }
     }
@@ -5012,6 +5370,15 @@ mod tests {
             TOOLBAR_MAX_VISIBLE_LINKS
         );
         assert_eq!(toolbar_visible_chip_count(&chips, 700.0, false), 0);
+        assert_eq!(
+            toolbar_visible_chip_count(&chips, crate::workbench::MIN_TERMINAL_WIDTH, true),
+            0,
+            "the reserved terminal minimum collapses chips rather than clipping them"
+        );
+        let compact_plain = toolbar_visible_chip_count(&chips, 780.0, true);
+        let compact_chrome = toolbar_visible_chip_count(&chips, 780.0, false);
+        assert!(compact_plain >= compact_chrome);
+        assert!(compact_plain <= TOOLBAR_MAX_VISIBLE_LINKS);
     }
 
     #[test]
@@ -5513,6 +5880,152 @@ mod tests {
             ),
             [0x15]
         );
+
+        let live_modes = terminal_input_modes(WireTerminalModes {
+            application_cursor_keys: true,
+            bracketed_paste: true,
+            alternate_scroll: true,
+            focus_reporting: true,
+            ..WireTerminalModes::default()
+        });
+        assert!(live_modes.alternate_scroll);
+        assert!(live_modes.focus_reporting);
+        assert_eq!(
+            encode_key(
+                &terminal_key_event(&event).unwrap(),
+                TermModifiers::default(),
+                live_modes
+            ),
+            b"\x1bOA",
+            "the pane must pass live DECCKM to the encoder"
+        );
+        assert_eq!(
+            paste("two\nlines", live_modes.bracketed_paste),
+            b"\x1b[200~two\nlines\x1b[201~",
+            "the pane must pass live bracketed-paste mode"
+        );
+
+        let modifier_backspaces = [
+            (Modifiers::default(), b"\x7f".as_slice()),
+            (
+                Modifiers {
+                    control: true,
+                    ..Modifiers::default()
+                },
+                b"\x08".as_slice(),
+            ),
+            (
+                Modifiers {
+                    alt: true,
+                    ..Modifiers::default()
+                },
+                b"\x1b\x7f".as_slice(),
+            ),
+            (
+                Modifiers {
+                    platform: true,
+                    ..Modifiers::default()
+                },
+                b"\x15".as_slice(),
+            ),
+        ];
+        for (gpui_modifiers, expected) in modifier_backspaces {
+            let event = KeyDownEvent {
+                keystroke: Keystroke {
+                    modifiers: gpui_modifiers,
+                    key: "backspace".to_owned(),
+                    key_char: None,
+                },
+                is_held: true,
+                prefer_character_input: false,
+            };
+            let mapped = terminal_key_event(&event).unwrap();
+            let modifiers = TermModifiers {
+                shift: gpui_modifiers.shift,
+                ctrl: gpui_modifiers.control,
+                alt: gpui_modifiers.alt,
+                cmd: gpui_modifiers.platform,
+            };
+            assert_eq!(encode_key(&mapped, modifiers, live_modes), expected);
+        }
+
+        let f20 = KeyDownEvent {
+            keystroke: Keystroke::parse("f20").unwrap(),
+            is_held: false,
+            prefer_character_input: false,
+        };
+        assert_eq!(
+            encode_key(
+                &terminal_key_event(&f20).expect("F20 adapter"),
+                TermModifiers::default(),
+                live_modes,
+            ),
+            b"\x1b[34~"
+        );
+
+        let composed = KeyDownEvent {
+            keystroke: Keystroke {
+                modifiers: Modifiers {
+                    alt: true,
+                    ..Modifiers::default()
+                },
+                key: "a".to_owned(),
+                key_char: Some("å".to_owned()),
+            },
+            is_held: false,
+            prefer_character_input: true,
+        };
+        let mapped = terminal_key_event(&composed).expect("Option-composed adapter");
+        let option = TermModifiers {
+            alt: true,
+            ..TermModifiers::default()
+        };
+        assert_eq!(encode_key(&mapped, option, live_modes), "å".as_bytes());
+        assert_eq!(
+            encode_key(
+                &mapped,
+                option,
+                TermInputModes {
+                    option_as_meta: true,
+                    ..live_modes
+                },
+            ),
+            b"\x1ba"
+        );
+    }
+
+    #[test]
+    fn wire_mouse_modes_drive_zed_compatible_reports() {
+        let modes = terminal_mouse_modes(WireTerminalModes {
+            mouse_reporting: true,
+            mouse_sgr: true,
+            mouse_drag: true,
+            ..WireTerminalModes::default()
+        });
+        assert_eq!(
+            press_report(
+                3,
+                7,
+                TermMouseButton::Left,
+                MouseModifiers {
+                    alt: true,
+                    control: true,
+                    ..MouseModifiers::default()
+                },
+                modes,
+            ),
+            Some(b"\x1b[<24;4;8M".to_vec())
+        );
+        assert_eq!(
+            motion_report(
+                3,
+                7,
+                Some(TermMouseButton::Left),
+                MouseModifiers::default(),
+                modes,
+            ),
+            Some(b"\x1b[<32;4;8M".to_vec())
+        );
     }
 
     #[test]
@@ -5570,6 +6083,64 @@ mod tests {
             reported.0 <= painted,
             "reported {} columns but only {painted} fit",
             reported.0
+        );
+    }
+
+    #[test]
+    fn painted_content_box_and_settled_estimate_can_disagree_by_one_cell() {
+        let metrics =
+            CellMetrics::from_measurements(px(8.0), px(16.0), px(0.0), px(0.0), gpui::FontId(7));
+        // 14px into a 16px row: subtracting the 2px layout chrome changes the
+        // row count. Driving the PTY from both this estimate and a painted-box
+        // measurement therefore ping-pongs by one row every frame.
+        let viewport_height = Metrics::TITLE_BAR
+            + GRID_VERTICAL_PADDING
+            + GRID_LAYOUT_VERTICAL_CHROME
+            + 16.0 * 29.0
+            + 14.0;
+        let estimated = estimated_grid_size(800.0, viewport_height, 0.0, 0.0, metrics);
+        let painted_rows = metrics
+            .rows_for_height(px((viewport_height
+                - Metrics::TITLE_BAR
+                - GRID_VERTICAL_PADDING)
+                .max(1.0)))
+            .max(2);
+        assert_eq!(estimated.1, 29);
+        assert_eq!(painted_rows, 30);
+    }
+
+    #[test]
+    fn pty_columns_are_derived_from_the_solver_terminal_width() {
+        use crate::workbench::{
+            HorizontalLayoutInput, MIN_TERMINAL_WIDTH, solve_horizontal_layout,
+        };
+
+        let metrics =
+            CellMetrics::from_measurements(px(8.0), px(16.0), px(3.0), px(1.0), gpui::FontId(7));
+        let layout = solve_horizontal_layout(HorizontalLayoutInput {
+            window_width: 1_400.0,
+            sidebar_visible: true,
+            sidebar_width: 220.0,
+            inspector_visible: true,
+            requested_inspector_width: 400.0,
+            inspector_min_width: crate::inspector::min_width(),
+            terminal_min_width: MIN_TERMINAL_WIDTH,
+            mirrored: false,
+        });
+        let from_terminal = estimated_grid_size(layout.terminal_width, 720.0, 0.0, 0.0, metrics);
+        let from_window = estimated_grid_size(1_400.0, 720.0, 0.0, 0.0, metrics);
+        assert!(
+            from_terminal.0 < from_window.0,
+            "PTY columns must follow the settled terminal card, not the window"
+        );
+        assert_eq!(
+            from_terminal.0,
+            metrics
+                .cols_for_width(px((layout.terminal_width
+                    - GRID_HORIZONTAL_PADDING
+                    - GRID_LAYOUT_HORIZONTAL_CHROME)
+                    .max(1.0)))
+                .max(2)
         );
     }
 }

--- a/zeus/crates/zeus-app/src/workbench.rs
+++ b/zeus/crates/zeus-app/src/workbench.rs
@@ -6,8 +6,135 @@
 //! rendering about workbench policy.
 
 pub const DEFAULT_PRIMARY_FRACTION: f32 = 0.62;
+pub const MAX_INSPECTOR_WIDTH: f32 = 720.0;
+pub const MIN_TERMINAL_WIDTH: f32 = 320.0;
 const MIN_PRIMARY_HEIGHT: f32 = 220.0;
 const MIN_AUXILIARY_HEIGHT: f32 = 140.0;
+
+/// The explicit responsive state of the horizontal workbench.
+///
+/// `Compact` is the short interval where the terminal is held at its useful
+/// minimum while the inspector gives up only the space above its own useful
+/// minimum. `Narrow` never squeezes the inspector further: it deliberately
+/// collapses the inspector and returns that space to the terminal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HorizontalLayoutState {
+    Wide,
+    Compact,
+    Narrow,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct HorizontalLayoutInput {
+    pub window_width: f32,
+    pub sidebar_visible: bool,
+    pub sidebar_width: f32,
+    pub inspector_visible: bool,
+    pub requested_inspector_width: f32,
+    pub inspector_min_width: f32,
+    pub terminal_min_width: f32,
+    pub mirrored: bool,
+}
+
+/// Settled horizontal geometry shared by the flex row and terminal viewport.
+///
+/// Mirroring affects only `terminal_x`: equivalent standard and mirrored
+/// inputs always receive identical widths.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct HorizontalLayout {
+    state: HorizontalLayoutState,
+    pub sidebar_width: f32,
+    pub terminal_width: f32,
+    pub inspector_width: f32,
+    pub terminal_x: f32,
+}
+
+impl HorizontalLayout {
+    pub const fn inspector_collapsed(self) -> bool {
+        matches!(self.state, HorizontalLayoutState::Narrow)
+    }
+
+    /// Whether terminal chrome should treat the inspector as present.
+    ///
+    /// A Narrow auto-collapse keeps the inspector "open" so a reveal button
+    /// does not appear for a panel that returns as soon as there is room.
+    /// A user-closed inspector is the only case that offers that control.
+    pub const fn inspector_chrome_open(self) -> bool {
+        self.inspector_width > 0.0 || self.inspector_collapsed()
+    }
+}
+
+/// Resolves the workbench's horizontal allocation without consulting GPUI.
+///
+/// The policy is intentionally small and deterministic:
+///
+/// 1. **Wide:** preserve the requested inspector width; the terminal receives
+///    the remainder.
+/// 2. **Compact:** preserve both useful minimums. The terminal stays at its
+///    minimum while the inspector uses the remainder, never less than its own
+///    minimum.
+/// 3. **Narrow:** when both minimums cannot fit, collapse the inspector and
+///    give the terminal all space after the sidebar.
+///
+/// A hidden inspector does not participate in the allocation. Sidebar width
+/// is kept ahead of terminal/inspector allocation, matching its independently
+/// persisted workbench seam.
+pub fn solve_horizontal_layout(input: HorizontalLayoutInput) -> HorizontalLayout {
+    let window_width = finite_nonnegative(input.window_width);
+    let sidebar_width = if input.sidebar_visible {
+        finite_nonnegative(input.sidebar_width).min(window_width)
+    } else {
+        0.0
+    };
+    let available = (window_width - sidebar_width).max(0.0);
+    let terminal_min_width = finite_nonnegative(input.terminal_min_width);
+
+    let (state, inspector_width, terminal_width) = if input.inspector_visible {
+        let inspector_min_width = finite_nonnegative(input.inspector_min_width);
+        let requested_inspector_width =
+            finite_nonnegative(input.requested_inspector_width).max(inspector_min_width);
+
+        if available >= requested_inspector_width + terminal_min_width {
+            (
+                HorizontalLayoutState::Wide,
+                requested_inspector_width,
+                available - requested_inspector_width,
+            )
+        } else if available >= inspector_min_width + terminal_min_width {
+            (
+                HorizontalLayoutState::Compact,
+                available - terminal_min_width,
+                terminal_min_width,
+            )
+        } else {
+            (HorizontalLayoutState::Narrow, 0.0, available)
+        }
+    } else {
+        (HorizontalLayoutState::Wide, 0.0, available)
+    };
+
+    let terminal_x = if input.mirrored {
+        inspector_width
+    } else {
+        sidebar_width
+    };
+
+    HorizontalLayout {
+        state,
+        sidebar_width,
+        terminal_width,
+        inspector_width,
+        terminal_x,
+    }
+}
+
+fn finite_nonnegative(value: f32) -> f32 {
+    if value.is_finite() {
+        value.max(0.0)
+    } else {
+        0.0
+    }
+}
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct PaneHeights {
@@ -81,6 +208,21 @@ impl WorkbenchLayout {
 mod tests {
     use super::*;
 
+    const INSPECTOR_MIN: f32 = 374.0;
+
+    fn horizontal_input(window_width: f32) -> HorizontalLayoutInput {
+        HorizontalLayoutInput {
+            window_width,
+            sidebar_visible: true,
+            sidebar_width: 220.0,
+            inspector_visible: true,
+            requested_inspector_width: 400.0,
+            inspector_min_width: INSPECTOR_MIN,
+            terminal_min_width: MIN_TERMINAL_WIDTH,
+            mirrored: false,
+        }
+    }
+
     #[test]
     fn default_split_favors_the_primary_pane() {
         let heights = WorkbenchLayout::default().pane_heights(600.0);
@@ -108,5 +250,250 @@ mod tests {
         layout.resize_primary(400.0, 600.0);
         layout.reset();
         assert_eq!(layout.pane_heights(600.0).primary, 372.0);
+    }
+
+    #[test]
+    fn horizontal_layout_has_explicit_wide_compact_and_narrow_states() {
+        let wide = solve_horizontal_layout(horizontal_input(1_400.0));
+        assert_eq!(wide.state, HorizontalLayoutState::Wide);
+        assert_eq!(wide.sidebar_width, 220.0);
+        assert_eq!(wide.inspector_width, 400.0);
+        assert_eq!(wide.terminal_width, 780.0);
+
+        let compact = solve_horizontal_layout(horizontal_input(930.0));
+        assert_eq!(compact.state, HorizontalLayoutState::Compact);
+        assert_eq!(compact.inspector_width, 390.0);
+        assert_eq!(compact.terminal_width, MIN_TERMINAL_WIDTH);
+
+        let narrow = solve_horizontal_layout(horizontal_input(900.0));
+        assert_eq!(narrow.state, HorizontalLayoutState::Narrow);
+        assert!(narrow.inspector_collapsed());
+        assert_eq!(narrow.inspector_width, 0.0);
+        assert_eq!(narrow.terminal_width, 680.0);
+    }
+
+    #[test]
+    fn horizontal_layout_matrix_preserves_minimums_or_explicitly_collapses() {
+        for window_width in [900.0, 930.0, 1_400.0] {
+            for sidebar_visible in [false, true] {
+                for inspector_visible in [false, true] {
+                    for mirrored in [false, true] {
+                        let mut input = horizontal_input(window_width);
+                        input.sidebar_visible = sidebar_visible;
+                        input.inspector_visible = inspector_visible;
+                        input.mirrored = mirrored;
+                        let layout = solve_horizontal_layout(input);
+
+                        assert_eq!(
+                            layout.sidebar_width + layout.terminal_width + layout.inspector_width,
+                            window_width
+                        );
+                        assert!(
+                            layout.inspector_width == 0.0
+                                || layout.inspector_width >= INSPECTOR_MIN
+                        );
+                        assert_eq!(
+                            layout.inspector_collapsed(),
+                            inspector_visible && layout.inspector_width == 0.0
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn mirrored_and_standard_layouts_have_identical_widths_at_every_breakpoint() {
+        for window_width in [913.0, 914.0, 919.0, 920.0, 939.0, 940.0, 941.0, 1_400.0] {
+            for sidebar_visible in [false, true] {
+                for inspector_visible in [false, true] {
+                    let mut standard_input = horizontal_input(window_width);
+                    standard_input.sidebar_visible = sidebar_visible;
+                    standard_input.inspector_visible = inspector_visible;
+                    let standard = solve_horizontal_layout(standard_input);
+
+                    let mirrored = solve_horizontal_layout(HorizontalLayoutInput {
+                        mirrored: true,
+                        ..standard_input
+                    });
+
+                    assert_eq!(standard.state, mirrored.state);
+                    assert_eq!(standard.sidebar_width, mirrored.sidebar_width);
+                    assert_eq!(standard.terminal_width, mirrored.terminal_width);
+                    assert_eq!(standard.inspector_width, mirrored.inspector_width);
+                    assert_eq!(standard.terminal_x, standard.sidebar_width);
+                    assert_eq!(mirrored.terminal_x, mirrored.inspector_width);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn compact_breakpoints_are_inclusive_and_narrow_is_a_clean_collapse() {
+        let exact_minimums = solve_horizontal_layout(horizontal_input(914.0));
+        assert_eq!(exact_minimums.state, HorizontalLayoutState::Compact);
+        assert_eq!(exact_minimums.inspector_width, INSPECTOR_MIN);
+        assert_eq!(exact_minimums.terminal_width, MIN_TERMINAL_WIDTH);
+
+        let below_minimums = solve_horizontal_layout(horizontal_input(913.0));
+        assert_eq!(below_minimums.state, HorizontalLayoutState::Narrow);
+        assert_eq!(below_minimums.inspector_width, 0.0);
+        assert_eq!(below_minimums.terminal_width, 693.0);
+
+        let exact_requested = solve_horizontal_layout(horizontal_input(940.0));
+        assert_eq!(exact_requested.state, HorizontalLayoutState::Wide);
+        assert_eq!(exact_requested.inspector_width, 400.0);
+        assert_eq!(exact_requested.terminal_width, MIN_TERMINAL_WIDTH);
+    }
+
+    #[test]
+    fn hidden_panels_do_not_consume_horizontal_space() {
+        let neither = solve_horizontal_layout(HorizontalLayoutInput {
+            sidebar_visible: false,
+            inspector_visible: false,
+            ..horizontal_input(900.0)
+        });
+        assert_eq!(neither.terminal_width, 900.0);
+
+        let inspector_only = solve_horizontal_layout(HorizontalLayoutInput {
+            sidebar_visible: false,
+            ..horizontal_input(900.0)
+        });
+        assert_eq!(inspector_only.inspector_width, 400.0);
+        assert_eq!(inspector_only.terminal_width, 500.0);
+
+        let sidebar_only = solve_horizontal_layout(HorizontalLayoutInput {
+            inspector_visible: false,
+            ..horizontal_input(900.0)
+        });
+        assert_eq!(sidebar_only.sidebar_width, 220.0);
+        assert_eq!(sidebar_only.terminal_width, 680.0);
+    }
+
+    #[test]
+    fn narrow_auto_collapse_is_distinct_from_a_user_closed_inspector() {
+        let auto_hidden = solve_horizontal_layout(horizontal_input(900.0));
+        assert!(auto_hidden.inspector_collapsed());
+        assert_eq!(auto_hidden.inspector_width, 0.0);
+        assert!(auto_hidden.inspector_chrome_open());
+
+        let user_closed = solve_horizontal_layout(HorizontalLayoutInput {
+            inspector_visible: false,
+            ..horizontal_input(900.0)
+        });
+        assert!(!user_closed.inspector_collapsed());
+        assert_eq!(user_closed.inspector_width, 0.0);
+        assert!(!user_closed.inspector_chrome_open());
+    }
+
+    struct WorkbenchRowHarness {
+        layout: HorizontalLayout,
+        mirrored: bool,
+    }
+
+    impl gpui::Render for WorkbenchRowHarness {
+        fn render(
+            &mut self,
+            _window: &mut gpui::Window,
+            _cx: &mut gpui::Context<Self>,
+        ) -> impl gpui::IntoElement {
+            use gpui::prelude::*;
+
+            let layout = self.layout;
+            let sidebar = (layout.sidebar_width > 0.0).then(|| {
+                gpui::div()
+                    .debug_selector(|| "workbench-sidebar".into())
+                    .flex_none()
+                    .w(gpui::px(layout.sidebar_width))
+                    .h_full()
+                    .bg(gpui::white())
+            });
+            let terminal = gpui::div()
+                .debug_selector(|| "workbench-terminal".into())
+                .flex_1()
+                .min_w(gpui::px(0.0))
+                .h_full()
+                .bg(gpui::white());
+            let inspector = (layout.inspector_width > 0.0).then(|| {
+                gpui::div()
+                    .debug_selector(|| "workbench-inspector".into())
+                    .flex_none()
+                    .w(gpui::px(layout.inspector_width))
+                    .h_full()
+                    .bg(gpui::white())
+            });
+
+            let mut row = gpui::div().flex().size_full();
+            if self.mirrored {
+                if let Some(inspector) = inspector {
+                    row = row.child(inspector);
+                }
+                row = row.child(terminal);
+                if let Some(sidebar) = sidebar {
+                    row = row.child(sidebar);
+                }
+            } else {
+                if let Some(sidebar) = sidebar {
+                    row = row.child(sidebar);
+                }
+                row = row.child(terminal);
+                if let Some(inspector) = inspector {
+                    row = row.child(inspector);
+                }
+            }
+            row
+        }
+    }
+
+    #[gpui::test]
+    fn gpui_row_matches_solver_at_wide_compact_and_narrow_breakpoints(
+        cx: &mut gpui::TestAppContext,
+    ) {
+        let initial = solve_horizontal_layout(horizontal_input(1_400.0));
+        let (view, cx) = cx.add_window_view(move |_, _| WorkbenchRowHarness {
+            layout: initial,
+            mirrored: false,
+        });
+
+        for window_width in [900.0, 913.0, 914.0, 930.0, 940.0, 1_400.0] {
+            for sidebar_visible in [false, true] {
+                for inspector_visible in [false, true] {
+                    for mirrored in [false, true] {
+                        let mut input = horizontal_input(window_width);
+                        input.sidebar_visible = sidebar_visible;
+                        input.inspector_visible = inspector_visible;
+                        input.mirrored = mirrored;
+                        let layout = solve_horizontal_layout(input);
+                        view.update(cx, |harness, cx| {
+                            harness.layout = layout;
+                            harness.mirrored = mirrored;
+                            cx.notify();
+                        });
+                        cx.simulate_resize(gpui::size(gpui::px(window_width), gpui::px(720.0)));
+
+                        let terminal = cx
+                            .debug_bounds("workbench-terminal")
+                            .expect("terminal column");
+                        assert_eq!(terminal.size.width, gpui::px(layout.terminal_width));
+                        assert_eq!(terminal.origin.x, gpui::px(layout.terminal_x));
+
+                        match cx.debug_bounds("workbench-inspector") {
+                            Some(inspector) => {
+                                assert_eq!(inspector.size.width, gpui::px(layout.inspector_width));
+                                assert!(inspector.size.width >= gpui::px(INSPECTOR_MIN));
+                            }
+                            None => assert_eq!(layout.inspector_width, 0.0),
+                        }
+
+                        match cx.debug_bounds("workbench-sidebar") {
+                            Some(sidebar) => {
+                                assert_eq!(sidebar.size.width, gpui::px(layout.sidebar_width))
+                            }
+                            None => assert_eq!(layout.sidebar_width, 0.0),
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/zeus/crates/zeus-client/src/attachment.rs
+++ b/zeus/crates/zeus-client/src/attachment.rs
@@ -17,7 +17,7 @@ use tokio::net::UnixStream;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio::time::{Instant, MissedTickBehavior};
-use zeus_proto::frames::{Frame, FrameCodec, FrameType};
+use zeus_proto::frames::{Frame, FrameCodec, FrameType, TerminalModes};
 use zeus_proto::grid::GridUpdate;
 use zeus_proto::methods::{AttachRequest, ClientRole};
 use zeus_proto::model::SessionId;
@@ -31,10 +31,7 @@ const DEAD_AFTER: Duration = Duration::from_secs(30);
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TerminalChunk {
     Grid(GridUpdate),
-    Modes {
-        alt_screen: bool,
-        mouse_reporting: bool,
-    },
+    Modes(TerminalModes),
     Pong,
 }
 
@@ -306,13 +303,8 @@ async fn process_incoming(
             chunks.send(TerminalChunk::Grid(update)).map_err(|_| ())?;
         }
         FrameType::Modes => {
-            let (alt_screen, mouse_reporting) = frame.modes_payload().ok_or(())?;
-            chunks
-                .send(TerminalChunk::Modes {
-                    alt_screen,
-                    mouse_reporting,
-                })
-                .map_err(|_| ())?;
+            let modes = frame.modes_payload().ok_or(())?;
+            chunks.send(TerminalChunk::Modes(modes)).map_err(|_| ())?;
         }
         FrameType::Ping => write_frame(stream, &Frame::pong()).await.map_err(|_| ())?,
         FrameType::Pong => chunks.send(TerminalChunk::Pong).map_err(|_| ())?,

--- a/zeus/crates/zeus-engine/src/attach.rs
+++ b/zeus/crates/zeus-engine/src/attach.rs
@@ -89,7 +89,7 @@ impl AttachHub {
             if write_frame(&writer, &grid_frame).is_err() {
                 return;
             }
-            let _ = write_frame(&writer, &Frame::modes(seed.modes.0, seed.modes.1));
+            let _ = write_frame(&writer, &Frame::modes(seed.modes));
             seed
         };
 
@@ -277,7 +277,7 @@ impl AttachHub {
                 if let Some(previous) = last_modes
                     && previous != modes
                 {
-                    frames.push(Frame::modes(modes.0, modes.1));
+                    frames.push(Frame::modes(modes));
                 }
                 last_modes = Some(modes);
             }

--- a/zeus/crates/zeus-engine/src/checkpoint.rs
+++ b/zeus/crates/zeus-engine/src/checkpoint.rs
@@ -20,7 +20,7 @@ use zeus_proto::grid::{GridCell, GridRowCodec, GridUpdate};
 // Version 1 persisted only the visible grid. Restoring it silently collapsed
 // every adopted session to at most one line of history, so it is deliberately
 // treated as a cache miss and rebuilt from the authoritative raw log.
-const CURRENT_VERSION: u64 = 2;
+const CURRENT_VERSION: u64 = 4;
 
 /// A decoded checkpoint, grid already validated.
 pub struct ScreenCheckpoint {
@@ -33,8 +33,11 @@ pub struct ScreenCheckpoint {
     /// checkpoint boundary is still recognized.
     pub marker_buffer: Vec<u8>,
     pub alt_screen: bool,
+    pub application_cursor_keys: bool,
     pub bracketed_paste: bool,
     pub mouse_reporting: bool,
+    pub alternate_scroll: bool,
+    pub focus_reporting: bool,
 }
 
 impl ScreenCheckpoint {
@@ -74,8 +77,11 @@ impl ScreenCheckpoint {
             grid,
             marker_buffer: as_data(dict.get("markerBuffer")?)?.to_vec(),
             alt_screen: dict.get("altScreen")?.as_boolean()?,
+            application_cursor_keys: dict.get("applicationCursorKeys")?.as_boolean()?,
             bracketed_paste: dict.get("bracketedPaste")?.as_boolean()?,
             mouse_reporting: dict.get("mouseReporting")?.as_boolean()?,
+            alternate_scroll: dict.get("alternateScroll")?.as_boolean()?,
+            focus_reporting: dict.get("focusReporting")?.as_boolean()?,
         })
     }
 
@@ -115,12 +121,24 @@ impl ScreenCheckpoint {
         );
         dict.insert("altScreen".into(), plist::Value::Boolean(self.alt_screen));
         dict.insert(
+            "applicationCursorKeys".into(),
+            plist::Value::Boolean(self.application_cursor_keys),
+        );
+        dict.insert(
             "bracketedPaste".into(),
             plist::Value::Boolean(self.bracketed_paste),
         );
         dict.insert(
             "mouseReporting".into(),
             plist::Value::Boolean(self.mouse_reporting),
+        );
+        dict.insert(
+            "alternateScroll".into(),
+            plist::Value::Boolean(self.alternate_scroll),
+        );
+        dict.insert(
+            "focusReporting".into(),
+            plist::Value::Boolean(self.focus_reporting),
         );
 
         let temp = path.with_extension("plist.tmp");
@@ -159,8 +177,11 @@ mod tests {
             },
             marker_buffer: vec![0x1b, b']'],
             alt_screen: true,
+            application_cursor_keys: true,
             bracketed_paste: false,
             mouse_reporting: true,
+            alternate_scroll: true,
+            focus_reporting: true,
         }
     }
 
@@ -176,8 +197,11 @@ mod tests {
         assert_eq!(loaded.grid, sample().grid);
         assert_eq!(loaded.marker_buffer, vec![0x1b, b']']);
         assert!(loaded.alt_screen);
+        assert!(loaded.application_cursor_keys);
         assert!(!loaded.bracketed_paste);
         assert!(loaded.mouse_reporting);
+        assert!(loaded.alternate_scroll);
+        assert!(loaded.focus_reporting);
     }
 
     #[test]
@@ -223,15 +247,18 @@ mod tests {
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>version</key><integer>2</integer>
+    <key>version</key><integer>4</integer>
     <key>logOffset</key><integer>777</integer>
     <key>gridPayload</key><data>{base64}</data>
     <key>historyRowCount</key><integer>1</integer>
     <key>historyPayload</key><data>{history_base64}</data>
     <key>markerBuffer</key><data></data>
     <key>altScreen</key><false/>
+    <key>applicationCursorKeys</key><true/>
     <key>bracketedPaste</key><true/>
     <key>mouseReporting</key><false/>
+    <key>alternateScroll</key><true/>
+    <key>focusReporting</key><true/>
 </dict>
 </plist>"#
         );
@@ -252,6 +279,9 @@ mod tests {
         assert_eq!(loaded.history, sample().history);
         assert_eq!(loaded.grid, sample().grid);
         assert!(loaded.bracketed_paste);
+        assert!(loaded.application_cursor_keys);
+        assert!(loaded.alternate_scroll);
+        assert!(loaded.focus_reporting);
     }
 
     #[test]
@@ -274,7 +304,7 @@ mod tests {
             .expect("read back")
             .into_dictionary()
             .expect("dict");
-        dict.insert("version".into(), plist::Value::Integer(3.into()));
+        dict.insert("version".into(), plist::Value::Integer(5.into()));
         plist::Value::Dictionary(dict)
             .to_file_binary(&path)
             .expect("rewrite");
@@ -287,15 +317,18 @@ mod tests {
         future.grid.changed_rows.clear();
         future.grid.is_full_snapshot = true;
         let mut dict = plist::Dictionary::new();
-        dict.insert("version".into(), plist::Value::Integer(2.into()));
+        dict.insert("version".into(), plist::Value::Integer(4.into()));
         dict.insert("logOffset".into(), plist::Value::Integer(1.into()));
         dict.insert("gridPayload".into(), plist::Value::Data(vec![0xde, 0xad]));
         dict.insert("historyRowCount".into(), plist::Value::Integer(0.into()));
         dict.insert("historyPayload".into(), plist::Value::Data(Vec::new()));
         dict.insert("markerBuffer".into(), plist::Value::Data(Vec::new()));
         dict.insert("altScreen".into(), plist::Value::Boolean(false));
+        dict.insert("applicationCursorKeys".into(), plist::Value::Boolean(false));
         dict.insert("bracketedPaste".into(), plist::Value::Boolean(false));
         dict.insert("mouseReporting".into(), plist::Value::Boolean(false));
+        dict.insert("alternateScroll".into(), plist::Value::Boolean(false));
+        dict.insert("focusReporting".into(), plist::Value::Boolean(false));
         plist::Value::Dictionary(dict)
             .to_file_binary(&path)
             .expect("write");

--- a/zeus/crates/zeus-engine/src/remote/manager.rs
+++ b/zeus/crates/zeus-engine/src/remote/manager.rs
@@ -974,7 +974,7 @@ mod tests {
         let target = RemoteTarget::MacosAarch64;
         let artifact_path = temporary.path().join("zeus-remote-fixture");
         let artifact_script = format!(
-            "#!/bin/sh\ncase \"$1\" in\nprobe) printf '%s\\n' '{{\"protocol\":{{\"major\":1,\"minor\":2}},\"buildId\":\"test-build\",\"artifactSha256\":\"'$TEST_ARTIFACT_SHA'\",\"target\":\"{}\",\"os\":\"test\",\"arch\":\"test\",\"supported\":true,\"holderAvailable\":true,\"capabilities\":[\"full-snapshot\",\"incremental-grid\",\"process-exit\",\"signal\",\"controller-lease\",\"scrollback\",\"session-management\",\"environment-capture\",\"directory-list\",\"persistence-probe\",\"atomic-activation\"]}}';;\nactivate) final=$(dirname \"$0\")/zeus-remote; ln \"$0\" \"$final\" 2>/dev/null || true; rm -f \"$0\"; exec \"$final\" probe --format=json;;\n*) exit 64;;\nesac\n",
+            "#!/bin/sh\ncase \"$1\" in\nprobe) printf '%s\\n' '{{\"protocol\":{{\"major\":1,\"minor\":5}},\"buildId\":\"test-build\",\"artifactSha256\":\"'$TEST_ARTIFACT_SHA'\",\"target\":\"{}\",\"os\":\"test\",\"arch\":\"test\",\"supported\":true,\"holderAvailable\":true,\"capabilities\":[\"full-snapshot\",\"incremental-grid\",\"process-exit\",\"signal\",\"controller-lease\",\"scrollback\",\"session-management\",\"environment-capture\",\"directory-list\",\"persistence-probe\",\"atomic-activation\",\"terminal-input-modes\",\"terminal-mouse-modes\"]}}';;\nactivate) final=$(dirname \"$0\")/zeus-remote; ln \"$0\" \"$final\" 2>/dev/null || true; rm -f \"$0\"; exec \"$final\" probe --format=json;;\n*) exit 64;;\nesac\n",
             target.artifact_name()
         );
         fs::write(&artifact_path, artifact_script).expect("artifact");

--- a/zeus/crates/zeus-engine/src/session.rs
+++ b/zeus/crates/zeus-engine/src/session.rs
@@ -24,7 +24,7 @@ use std::sync::{Arc, Condvar, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant, SystemTime};
 
-use zeus_proto::frames::FrameType;
+use zeus_proto::frames::{FrameType, TerminalModes};
 use zeus_proto::remote_pty::{
     FullSnapshot, GridDelta, LaunchRequest, ProcessExit, RemoteCodec, RemoteMessage,
     RemoteProcessState,
@@ -358,7 +358,7 @@ fn grid_wake_event(state: &GridWakeState, observed: u64) -> GridWakeEvent {
 
 pub(crate) struct AttachmentSeed {
     pub grid: zeus_proto::grid::GridUpdate,
-    pub modes: (bool, bool),
+    pub modes: TerminalModes,
     pub signature: GridSignature,
     pub wake: GridWake,
     pub wake_generation: u64,
@@ -1074,16 +1074,16 @@ impl Session {
                     let grid = remote.mirror.full_update()?;
                     let (cols, rows) = remote.mirror.size();
                     let (cursor_col, cursor_row, cursor_visible) = remote.mirror.cursor();
-                    let (alt_screen, _, mouse_reporting) = remote.mirror.modes();
+                    let modes = remote.mirror.modes();
                     Some((
                         grid,
-                        (alt_screen, mouse_reporting),
+                        modes,
                         GridSignature {
                             content_seq: remote.revision,
                             size: (usize::from(cols), usize::from(rows)),
                             cursor: (cursor_col, cursor_row, cursor_visible),
-                            alt_screen,
-                            mouse_reporting,
+                            alt_screen: modes.alt_screen,
+                            mouse_reporting: modes.mouse_reporting,
                         },
                     ))
                 })
@@ -1092,7 +1092,18 @@ impl Session {
                 let screen = self.shared.screen.lock().expect("screen");
                 (
                     screen.full_snapshot(),
-                    (screen.is_alt_screen(), screen.mouse_reporting()),
+                    TerminalModes {
+                        alt_screen: screen.is_alt_screen(),
+                        mouse_reporting: screen.mouse_reporting(),
+                        application_cursor_keys: screen.application_cursor_keys(),
+                        bracketed_paste: screen.bracketed_paste(),
+                        mouse_sgr: screen.mouse_sgr(),
+                        mouse_utf8: screen.mouse_utf8(),
+                        mouse_drag: screen.mouse_drag(),
+                        mouse_motion: screen.mouse_motion(),
+                        alternate_scroll: screen.alternate_scroll(),
+                        focus_reporting: screen.focus_reporting(),
+                    },
                     GridSignature {
                         content_seq: screen.content_seq(),
                         size: screen.size(),
@@ -1130,13 +1141,13 @@ impl Session {
         {
             let (cols, rows) = remote.mirror.size();
             let (cursor_col, cursor_row, cursor_visible) = remote.mirror.cursor();
-            let (alt_screen, _, mouse_reporting) = remote.mirror.modes();
+            let modes = remote.mirror.modes();
             let current = GridSignature {
                 content_seq: remote.revision,
                 size: (usize::from(cols), usize::from(rows)),
                 cursor: (cursor_col, cursor_row, cursor_visible),
-                alt_screen,
-                mouse_reporting,
+                alt_screen: modes.alt_screen,
+                mouse_reporting: modes.mouse_reporting,
             };
             if current == *signature {
                 return None;
@@ -1177,13 +1188,13 @@ impl Session {
             .as_ref()
             && remote.mirror.sequence().is_some()
         {
-            return remote.mirror.modes().1;
+            return remote.mirror.modes().bracketed_paste;
         }
         self.shared.screen.lock().expect("screen").bracketed_paste()
     }
 
-    /// Current (alt_screen, mouse_reporting).
-    pub fn modes(&self) -> (bool, bool) {
+    /// Current display and input modes for an attached terminal client.
+    pub fn modes(&self) -> TerminalModes {
         if let Some(remote) = self
             .shared
             .remote_grid
@@ -1192,11 +1203,21 @@ impl Session {
             .as_ref()
             && remote.mirror.sequence().is_some()
         {
-            let (alt_screen, _, mouse_reporting) = remote.mirror.modes();
-            return (alt_screen, mouse_reporting);
+            return remote.mirror.modes();
         }
         let screen = self.shared.screen.lock().expect("screen");
-        (screen.is_alt_screen(), screen.mouse_reporting())
+        TerminalModes {
+            alt_screen: screen.is_alt_screen(),
+            mouse_reporting: screen.mouse_reporting(),
+            application_cursor_keys: screen.application_cursor_keys(),
+            bracketed_paste: screen.bracketed_paste(),
+            mouse_sgr: screen.mouse_sgr(),
+            mouse_utf8: screen.mouse_utf8(),
+            mouse_drag: screen.mouse_drag(),
+            mouse_motion: screen.mouse_motion(),
+            alternate_scroll: screen.alternate_scroll(),
+            focus_reporting: screen.focus_reporting(),
+        }
     }
 
     /// A wheel event from an attached client: forwarded to the child when it
@@ -2050,6 +2071,18 @@ fn apply_remote_snapshot(
     last_eval_seq: &mut u64,
     snapshot: FullSnapshot,
 ) -> std::io::Result<()> {
+    let modes = TerminalModes {
+        alt_screen: snapshot.alt_screen,
+        application_cursor_keys: snapshot.application_cursor_keys,
+        bracketed_paste: snapshot.bracketed_paste,
+        mouse_reporting: snapshot.mouse_reporting,
+        mouse_sgr: snapshot.mouse_sgr,
+        mouse_utf8: snapshot.mouse_utf8,
+        mouse_drag: snapshot.mouse_drag,
+        mouse_motion: snapshot.mouse_motion,
+        alternate_scroll: snapshot.alternate_scroll,
+        focus_reporting: snapshot.focus_reporting,
+    };
     {
         let mut remote = shared.remote_grid.lock().expect("remote grid");
         let remote = remote
@@ -2057,13 +2090,7 @@ fn apply_remote_snapshot(
             .ok_or_else(|| std::io::Error::other("remote grid state is unavailable"))?;
         remote
             .mirror
-            .apply_snapshot(
-                snapshot.sequence,
-                &snapshot.grid,
-                snapshot.alt_screen,
-                snapshot.bracketed_paste,
-                snapshot.mouse_reporting,
-            )
+            .apply_snapshot(snapshot.sequence, &snapshot.grid, modes)
             .map_err(std::io::Error::other)?;
         remote.revision = remote.revision.saturating_add(1);
         remote.pending = Some(snapshot.grid.clone());
@@ -2080,9 +2107,7 @@ fn apply_remote_snapshot(
             // is fetched on demand through `Scroll`, never replayed here.
             &[],
             &snapshot.grid,
-            snapshot.alt_screen,
-            snapshot.bracketed_paste,
-            snapshot.mouse_reporting,
+            modes,
         ) {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
@@ -2113,9 +2138,18 @@ fn apply_remote_delta(shared: &Shared, delta: GridDelta) -> std::io::Result<()> 
             .apply_delta(
                 delta.sequence,
                 &delta.grid,
-                delta.alt_screen,
-                delta.bracketed_paste,
-                delta.mouse_reporting,
+                TerminalModes {
+                    alt_screen: delta.alt_screen,
+                    application_cursor_keys: delta.application_cursor_keys,
+                    bracketed_paste: delta.bracketed_paste,
+                    mouse_reporting: delta.mouse_reporting,
+                    mouse_sgr: delta.mouse_sgr,
+                    mouse_utf8: delta.mouse_utf8,
+                    mouse_drag: delta.mouse_drag,
+                    mouse_motion: delta.mouse_motion,
+                    alternate_scroll: delta.alternate_scroll,
+                    focus_reporting: delta.focus_reporting,
+                },
             )
             .map_err(std::io::Error::other)?;
         remote.revision = remote.revision.saturating_add(1);
@@ -2355,9 +2389,15 @@ fn pump_held(
                 shared.screen.lock().expect("screen").restore(
                     &checkpoint.history,
                     &checkpoint.grid,
-                    checkpoint.alt_screen,
-                    checkpoint.bracketed_paste,
-                    checkpoint.mouse_reporting,
+                    TerminalModes {
+                        alt_screen: checkpoint.alt_screen,
+                        application_cursor_keys: checkpoint.application_cursor_keys,
+                        bracketed_paste: checkpoint.bracketed_paste,
+                        mouse_reporting: checkpoint.mouse_reporting,
+                        alternate_scroll: checkpoint.alternate_scroll,
+                        focus_reporting: checkpoint.focus_reporting,
+                        ..TerminalModes::default()
+                    },
                 )
             });
         match restored {
@@ -2592,8 +2632,11 @@ struct CheckpointKey {
     content_seq: u64,
     marker_bytes: usize,
     alt_screen: bool,
+    application_cursor_keys: bool,
     bracketed_paste: bool,
     mouse_reporting: bool,
+    alternate_scroll: bool,
+    focus_reporting: bool,
 }
 
 /// Writes the current screen as a durable checkpoint, skipping the write when
@@ -2605,14 +2648,27 @@ fn persist_checkpoint(
     marker_buffer: &[u8],
     last_key: &mut Option<CheckpointKey>,
 ) {
-    let (history, grid, alt_screen, bracketed_paste, mouse_reporting, content_seq) = {
+    let (
+        history,
+        grid,
+        alt_screen,
+        application_cursor_keys,
+        bracketed_paste,
+        mouse_reporting,
+        alternate_scroll,
+        focus_reporting,
+        content_seq,
+    ) = {
         let screen = shared.screen.lock().expect("screen");
         (
             screen.history_snapshot(),
             screen.full_snapshot(),
             screen.is_alt_screen(),
+            screen.application_cursor_keys(),
             screen.bracketed_paste(),
             screen.mouse_reporting(),
+            screen.alternate_scroll(),
+            screen.focus_reporting(),
             screen.content_seq(),
         )
     };
@@ -2621,8 +2677,11 @@ fn persist_checkpoint(
         content_seq,
         marker_bytes: marker_buffer.len(),
         alt_screen,
+        application_cursor_keys,
         bracketed_paste,
         mouse_reporting,
+        alternate_scroll,
+        focus_reporting,
     };
     if *last_key == Some(key) {
         return;
@@ -2633,8 +2692,11 @@ fn persist_checkpoint(
         grid,
         marker_buffer: marker_buffer.to_vec(),
         alt_screen,
+        application_cursor_keys,
         bracketed_paste,
         mouse_reporting,
+        alternate_scroll,
+        focus_reporting,
     };
     // A failed write must not stop the session; the checkpoint is a cache.
     if checkpoint.write_atomically(path).is_ok() {

--- a/zeus/crates/zeus-engine/tests/attach.rs
+++ b/zeus/crates/zeus-engine/tests/attach.rs
@@ -13,7 +13,7 @@ use zeus_engine::control::ControlServer;
 use zeus_engine::detect::ManifestEngine;
 use zeus_engine::registry::Registry;
 use zeus_proto::ControlMessage;
-use zeus_proto::frames::{Frame, FrameCodec, FrameType};
+use zeus_proto::frames::{Frame, FrameCodec, FrameType, TerminalModes};
 use zeus_proto::grid::GridUpdate;
 
 fn engine() -> Arc<ManifestEngine> {
@@ -51,8 +51,21 @@ impl FrameReader {
                 }
                 continue;
             }
-            assert!(Instant::now() < deadline, "timed out waiting for {what}");
-            let count = self.stream.read(&mut chunk).expect("read frames");
+            let remaining = deadline
+                .checked_duration_since(Instant::now())
+                .unwrap_or_else(|| panic!("timed out waiting for {what}"));
+            self.stream
+                .set_read_timeout(Some(remaining))
+                .expect("set frame read timeout");
+            let count = self.stream.read(&mut chunk).unwrap_or_else(|error| {
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) {
+                    panic!("timed out waiting for {what}");
+                }
+                panic!("read frames while waiting for {what}: {error}");
+            });
             assert!(count > 0, "data channel closed while waiting for {what}");
             self.queue
                 .extend(self.codec.feed(&chunk[..count]).expect("valid frames"));
@@ -111,7 +124,7 @@ fn an_attach_is_seeded_then_streams_diffs_and_answers_input() {
         params: Some(json!({
             "kind": { "shell": {} },
             "cwd": "/tmp",
-            "argv": ["/bin/sh", "-c", "printf 'seeded-screen\\n'; exec cat"],
+            "argv": ["/bin/sh", "-c", "printf 'seeded-screen\\n'; stty -echo -icanon min 1 time 0; exec cat"],
         })),
     });
     let mut reader = std::io::BufReader::new(control.try_clone().expect("clone"));
@@ -149,9 +162,16 @@ fn an_attach_is_seeded_then_streams_diffs_and_answers_input() {
         "the seed carries what the child already painted"
     );
 
-    let _modes = frames.until("initial modes", |frame| {
+    let modes = frames.until("initial modes", |frame| {
         frame.frame_type == FrameType::Modes
     });
+    assert_eq!(
+        modes.modes_payload(),
+        Some(TerminalModes {
+            alternate_scroll: true,
+            ..TerminalModes::default()
+        })
+    );
 
     // Let the per-session pump establish its shared diff baseline. Its first
     // sample is allowed to be a FullSnapshot: if input beats that first tick,
@@ -220,6 +240,77 @@ fn an_attach_is_seeded_then_streams_diffs_and_answers_input() {
                 .flatten()
                 .is_some_and(|update| update.cols == 100 && update.rows == 30)
     });
+
+    // Mode-only output must cross the same channel even when it changes no
+    // visible cells. This is the state the pane uses for arrow and paste
+    // encoding, so it cannot wait for or be inferred from a later grid.
+    data.write_all(
+        &FrameCodec::encode(&Frame::input(
+            b"\x1b[?1h\x1b[?2004h\x1b[?1003h\x1b[?1005h\x1b[?1007l\x1b[?1004h".to_vec(),
+        ))
+        .expect("encode"),
+    )
+    .expect("enable input modes");
+    let enabled = frames.until("enabled input modes", |frame| {
+        frame.modes_payload().is_some_and(|modes| {
+            modes.application_cursor_keys
+                && modes.bracketed_paste
+                && modes.mouse_reporting
+                && modes.mouse_utf8
+                && modes.mouse_motion
+                && !modes.alternate_scroll
+                && modes.focus_reporting
+        })
+    });
+    assert_eq!(
+        enabled.modes_payload(),
+        Some(TerminalModes {
+            application_cursor_keys: true,
+            bracketed_paste: true,
+            mouse_reporting: true,
+            mouse_utf8: true,
+            mouse_motion: true,
+            focus_reporting: true,
+            ..TerminalModes::default()
+        })
+    );
+
+    // A fresh attachment is seeded from the authoritative screen modes, not
+    // from client defaults or only from changes observed after reconnect.
+    drop(frames);
+    drop(data);
+    let mut data = UnixStream::connect(server.socket_path()).expect("reconnect data");
+    let mut attach_line = serde_json::to_vec(&json!({ "attach": id })).expect("encode");
+    attach_line.push(b'\n');
+    data.write_all(&attach_line).expect("reattach");
+    let mut frames = FrameReader::new(data.try_clone().expect("clone reattached data"));
+    frames.until("reattached seed grid", |frame| {
+        frame.frame_type == FrameType::Grid
+    });
+    let reattached = frames.until("reattached input modes", |frame| {
+        frame.frame_type == FrameType::Modes
+    });
+    assert_eq!(reattached.modes_payload(), enabled.modes_payload());
+
+    data.write_all(
+        &FrameCodec::encode(&Frame::input(
+            b"\x1b[?1l\x1b[?2004l\x1b[?1003l\x1b[?1005l\x1b[?1004l".to_vec(),
+        ))
+        .expect("encode"),
+    )
+    .expect("disable input modes");
+    let disabled = frames.until("disabled input modes", |frame| {
+        frame.modes_payload().is_some_and(|modes| {
+            !modes.application_cursor_keys
+                && !modes.bracketed_paste
+                && !modes.mouse_reporting
+                && !modes.mouse_utf8
+                && !modes.mouse_motion
+                && !modes.alternate_scroll
+                && !modes.focus_reporting
+        })
+    });
+    assert_eq!(disabled.modes_payload(), Some(TerminalModes::default()));
 
     // Clean up the child.
     send(&ControlMessage::Request {

--- a/zeus/crates/zeus-engine/tests/checkpoint.rs
+++ b/zeus/crates/zeus-engine/tests/checkpoint.rs
@@ -238,8 +238,11 @@ fn adoption_seeds_from_the_checkpoint_not_the_raw_tail() {
         grid: synthetic_grid("PAINTED-FROM-CHECKPOINT"),
         marker_buffer: Vec::new(),
         alt_screen: false,
+        application_cursor_keys: false,
         bracketed_paste: false,
         mouse_reporting: false,
+        alternate_scroll: false,
+        focus_reporting: false,
     }
     .write_atomically(&checkpoint_path(&logs, "s_ad"))
     .expect("plant checkpoint");
@@ -311,8 +314,11 @@ fn a_stale_checkpoint_falls_back_to_tail_replay() {
         grid,
         marker_buffer: Vec::new(),
         alt_screen: false,
+        application_cursor_keys: false,
         bracketed_paste: false,
         mouse_reporting: false,
+        alternate_scroll: false,
+        focus_reporting: false,
     }
     .write_atomically(&checkpoint_path(&logs, "s_fb"))
     .expect("plant checkpoint");

--- a/zeus/crates/zeus-proto/src/frames.rs
+++ b/zeus/crates/zeus-proto/src/frames.rs
@@ -52,6 +52,25 @@ pub struct Frame {
     pub payload: Vec<u8>,
 }
 
+/// Terminal state that changes how an attached client encodes input.
+///
+/// The first byte preserves the original local data-channel layout. Extended
+/// modes use a second byte so older readers can continue decoding the flags
+/// they understand.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct TerminalModes {
+    pub alt_screen: bool,
+    pub mouse_reporting: bool,
+    pub application_cursor_keys: bool,
+    pub bracketed_paste: bool,
+    pub mouse_sgr: bool,
+    pub mouse_utf8: bool,
+    pub mouse_drag: bool,
+    pub mouse_motion: bool,
+    pub alternate_scroll: bool,
+    pub focus_reporting: bool,
+}
+
 impl Frame {
     #[must_use]
     pub fn new(frame_type: FrameType, payload: Vec<u8>) -> Self {
@@ -118,9 +137,17 @@ impl Frame {
     }
 
     #[must_use]
-    pub fn modes(alt_screen: bool, mouse_reporting: bool) -> Self {
-        let bits = u8::from(alt_screen) | (u8::from(mouse_reporting) << 1);
-        Self::new(FrameType::Modes, vec![bits])
+    pub fn modes(modes: TerminalModes) -> Self {
+        let primary = u8::from(modes.alt_screen)
+            | (u8::from(modes.mouse_reporting) << 1)
+            | (u8::from(modes.application_cursor_keys) << 2)
+            | (u8::from(modes.bracketed_paste) << 3)
+            | (u8::from(modes.mouse_sgr) << 4)
+            | (u8::from(modes.mouse_utf8) << 5)
+            | (u8::from(modes.mouse_drag) << 6)
+            | (u8::from(modes.mouse_motion) << 7);
+        let extended = u8::from(modes.alternate_scroll) | (u8::from(modes.focus_reporting) << 1);
+        Self::new(FrameType::Modes, vec![primary, extended])
     }
 
     pub fn grid_payload(&self) -> Result<Option<GridUpdate>, GridCodecError> {
@@ -175,13 +202,25 @@ impl Frame {
     }
 
     #[must_use]
-    pub fn modes_payload(&self) -> Option<(bool, bool)> {
+    pub fn modes_payload(&self) -> Option<TerminalModes> {
         if self.frame_type != FrameType::Modes {
             return None;
         }
-        self.payload
-            .first()
-            .map(|bits| (bits & 1 != 0, bits & 2 != 0))
+        self.payload.first().map(|primary| {
+            let extended = self.payload.get(1).copied().unwrap_or_default();
+            TerminalModes {
+                alt_screen: primary & 1 != 0,
+                mouse_reporting: primary & 2 != 0,
+                application_cursor_keys: primary & 4 != 0,
+                bracketed_paste: primary & 8 != 0,
+                mouse_sgr: primary & 16 != 0,
+                mouse_utf8: primary & 32 != 0,
+                mouse_drag: primary & 64 != 0,
+                mouse_motion: primary & 128 != 0,
+                alternate_scroll: extended & 1 != 0,
+                focus_reporting: extended & 2 != 0,
+            }
+        })
     }
 
     fn offset_frame(frame_type: FrameType, offset: u64) -> Self {
@@ -357,11 +396,33 @@ mod tests {
         assert_eq!(scroll.payload, [1, 2, 3, 4, 5, 6, 7]);
         assert_eq!(scroll.scroll_payload(), Some((1, 0x0203, 0x0405, 0x0607)));
 
-        for alt_screen in [false, true] {
-            for mouse_reporting in [false, true] {
-                let modes = Frame::modes(alt_screen, mouse_reporting);
-                assert_eq!(modes.modes_payload(), Some((alt_screen, mouse_reporting)));
-            }
+        for primary in u8::MIN..=u8::MAX {
+            let extended = primary.rotate_left(3) & 3;
+            let expected = TerminalModes {
+                alt_screen: primary & 1 != 0,
+                mouse_reporting: primary & 2 != 0,
+                application_cursor_keys: primary & 4 != 0,
+                bracketed_paste: primary & 8 != 0,
+                mouse_sgr: primary & 16 != 0,
+                mouse_utf8: primary & 32 != 0,
+                mouse_drag: primary & 64 != 0,
+                mouse_motion: primary & 128 != 0,
+                alternate_scroll: extended & 1 != 0,
+                focus_reporting: extended & 2 != 0,
+            };
+            let modes = Frame::modes(expected);
+            assert_eq!(modes.payload, [primary, extended]);
+            assert_eq!(modes.modes_payload(), Some(expected));
+
+            let legacy = Frame::new(FrameType::Modes, vec![primary]);
+            assert_eq!(
+                legacy.modes_payload(),
+                Some(TerminalModes {
+                    alternate_scroll: false,
+                    focus_reporting: false,
+                    ..expected
+                })
+            );
         }
         assert_eq!(Frame::ping().payload, Vec::<u8>::new());
         assert_eq!(Frame::pong().payload, Vec::<u8>::new());

--- a/zeus/crates/zeus-proto/src/remote_pty.rs
+++ b/zeus/crates/zeus-proto/src/remote_pty.rs
@@ -17,7 +17,7 @@ use crate::frames::{Frame, FrameType, MAX_FRAME_BYTES};
 use crate::grid::{GridCodecError, GridUpdate};
 
 pub const PROTOCOL_MAJOR: u16 = 1;
-pub const PROTOCOL_MINOR: u16 = 2;
+pub const PROTOCOL_MINOR: u16 = 5;
 pub const MAX_CONTROL_FRAME_BYTES: usize = 64 * 1024;
 pub const MAX_ARGUMENTS: usize = 512;
 pub const MAX_ENVIRONMENT_VARIABLES: usize = 4096;
@@ -31,7 +31,8 @@ pub const MAX_DIRECTORY_SCANNED_ENTRIES: usize = 16_384;
 pub const MAX_DIRECTORY_RESPONSE_BYTES: usize = 512 * 1024;
 
 const HEADER_BYTES: usize = 5;
-const FULL_SNAPSHOT_FIXED_BYTES: usize = 9;
+const LEGACY_SNAPSHOT_FIXED_BYTES: usize = 9;
+const EXTENDED_INPUT_MODES_MINOR: u16 = 5;
 const KIND_HELLO: u8 = 32;
 const KIND_HELLO_ACK: u8 = 33;
 const KIND_FULL_SNAPSHOT: u8 = 34;
@@ -85,6 +86,10 @@ pub enum RemoteCapability {
     PersistenceProbe,
     /// Uploaded Helper can activate itself without replacing different bytes.
     AtomicActivation,
+    /// Snapshots and deltas carry every mode needed for correct key/paste input.
+    TerminalInputModes,
+    /// Snapshots and deltas distinguish mouse encoding, drag, and motion modes.
+    TerminalMouseModes,
     AgentEvents,
     McpStdio,
     ResourceInspect,
@@ -112,6 +117,8 @@ impl RemoteCapability {
             Self::DirectoryList => "directory-list",
             Self::PersistenceProbe => "persistence-probe",
             Self::AtomicActivation => "atomic-activation",
+            Self::TerminalInputModes => "terminal-input-modes",
+            Self::TerminalMouseModes => "terminal-mouse-modes",
             Self::AgentEvents => "agent-events",
             Self::McpStdio => "mcp-stdio",
             Self::ResourceInspect => "resource-inspect",
@@ -131,6 +138,8 @@ pub const PHASE_ONE_HOLDER_CAPABILITIES: &[RemoteCapability] = &[
     RemoteCapability::Signal,
     RemoteCapability::ControllerLease,
     RemoteCapability::Scrollback,
+    RemoteCapability::TerminalInputModes,
+    RemoteCapability::TerminalMouseModes,
 ];
 
 /// Complete phase-one Helper command surface required before the Engine may
@@ -148,6 +157,8 @@ pub const PHASE_ONE_HELPER_CAPABILITIES: &[RemoteCapability] = &[
     RemoteCapability::DirectoryList,
     RemoteCapability::PersistenceProbe,
     RemoteCapability::AtomicActivation,
+    RemoteCapability::TerminalInputModes,
+    RemoteCapability::TerminalMouseModes,
 ];
 
 /// Authentication bearer shared only by the local Engine and one Holder.
@@ -257,8 +268,15 @@ impl HelloAck {
 pub struct FullSnapshot {
     pub sequence: u64,
     pub alt_screen: bool,
+    pub application_cursor_keys: bool,
     pub bracketed_paste: bool,
     pub mouse_reporting: bool,
+    pub mouse_sgr: bool,
+    pub mouse_utf8: bool,
+    pub mouse_drag: bool,
+    pub mouse_motion: bool,
+    pub alternate_scroll: bool,
+    pub focus_reporting: bool,
     pub grid: GridUpdate,
 }
 
@@ -266,8 +284,15 @@ pub struct FullSnapshot {
 pub struct GridDelta {
     pub sequence: u64,
     pub alt_screen: bool,
+    pub application_cursor_keys: bool,
     pub bracketed_paste: bool,
     pub mouse_reporting: bool,
+    pub mouse_sgr: bool,
+    pub mouse_utf8: bool,
+    pub mouse_drag: bool,
+    pub mouse_motion: bool,
+    pub alternate_scroll: bool,
+    pub focus_reporting: bool,
     pub grid: GridUpdate,
 }
 
@@ -698,6 +723,7 @@ impl From<GridCodecError> for RemoteCodecError {
 #[derive(Clone, Debug, Default)]
 pub struct RemoteCodec {
     buffer: Vec<u8>,
+    peer_protocol_minor: Option<u16>,
 }
 
 impl RemoteCodec {
@@ -743,8 +769,15 @@ impl RemoteCodec {
                 output.extend_from_slice(&value.sequence.to_be_bytes());
                 let modes = u8::from(value.alt_screen)
                     | (u8::from(value.bracketed_paste) << 1)
-                    | (u8::from(value.mouse_reporting) << 2);
+                    | (u8::from(value.mouse_reporting) << 2)
+                    | (u8::from(value.application_cursor_keys) << 3)
+                    | (u8::from(value.mouse_sgr) << 4)
+                    | (u8::from(value.mouse_utf8) << 5)
+                    | (u8::from(value.mouse_drag) << 6)
+                    | (u8::from(value.mouse_motion) << 7);
                 output.push(modes);
+                let extended_modes =
+                    u8::from(value.alternate_scroll) | (u8::from(value.focus_reporting) << 1);
                 if !value.grid.is_full_snapshot {
                     return rollback(
                         output,
@@ -755,6 +788,10 @@ impl RemoteCodec {
                     );
                 }
                 output.extend_from_slice(&value.grid.encode()?);
+                // Appending keeps the 1.4 grid offset stable. Older readers
+                // already ignore trailing grid bytes, so live holders remain
+                // attachable across the minor upgrade.
+                output.push(extended_modes);
                 Ok(())
             }
             RemoteMessage::GridDelta(value) => {
@@ -763,8 +800,15 @@ impl RemoteCodec {
                 output.extend_from_slice(&value.sequence.to_be_bytes());
                 let modes = u8::from(value.alt_screen)
                     | (u8::from(value.bracketed_paste) << 1)
-                    | (u8::from(value.mouse_reporting) << 2);
+                    | (u8::from(value.mouse_reporting) << 2)
+                    | (u8::from(value.application_cursor_keys) << 3)
+                    | (u8::from(value.mouse_sgr) << 4)
+                    | (u8::from(value.mouse_utf8) << 5)
+                    | (u8::from(value.mouse_drag) << 6)
+                    | (u8::from(value.mouse_motion) << 7);
                 output.push(modes);
+                let extended_modes =
+                    u8::from(value.alternate_scroll) | (u8::from(value.focus_reporting) << 1);
                 if value.grid.is_full_snapshot {
                     return rollback(
                         output,
@@ -775,6 +819,7 @@ impl RemoteCodec {
                     );
                 }
                 output.extend_from_slice(&value.grid.encode()?);
+                output.push(extended_modes);
                 Ok(())
             }
             RemoteMessage::ProcessExit(value) => {
@@ -877,10 +922,21 @@ impl RemoteCodec {
             if self.buffer.len() < frame_end {
                 break;
             }
-            messages.push(decode_message(
+            let message = decode_message(
                 kind,
                 &self.buffer[consumed + HEADER_BYTES..frame_end],
-            )?);
+                self.peer_protocol_minor,
+            )?;
+            match &message {
+                RemoteMessage::Hello(hello) => {
+                    self.peer_protocol_minor = Some(hello.protocol.minor);
+                }
+                RemoteMessage::HelloAck(acknowledgement) => {
+                    self.peer_protocol_minor = Some(acknowledgement.protocol.minor);
+                }
+                _ => {}
+            }
+            messages.push(message);
             consumed = frame_end;
         }
 
@@ -916,7 +972,11 @@ fn decode_json<T: DeserializeOwned>(kind: u8, payload: &[u8]) -> Result<T, Remot
     })
 }
 
-fn decode_message(kind: u8, payload: &[u8]) -> Result<RemoteMessage, RemoteCodecError> {
+fn decode_message(
+    kind: u8,
+    payload: &[u8],
+    peer_protocol_minor: Option<u16>,
+) -> Result<RemoteMessage, RemoteCodecError> {
     if kind <= FrameType::Modes as u8 {
         return Ok(RemoteMessage::Terminal(Frame::new(
             FrameType::try_from(kind).map_err(|_| RemoteCodecError::UnknownMessageType(kind))?,
@@ -935,15 +995,24 @@ fn decode_message(kind: u8, payload: &[u8]) -> Result<RemoteMessage, RemoteCodec
             Ok(RemoteMessage::HelloAck(value))
         }
         KIND_FULL_SNAPSHOT => {
-            if payload.len() < FULL_SNAPSHOT_FIXED_BYTES {
+            let has_extended_modes =
+                peer_protocol_minor.unwrap_or(PROTOCOL_MINOR) >= EXTENDED_INPUT_MODES_MINOR;
+            let minimum_bytes = LEGACY_SNAPSHOT_FIXED_BYTES + usize::from(has_extended_modes);
+            if payload.len() < minimum_bytes {
                 return Err(RemoteCodecError::InvalidFullSnapshot(format!(
-                    "need at least {FULL_SNAPSHOT_FIXED_BYTES} bytes, got {}",
+                    "need at least {minimum_bytes} bytes, got {}",
                     payload.len()
                 )));
             }
             let sequence = u64::from_be_bytes(payload[..8].try_into().expect("length checked"));
             let modes = payload[8];
-            let grid = GridUpdate::decode(&payload[FULL_SNAPSHOT_FIXED_BYTES..])?;
+            let grid_end = payload.len() - usize::from(has_extended_modes);
+            let extended_modes = if has_extended_modes {
+                payload[grid_end]
+            } else {
+                0
+            };
+            let grid = GridUpdate::decode(&payload[LEGACY_SNAPSHOT_FIXED_BYTES..grid_end])?;
             validate_grid_update(&grid)?;
             if !grid.is_full_snapshot {
                 return Err(RemoteCodecError::InvalidFullSnapshot(
@@ -953,21 +1022,37 @@ fn decode_message(kind: u8, payload: &[u8]) -> Result<RemoteMessage, RemoteCodec
             Ok(RemoteMessage::FullSnapshot(FullSnapshot {
                 sequence,
                 alt_screen: modes & 1 != 0,
+                application_cursor_keys: modes & 8 != 0,
                 bracketed_paste: modes & 2 != 0,
                 mouse_reporting: modes & 4 != 0,
+                mouse_sgr: modes & 16 != 0,
+                mouse_utf8: modes & 32 != 0,
+                mouse_drag: modes & 64 != 0,
+                mouse_motion: modes & 128 != 0,
+                alternate_scroll: extended_modes & 1 != 0,
+                focus_reporting: extended_modes & 2 != 0,
                 grid,
             }))
         }
         KIND_GRID_DELTA => {
-            if payload.len() < 9 {
+            let has_extended_modes =
+                peer_protocol_minor.unwrap_or(PROTOCOL_MINOR) >= EXTENDED_INPUT_MODES_MINOR;
+            let minimum_bytes = LEGACY_SNAPSHOT_FIXED_BYTES + usize::from(has_extended_modes);
+            if payload.len() < minimum_bytes {
                 return Err(RemoteCodecError::InvalidFullSnapshot(format!(
-                    "grid delta needs at least 8 bytes, got {}",
+                    "grid delta needs at least {minimum_bytes} bytes, got {}",
                     payload.len()
                 )));
             }
             let sequence = u64::from_be_bytes(payload[..8].try_into().expect("length checked"));
             let modes = payload[8];
-            let grid = GridUpdate::decode(&payload[9..])?;
+            let grid_end = payload.len() - usize::from(has_extended_modes);
+            let extended_modes = if has_extended_modes {
+                payload[grid_end]
+            } else {
+                0
+            };
+            let grid = GridUpdate::decode(&payload[LEGACY_SNAPSHOT_FIXED_BYTES..grid_end])?;
             validate_grid_update(&grid)?;
             if grid.is_full_snapshot {
                 return Err(RemoteCodecError::InvalidFullSnapshot(
@@ -977,8 +1062,15 @@ fn decode_message(kind: u8, payload: &[u8]) -> Result<RemoteMessage, RemoteCodec
             Ok(RemoteMessage::GridDelta(GridDelta {
                 sequence,
                 alt_screen: modes & 1 != 0,
+                application_cursor_keys: modes & 8 != 0,
                 bracketed_paste: modes & 2 != 0,
                 mouse_reporting: modes & 4 != 0,
+                mouse_sgr: modes & 16 != 0,
+                mouse_utf8: modes & 32 != 0,
+                mouse_drag: modes & 64 != 0,
+                mouse_motion: modes & 128 != 0,
+                alternate_scroll: extended_modes & 1 != 0,
+                focus_reporting: extended_modes & 2 != 0,
                 grid,
             }))
         }
@@ -1087,6 +1179,31 @@ mod tests {
     }
 
     #[test]
+    fn phase_one_requires_complete_terminal_input_modes() {
+        assert_eq!(
+            ProtocolVersion::CURRENT,
+            ProtocolVersion {
+                major: PROTOCOL_MAJOR,
+                minor: PROTOCOL_MINOR,
+            }
+        );
+        assert_eq!(PROTOCOL_MINOR, 5);
+        for required in [
+            RemoteCapability::TerminalInputModes,
+            RemoteCapability::TerminalMouseModes,
+        ] {
+            assert!(
+                PHASE_ONE_HOLDER_CAPABILITIES.contains(&required),
+                "{required:?} must be required of every Holder attach"
+            );
+            assert!(
+                PHASE_ONE_HELPER_CAPABILITIES.contains(&required),
+                "{required:?} must be required of every Helper"
+            );
+        }
+    }
+
+    #[test]
     fn directory_requests_accept_only_normalized_absolute_or_home_paths() {
         for valid in ["/", "/srv/app", "~", "~/code"] {
             assert!(
@@ -1112,8 +1229,15 @@ mod tests {
         FullSnapshot {
             sequence: 42,
             alt_screen: true,
+            application_cursor_keys: true,
             bracketed_paste: true,
-            mouse_reporting: false,
+            mouse_reporting: true,
+            mouse_sgr: true,
+            mouse_utf8: false,
+            mouse_drag: true,
+            mouse_motion: false,
+            alternate_scroll: true,
+            focus_reporting: true,
             grid: GridUpdate {
                 cols: 2,
                 rows: 1,
@@ -1163,6 +1287,37 @@ mod tests {
     }
 
     #[test]
+    fn protocol_four_snapshots_remain_decodable_for_live_holders() {
+        let message = RemoteMessage::FullSnapshot(snapshot());
+        let mut encoded = RemoteCodec::encode(&message).expect("encode");
+        let payload_length =
+            u32::from_be_bytes(encoded[1..HEADER_BYTES].try_into().unwrap()) as usize;
+        let payload = &encoded[HEADER_BYTES..HEADER_BYTES + payload_length];
+        assert_eq!(
+            GridUpdate::decode(&payload[LEGACY_SNAPSHOT_FIXED_BYTES..])
+                .expect("a 1.4 reader ignores the trailing extension"),
+            snapshot().grid
+        );
+        // Protocol 1.4 carried only the primary mode byte. Keep the message
+        // kind/sequence/grid identical while removing the 1.5 extension.
+        assert_eq!(encoded.pop(), Some(3));
+        let payload_length = u32::try_from(payload_length - 1).unwrap();
+        encoded[1..HEADER_BYTES].copy_from_slice(&payload_length.to_be_bytes());
+
+        let mut expected = snapshot();
+        expected.alternate_scroll = false;
+        expected.focus_reporting = false;
+        let mut codec = RemoteCodec {
+            peer_protocol_minor: Some(4),
+            ..RemoteCodec::default()
+        };
+        assert_eq!(
+            codec.feed(&encoded).expect("decode legacy snapshot"),
+            vec![RemoteMessage::FullSnapshot(expected)]
+        );
+    }
+
+    #[test]
     fn grid_delta_round_trips_with_its_sequence() {
         let mut grid = snapshot().grid;
         grid.is_full_snapshot = false;
@@ -1170,8 +1325,15 @@ mod tests {
         let message = RemoteMessage::GridDelta(GridDelta {
             sequence: 43,
             alt_screen: true,
+            application_cursor_keys: true,
             bracketed_paste: true,
-            mouse_reporting: false,
+            mouse_reporting: true,
+            mouse_sgr: false,
+            mouse_utf8: true,
+            mouse_drag: false,
+            mouse_motion: true,
+            alternate_scroll: false,
+            focus_reporting: true,
             grid,
         });
         let encoded = RemoteCodec::encode(&message).expect("encode");
@@ -1232,6 +1394,7 @@ mod tests {
         payload.extend_from_slice(&oversized.sequence.to_be_bytes());
         payload.push(0);
         payload.extend_from_slice(&oversized.grid.encode().expect("raw grid encoding"));
+        payload.push(0);
         let mut frame = vec![KIND_FULL_SNAPSHOT];
         frame.extend_from_slice(&(payload.len() as u32).to_be_bytes());
         frame.extend_from_slice(&payload);

--- a/zeus/crates/zeus-remote/src/holder.rs
+++ b/zeus/crates/zeus-remote/src/holder.rs
@@ -1024,16 +1024,30 @@ impl Holder {
             self.queue(RemoteMessage::FullSnapshot(FullSnapshot {
                 sequence: self.state.snapshot_sequence,
                 alt_screen: self.screen.is_alt_screen(),
+                application_cursor_keys: self.screen.application_cursor_keys(),
                 bracketed_paste: self.screen.bracketed_paste(),
                 mouse_reporting: self.screen.mouse_reporting(),
+                mouse_sgr: self.screen.mouse_sgr(),
+                mouse_utf8: self.screen.mouse_utf8(),
+                mouse_drag: self.screen.mouse_drag(),
+                mouse_motion: self.screen.mouse_motion(),
+                alternate_scroll: self.screen.alternate_scroll(),
+                focus_reporting: self.screen.focus_reporting(),
                 grid,
             }))?;
         } else {
             self.queue(RemoteMessage::GridDelta(GridDelta {
                 sequence: self.state.snapshot_sequence,
                 alt_screen: self.screen.is_alt_screen(),
+                application_cursor_keys: self.screen.application_cursor_keys(),
                 bracketed_paste: self.screen.bracketed_paste(),
                 mouse_reporting: self.screen.mouse_reporting(),
+                mouse_sgr: self.screen.mouse_sgr(),
+                mouse_utf8: self.screen.mouse_utf8(),
+                mouse_drag: self.screen.mouse_drag(),
+                mouse_motion: self.screen.mouse_motion(),
+                alternate_scroll: self.screen.alternate_scroll(),
+                focus_reporting: self.screen.focus_reporting(),
                 grid,
             }))?;
         }
@@ -1091,8 +1105,15 @@ impl Holder {
         connection.queue(RemoteMessage::FullSnapshot(FullSnapshot {
             sequence: self.state.snapshot_sequence,
             alt_screen: self.screen.is_alt_screen(),
+            application_cursor_keys: self.screen.application_cursor_keys(),
             bracketed_paste: self.screen.bracketed_paste(),
             mouse_reporting: self.screen.mouse_reporting(),
+            mouse_sgr: self.screen.mouse_sgr(),
+            mouse_utf8: self.screen.mouse_utf8(),
+            mouse_drag: self.screen.mouse_drag(),
+            mouse_motion: self.screen.mouse_motion(),
+            alternate_scroll: self.screen.alternate_scroll(),
+            focus_reporting: self.screen.focus_reporting(),
             grid: self.screen.full_snapshot(),
         }))
     }
@@ -1432,8 +1453,15 @@ mod tests {
             .queue(RemoteMessage::GridDelta(GridDelta {
                 sequence: 7,
                 alt_screen: false,
+                application_cursor_keys: false,
                 bracketed_paste: false,
                 mouse_reporting: false,
+                mouse_sgr: false,
+                mouse_utf8: false,
+                mouse_drag: false,
+                mouse_motion: false,
+                alternate_scroll: false,
+                focus_reporting: false,
                 grid: GridUpdate {
                     cols: 1,
                     rows: 1,

--- a/zeus/crates/zeus-remote/tests/holder_e2e.rs
+++ b/zeus/crates/zeus-remote/tests/holder_e2e.rs
@@ -248,7 +248,7 @@ fn detach_reconnect_preserves_pid_snapshot_and_input() {
         argv: vec![
             "/bin/sh".into(),
             "-c".into(),
-            "printf 'ready>'; IFS= read -r first; printf 'got:%s\\nnext>' \"$first\"; IFS= read -r second; printf 'bye:%s\\n' \"$second\"".into(),
+            "printf '\\033[?1h\\033[?2004h\\033[?1002h\\033[?1006hready>'; IFS= read -r first; printf '\\033[?1002l\\033[?1006l\\033[?1003h\\033[?1005hgot:%s\\nnext>' \"$first\"; IFS= read -r second; printf 'bye:%s\\n' \"$second\"".into(),
         ],
         cwd: "/".into(),
         environment: vec![zeus_proto::remote_pty::EnvironmentVariable {
@@ -275,6 +275,23 @@ fn detach_reconnect_preserves_pid_snapshot_and_input() {
             _ => None,
         })
         .expect("HelloAck");
+    assert!(initial.iter().any(|message| match message {
+        RemoteMessage::FullSnapshot(snapshot) => {
+            snapshot.application_cursor_keys
+                && snapshot.bracketed_paste
+                && snapshot.mouse_reporting
+                && snapshot.mouse_sgr
+                && snapshot.mouse_drag
+        }
+        RemoteMessage::GridDelta(delta) => {
+            delta.application_cursor_keys
+                && delta.bracketed_paste
+                && delta.mouse_reporting
+                && delta.mouse_sgr
+                && delta.mouse_drag
+        }
+        _ => false,
+    }));
     first.send(RemoteMessage::Terminal(Frame::input(b"alpha\n".to_vec())));
     let output = first.receive_until(Duration::from_secs(2), |message| match message {
         RemoteMessage::Terminal(frame) => frame
@@ -335,6 +352,13 @@ fn detach_reconnect_preserves_pid_snapshot_and_input() {
         })
         .expect("reconnect snapshot");
     assert!(grid_text(&snapshot.grid).contains("next>"));
+    assert!(snapshot.application_cursor_keys);
+    assert!(snapshot.bracketed_paste);
+    assert!(snapshot.mouse_reporting);
+    assert!(snapshot.mouse_utf8);
+    assert!(snapshot.mouse_motion);
+    assert!(!snapshot.mouse_sgr);
+    assert!(!snapshot.mouse_drag);
 
     first.receive_until(Duration::from_secs(2), |message| {
         matches!(

--- a/zeus/crates/zeus-term/Cargo.toml
+++ b/zeus/crates/zeus-term/Cargo.toml
@@ -11,3 +11,4 @@ gpui.workspace = true
 
 [dev-dependencies]
 gpui_platform.workspace = true
+zeus-pty.workspace = true

--- a/zeus/crates/zeus-term/src/element.rs
+++ b/zeus/crates/zeus-term/src/element.rs
@@ -309,8 +309,9 @@ pub struct TerminalPrepaintState {
 struct CursorPaint {
     row: u16,
     col: u16,
-    quad: PaintQuad,
+    quads: Vec<PaintQuad>,
     glyph: Option<ShapedLine>,
+    masks_text: bool,
 }
 
 impl TerminalElement {
@@ -371,6 +372,12 @@ impl TerminalElement {
     #[must_use]
     pub fn grid_rows(&self) -> u16 {
         read_lock(&self.buffer).rows
+    }
+
+    /// Columns in the authoritative mirrored screen.
+    #[must_use]
+    pub fn grid_cols(&self) -> u16 {
+        read_lock(&self.buffer).cols
     }
 
     #[must_use]
@@ -472,12 +479,18 @@ impl TerminalElement {
         mutex_lock(&self.shared.viewport).scroll_to_absolute(absolute_row, anchor, visible_rows)
     }
 
-    pub fn set_modes(&self, alt_screen: bool, mouse_reporting: bool) -> bool {
+    pub fn set_modes(
+        &self,
+        alt_screen: bool,
+        mouse_reporting: bool,
+        alternate_scroll: bool,
+    ) -> bool {
         let mut modes = mutex_lock(&self.shared.modes);
         let entered_alt = alt_screen && !modes.alt_screen;
         *modes = TerminalModes {
             alt_screen,
             mouse_reporting,
+            alternate_scroll,
         };
         drop(modes);
         entered_alt && mutex_lock(&self.shared.viewport).enter_alt_screen()
@@ -489,8 +502,8 @@ impl TerminalElement {
         mutex_lock(&self.shared.modes).mouse_reporting
     }
 
-    /// Resolves a wheel event and applies local scrollback movement. Daemon
-    /// routes are returned for the app to pass to `SessionAttachment::scroll`.
+    /// Resolves a wheel event and applies local scrollback movement. Terminal
+    /// routes are returned for the app to encode with the live mouse modes.
     pub fn route_wheel(&self, event: WheelEvent) -> Option<WheelRoute> {
         let modes = *mutex_lock(&self.shared.modes);
         let route = mutex_lock(&self.shared.scroll_router).route(modes, event)?;
@@ -532,10 +545,27 @@ impl TerminalElement {
         });
     }
 
+    /// Extends the current selection from its existing anchor, or creates an
+    /// empty anchor when Shift-click begins without a selection.
+    pub fn extend_selection(&self, col: usize, window_row: usize) {
+        let absolute_row = mutex_lock(&self.shared.viewport).absolute_row(window_row);
+        mutex_lock(&self.shared.selection).extend_to(SelectionPoint {
+            row: absolute_row,
+            col,
+        });
+    }
+
     pub fn select_word(&self, col: usize, window_row: usize) {
         let viewport = mutex_lock(&self.shared.viewport).clone();
         let buffer = read_lock(&self.buffer);
         mutex_lock(&self.shared.selection).select_word(&viewport, &buffer, window_row, col);
+    }
+
+    /// Selects every cell in one terminal row with an exclusive endpoint.
+    pub fn select_line(&self, window_row: usize) {
+        let viewport = mutex_lock(&self.shared.viewport).clone();
+        let buffer = read_lock(&self.buffer);
+        mutex_lock(&self.shared.selection).select_line(&viewport, &buffer, window_row);
     }
 
     pub fn clear_selection(&self) {
@@ -981,7 +1011,7 @@ impl Element for TerminalElement {
             );
         }
 
-        let cursor_visible = cursor_should_render(focused, cursor.visible);
+        let cursor_visible = cursor_should_render(cursor.visible);
         let cursor = if cursor_visible
             && viewport.view_offset() == 0
             && usize::from(cursor.row) < visible_rows
@@ -997,14 +1027,15 @@ impl Element for TerminalElement {
                 bounds.left() + metrics.x_for_col(cursor.col),
                 bounds.top() + metrics.y_for_row(cursor.row),
             );
+            let cursor_bounds = Bounds::new(origin, size(metrics.cell_width, metrics.line_height));
             Some(CursorPaint {
                 row: cursor.row,
                 col: cursor.col,
-                quad: fill(
-                    Bounds::new(origin, size(metrics.cell_width, metrics.line_height)),
-                    self.theme.cursor,
-                ),
-                glyph: self.shape_cursor_glyph(cell, metrics, window),
+                quads: cursor_quads(cursor_bounds, self.theme.cursor, focused),
+                glyph: focused
+                    .then(|| self.shape_cursor_glyph(cell, metrics, window))
+                    .flatten(),
+                masks_text: focused,
             })
         } else {
             None
@@ -1102,7 +1133,7 @@ impl Element for TerminalElement {
                     if prepaint
                         .cursor
                         .as_ref()
-                        .is_some_and(|cursor| cursor.row == row)
+                        .is_some_and(|cursor| cursor.row == row && cursor.masks_text)
                     {
                         let cursor = prepaint.cursor.as_ref().unwrap();
                         paint_line_around_cursor(
@@ -1137,7 +1168,7 @@ impl Element for TerminalElement {
                 if prepaint
                     .cursor
                     .as_ref()
-                    .is_some_and(|cursor| cursor.row == *row)
+                    .is_some_and(|cursor| cursor.row == *row && cursor.masks_text)
                 {
                     let cursor = prepaint.cursor.as_ref().unwrap();
                     paint_line_around_cursor(line, origin, bounds, metrics, cursor.col, window, cx);
@@ -1158,7 +1189,9 @@ impl Element for TerminalElement {
             }
 
             if let Some(cursor) = prepaint.cursor.take() {
-                window.paint_quad(cursor.quad);
+                for quad in cursor.quads {
+                    window.paint_quad(quad);
+                }
                 if let Some(glyph) = cursor.glyph {
                     let origin = point(
                         bounds.left() + metrics.x_for_col(cursor.col),
@@ -1190,8 +1223,39 @@ impl Element for TerminalElement {
     }
 }
 
-const fn cursor_should_render(focused: bool, protocol_visible: bool) -> bool {
-    focused && protocol_visible
+const fn cursor_should_render(protocol_visible: bool) -> bool {
+    protocol_visible
+}
+
+fn cursor_quads(bounds: Bounds<Pixels>, color: gpui::Rgba, focused: bool) -> Vec<PaintQuad> {
+    if focused {
+        return vec![fill(bounds, color)];
+    }
+    let stroke = px(1.0);
+    vec![
+        fill(
+            Bounds::new(bounds.origin, size(bounds.size.width, stroke)),
+            color,
+        ),
+        fill(
+            Bounds::new(
+                point(bounds.left(), bounds.bottom() - stroke),
+                size(bounds.size.width, stroke),
+            ),
+            color,
+        ),
+        fill(
+            Bounds::new(bounds.origin, size(stroke, bounds.size.height)),
+            color,
+        ),
+        fill(
+            Bounds::new(
+                point(bounds.right() - stroke, bounds.top()),
+                size(stroke, bounds.size.height),
+            ),
+            color,
+        ),
+    ]
 }
 
 fn append_background_quads(
@@ -1572,11 +1636,18 @@ mod link_tests {
     }
 
     #[test]
-    fn static_cursor_follows_focus_and_protocol_visibility() {
-        assert!(super::cursor_should_render(true, true));
-        assert!(!super::cursor_should_render(false, true));
-        assert!(!super::cursor_should_render(true, false));
-        assert!(!super::cursor_should_render(false, false));
+    fn cursor_visibility_follows_the_terminal_protocol() {
+        assert!(super::cursor_should_render(true));
+        assert!(!super::cursor_should_render(false));
+        let bounds = Bounds::new(point(px(0.0), px(0.0)), size(px(8.0), px(16.0)));
+        assert_eq!(
+            super::cursor_quads(bounds, gpui::rgba(0xffffffff), true).len(),
+            1
+        );
+        assert_eq!(
+            super::cursor_quads(bounds, gpui::rgba(0xffffffff), false).len(),
+            4
+        );
     }
 
     #[test]

--- a/zeus/crates/zeus-term/src/keys.rs
+++ b/zeus/crates/zeus-term/src/keys.rs
@@ -1,10 +1,9 @@
 //! Platform-independent keyboard and paste encoding for terminal input.
 //!
-//! The default behavior follows `TerminalKeyEncoding.swift` and
-//! `GridTerminalView+Input.swift`.  UI adapters should put the logical,
-//! modifier-free value in [`Key::Character`] and the platform-produced text in
-//! [`KeyEvent::text`].  Keeping both values is what lets Option act as Meta while
-//! retaining composed characters.
+//! UI adapters put the logical, modifier-free value in [`Key::Character`] and
+//! the platform-produced text in [`KeyEvent::text`]. Keeping both values lets
+//! the caller choose Zed's macOS Option behavior: native composed characters
+//! by default, or ESC-prefixed logical input when `option_as_meta` is enabled.
 
 const ESC: u8 = 0x1b;
 
@@ -46,6 +45,14 @@ pub enum NamedKey {
     F10,
     F11,
     F12,
+    F13,
+    F14,
+    F15,
+    F16,
+    F17,
+    F18,
+    F19,
+    F20,
 }
 
 /// A logical key plus the text produced by the platform keyboard layout.
@@ -94,27 +101,23 @@ pub struct Modifiers {
 }
 
 /// Terminal modes and input preferences that change emitted bytes.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct TermInputModes {
-    /// DEC application cursor keys (DECCKM). Only unmodified arrows use SS3;
-    /// modified arrows retain xterm's CSI `1;mod` form.
+    /// DEC application cursor keys (DECCKM). Only unmodified arrows, Home,
+    /// and End use SS3; modified keys retain xterm's CSI `1;mod` form.
     pub application_cursor_keys: bool,
     /// DEC bracketed-paste mode (DECSET 2004). Pass this to [`paste`].
     pub bracketed_paste: bool,
-    /// `true` for DEL (0x7f), matching Zeus's Swift view; `false` for BS
-    /// (0x08), for terminals configured with the alternate backspace mapping.
-    /// Configurable BS is an intentional extension; Swift always sends DEL.
-    pub backspace_sends_delete: bool,
-}
-
-impl Default for TermInputModes {
-    fn default() -> Self {
-        Self {
-            application_cursor_keys: false,
-            bracketed_paste: false,
-            backspace_sends_delete: true,
-        }
-    }
+    /// Treat macOS Option as terminal Meta. When disabled, Option-composed
+    /// printable input uses the platform-produced text unchanged. When
+    /// enabled, a single logical ASCII/control key is prefixed with ESC.
+    pub option_as_meta: bool,
+    /// Translate wheel events in the alternate screen into application-cursor
+    /// up/down keys (DEC private mode 1007).
+    pub alternate_scroll: bool,
+    /// Send CSI I / CSI O when the terminal pane gains or loses focus (DEC
+    /// private mode 1004).
+    pub focus_reporting: bool,
 }
 
 /// Encodes one key event as bytes to write to the PTY.
@@ -139,31 +142,49 @@ pub fn encode_key(event: &KeyEvent, modifiers: Modifiers, modes: TermInputModes)
         return bytes;
     }
 
-    if modifiers.ctrl
-        && let Key::Character(logical) = &event.key
-        && let Some(bytes) = encode_control_text(logical)
-    {
-        return bytes;
-    }
-
     if event.key == Key::Named(NamedKey::Backspace) {
-        let byte = backspace_byte(modes);
+        // Zed/Alacritty's xterm mapping is the source of truth: ordinary and
+        // Shift-Backspace send DEL, Ctrl-Backspace sends BS, and Option sends
+        // Meta-DEL. Command-Backspace remains Zeus's Ctrl-U shortcut above.
+        // Unsupported Command combinations are left to the UI shortcut layer.
+        if modifiers.cmd {
+            return Vec::new();
+        }
+        if modifiers.ctrl && !modifiers.alt {
+            return vec![0x08];
+        }
         return if modifiers.alt {
-            vec![ESC, byte]
+            vec![ESC, 0x7f]
         } else {
-            vec![byte]
+            vec![0x7f]
         };
     }
 
     let produced = event.text.as_deref().unwrap_or_default();
 
-    // Swift checks Option before named control characters, making Option-Enter
-    // ESC CR, Option-Backspace ESC DEL, and Option-Escape ESC ESC.
-    if modifiers.alt && !produced.is_empty() {
+    // Special Option chords are terminal keys regardless of the printable
+    // Option policy. This preserves Option-Enter/Tab/Escape and all named CSI
+    // mappings while Option-composed text remains native by default.
+    if modifiers.alt && matches!(event.key, Key::Named(_)) && !produced.is_empty() {
         let mut bytes = Vec::with_capacity(1 + produced.len());
         bytes.push(ESC);
         bytes.extend_from_slice(produced.as_bytes());
         return bytes;
+    }
+
+    if let Key::Character(logical) = &event.key {
+        if modifiers.alt
+            && modes.option_as_meta
+            && let Some(bytes) = encode_meta_text(logical, modifiers)
+        {
+            return bytes;
+        }
+        if modifiers.ctrl
+            && !modifiers.alt
+            && let Some(bytes) = encode_control_text(logical)
+        {
+            return bytes;
+        }
     }
 
     produced.as_bytes().to_vec()
@@ -172,16 +193,29 @@ pub fn encode_key(event: &KeyEvent, modifiers: Modifiers, modes: TermInputModes)
 /// Encodes pasted UTF-8 text, optionally using DEC bracketed-paste framing.
 pub fn paste(text: &str, bracketed: bool) -> Vec<u8> {
     if !bracketed {
-        return text.as_bytes().to_vec();
+        // Zed normalizes pasted lines to the terminal's carriage-return input
+        // convention without doubling CRLF into two submissions.
+        return text.replace("\r\n", "\r").replace('\n', "\r").into_bytes();
     }
 
-    // The current Swift GridTerminalView paste action sends raw UTF-8. This
-    // framing is an intentional extension required by T6 and matches the
-    // daemon's existing submitted-text framing.
+    // Never let pasted content inject a control sequence that can terminate
+    // or escape its bracketed-paste envelope.
+    let sanitized = text.replace('\x1b', "");
     let mut bytes = Vec::with_capacity(6 + text.len() + 6);
     bytes.extend_from_slice(b"\x1b[200~");
-    bytes.extend_from_slice(text.as_bytes());
+    bytes.extend_from_slice(sanitized.as_bytes());
     bytes.extend_from_slice(b"\x1b[201~");
+    bytes
+}
+
+/// Encodes alternate-screen wheel steps as SS3 cursor keys.
+#[must_use]
+pub fn alternate_scroll(up: bool, lines: usize) -> Vec<u8> {
+    let final_byte = if up { b'A' } else { b'B' };
+    let mut bytes = Vec::with_capacity(lines.saturating_mul(3));
+    for _ in 0..lines {
+        bytes.extend_from_slice(&[ESC, b'O', final_byte]);
+    }
     bytes
 }
 
@@ -205,13 +239,6 @@ fn encode_csi_key(
             csi_modified(modifier, final_byte)
         }
     };
-    let csi = |final_byte| {
-        if modifier == 1 {
-            csi_final(final_byte)
-        } else {
-            csi_modified(modifier, final_byte)
-        }
-    };
     let tilde = |number| csi_tilde(number, modifier);
     let fkey = |final_byte| {
         if modifier == 1 {
@@ -227,15 +254,15 @@ fn encode_csi_key(
         NamedKey::ArrowDown => Some(cursor(b'B')),
         NamedKey::ArrowRight => Some(cursor(b'C')),
         NamedKey::ArrowLeft => Some(cursor(b'D')),
-        NamedKey::Home => Some(csi(b'H')),
-        NamedKey::End => Some(csi(b'F')),
+        NamedKey::Home => Some(cursor(b'H')),
+        NamedKey::End => Some(cursor(b'F')),
         NamedKey::PageUp => Some(tilde(5)),
         NamedKey::PageDown => Some(tilde(6)),
         NamedKey::Insert => Some(tilde(2)),
         NamedKey::Delete => Some(tilde(3)),
         NamedKey::Tab if modifiers.shift => Some(b"\x1b[Z".to_vec()),
         NamedKey::Tab => None,
-        NamedKey::Enter if modifiers.shift => Some(format!("\x1b[13;{modifier}u").into_bytes()),
+        NamedKey::Enter if modifiers == shift_only() => Some(vec![b'\n']),
         NamedKey::Enter => None,
         NamedKey::F1 => Some(fkey(b'P')),
         NamedKey::F2 => Some(fkey(b'Q')),
@@ -249,7 +276,47 @@ fn encode_csi_key(
         NamedKey::F10 => Some(tilde(21)),
         NamedKey::F11 => Some(tilde(23)),
         NamedKey::F12 => Some(tilde(24)),
+        NamedKey::F13 => Some(tilde(25)),
+        NamedKey::F14 => Some(tilde(26)),
+        NamedKey::F15 => Some(tilde(28)),
+        NamedKey::F16 => Some(tilde(29)),
+        NamedKey::F17 => Some(tilde(31)),
+        NamedKey::F18 => Some(tilde(32)),
+        NamedKey::F19 => Some(tilde(33)),
+        NamedKey::F20 => Some(tilde(34)),
         NamedKey::Escape | NamedKey::Backspace => None,
+    }
+}
+
+fn encode_meta_text(logical: &str, modifiers: Modifiers) -> Option<Vec<u8>> {
+    let mut scalars = logical.chars();
+    let scalar = scalars.next()?;
+    if scalars.next().is_some() || !scalar.is_ascii() {
+        return None;
+    }
+
+    let payload = if modifiers.ctrl {
+        encode_control_text(&scalar.to_string()).unwrap_or_else(|| vec![scalar as u8])
+    } else {
+        let scalar = if modifiers.shift {
+            scalar.to_ascii_uppercase()
+        } else {
+            scalar
+        };
+        vec![scalar as u8]
+    };
+    let mut bytes = Vec::with_capacity(1 + payload.len());
+    bytes.push(ESC);
+    bytes.extend_from_slice(&payload);
+    Some(bytes)
+}
+
+const fn shift_only() -> Modifiers {
+    Modifiers {
+        shift: true,
+        ctrl: false,
+        alt: false,
+        cmd: false,
     }
 }
 
@@ -294,14 +361,6 @@ fn named_text(key: NamedKey) -> Option<&'static str> {
     }
 }
 
-fn backspace_byte(modes: TermInputModes) -> u8 {
-    if modes.backspace_sends_delete {
-        0x7f
-    } else {
-        0x08
-    }
-}
-
 fn xterm_modifier(modifiers: Modifiers) -> u8 {
     1 + u8::from(modifiers.shift) + 2 * u8::from(modifiers.alt) + 4 * u8::from(modifiers.ctrl)
 }
@@ -328,7 +387,14 @@ fn csi_tilde(number: u8, modifier: u8) -> Vec<u8> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    use std::io::{Read, Write};
+    #[cfg(unix)]
+    use std::time::{Duration, Instant};
+
     use super::*;
+    #[cfg(unix)]
+    use zeus_pty::{Pty, PtySpec};
 
     const MODIFIER_CASES: [(&str, Modifiers, u8); 8] = [
         ("plain", modifiers(false, false, false, false), 1),
@@ -420,6 +486,14 @@ mod tests {
             ("f10", NamedKey::F10, Sequence::Tilde(21)),
             ("f11", NamedKey::F11, Sequence::Tilde(23)),
             ("f12", NamedKey::F12, Sequence::Tilde(24)),
+            ("f13", NamedKey::F13, Sequence::Tilde(25)),
+            ("f14", NamedKey::F14, Sequence::Tilde(26)),
+            ("f15", NamedKey::F15, Sequence::Tilde(28)),
+            ("f16", NamedKey::F16, Sequence::Tilde(29)),
+            ("f17", NamedKey::F17, Sequence::Tilde(31)),
+            ("f18", NamedKey::F18, Sequence::Tilde(32)),
+            ("f19", NamedKey::F19, Sequence::Tilde(33)),
+            ("f20", NamedKey::F20, Sequence::Tilde(34)),
         ];
 
         for (key_name, key, sequence) in cases {
@@ -446,7 +520,7 @@ mod tests {
 
     #[test]
     fn tab_and_enter_switch_cases_match_swift_for_every_modifier() {
-        for (name, base_modifiers, modifier) in MODIFIER_CASES {
+        for (name, base_modifiers, _) in MODIFIER_CASES {
             for cmd in [false, true] {
                 let modifiers = Modifiers {
                     cmd,
@@ -466,8 +540,8 @@ mod tests {
                     "tab, {name}, cmd={cmd}"
                 );
 
-                let enter = if modifiers.shift {
-                    format!("\x1b[13;{modifier}u").into_bytes()
+                let enter = if modifiers == shift_only() {
+                    b"\n".to_vec()
                 } else if modifiers.alt {
                     b"\x1b\r".to_vec()
                 } else {
@@ -487,12 +561,14 @@ mod tests {
     }
 
     #[test]
-    fn application_cursor_mode_uses_ss3_only_for_unmodified_arrows() {
+    fn application_cursor_mode_uses_ss3_only_for_unmodified_cursor_keys() {
         let cases = [
             (NamedKey::ArrowUp, b'A'),
             (NamedKey::ArrowDown, b'B'),
             (NamedKey::ArrowRight, b'C'),
             (NamedKey::ArrowLeft, b'D'),
+            (NamedKey::Home, b'H'),
+            (NamedKey::End, b'F'),
         ];
 
         for (key, final_byte) in cases {
@@ -557,35 +633,58 @@ mod tests {
                     "escape, {name}, cmd={cmd}"
                 );
 
-                for backspace_sends_delete in [true, false] {
-                    let modes = TermInputModes {
-                        backspace_sends_delete,
-                        ..TermInputModes::default()
-                    };
-                    let backspace = if modifiers.cmd && !modifiers.alt && !modifiers.ctrl {
-                        vec![0x15]
-                    } else {
-                        let byte = if backspace_sends_delete { 0x7f } else { 0x08 };
-                        if modifiers.alt {
-                            vec![ESC, byte]
-                        } else {
-                            vec![byte]
-                        }
-                    };
-                    assert_eq!(
-                        encode_key(&event(NamedKey::Backspace), modifiers, modes),
-                        backspace,
-                        "backspace, {name}, cmd={cmd}, del={backspace_sends_delete}"
-                    );
-                }
+                let backspace = if modifiers.cmd && !modifiers.alt && !modifiers.ctrl {
+                    vec![0x15]
+                } else if modifiers.cmd {
+                    Vec::new()
+                } else if modifiers.ctrl && !modifiers.alt {
+                    vec![0x08]
+                } else if modifiers.alt {
+                    vec![ESC, 0x7f]
+                } else {
+                    vec![0x7f]
+                };
+                assert_eq!(
+                    encode_key(
+                        &event(NamedKey::Backspace),
+                        modifiers,
+                        TermInputModes::default()
+                    ),
+                    backspace,
+                    "backspace, {name}, cmd={cmd}"
+                );
             }
         }
+    }
+
+    #[test]
+    fn backspace_and_forward_delete_are_distinct_xterm_keys() {
+        assert_eq!(
+            encode_key(
+                &event(NamedKey::Backspace),
+                Modifiers::default(),
+                TermInputModes::default()
+            ),
+            [0x7f]
+        );
+        assert_eq!(
+            encode_key(
+                &event(NamedKey::Delete),
+                Modifiers::default(),
+                TermInputModes::default()
+            ),
+            b"\x1b[3~"
+        );
     }
 
     #[test]
     fn ctrl_letters_match_swift_a_through_z() {
         let ctrl = modifiers(false, true, false, false);
         let ctrl_alt = modifiers(false, true, true, false);
+        let meta = TermInputModes {
+            option_as_meta: true,
+            ..TermInputModes::default()
+        };
 
         for offset in 0_u8..26 {
             let lower = char::from(b'a' + offset).to_string();
@@ -607,8 +706,19 @@ mod tests {
                     ctrl_alt,
                     TermInputModes::default()
                 ),
-                expected,
-                "control takes precedence over Option at offset {offset}"
+                vec![b'a' + offset],
+                "native Option policy keeps platform text at offset {offset}"
+            );
+            let mut meta_expected = vec![ESC];
+            meta_expected.extend_from_slice(&expected);
+            assert_eq!(
+                encode_key(
+                    &KeyEvent::character(char::from(b'a' + offset).to_string()),
+                    ctrl_alt,
+                    meta
+                ),
+                meta_expected,
+                "Meta prefixes the logical control byte at offset {offset}"
             );
         }
     }
@@ -637,20 +747,38 @@ mod tests {
     }
 
     #[test]
-    fn option_prefixes_the_composed_text_not_the_logical_key() {
+    fn option_policy_selects_native_composed_text_or_meta_logical_key() {
         let alt = modifiers(false, false, true, false);
-        let cases = [
-            (KeyEvent::character("x"), b"\x1bx".as_slice()),
-            (KeyEvent::composed("e", "é"), b"\x1b\xc3\xa9".as_slice()),
-            (
-                KeyEvent::composed("dead-key", "´e"),
-                b"\x1b\xc2\xb4e".as_slice(),
-            ),
-        ];
+        let meta = TermInputModes {
+            option_as_meta: true,
+            ..TermInputModes::default()
+        };
 
-        for (event, expected) in cases {
-            assert_eq!(encode_key(&event, alt, TermInputModes::default()), expected);
-        }
+        assert_eq!(
+            encode_key(
+                &KeyEvent::composed("e", "é"),
+                alt,
+                TermInputModes::default()
+            ),
+            "é".as_bytes()
+        );
+        assert_eq!(
+            encode_key(&KeyEvent::composed("e", "é"), alt, meta),
+            b"\x1be"
+        );
+        assert_eq!(
+            encode_key(&KeyEvent::composed("dead-key", "´e"), alt, meta),
+            "´e".as_bytes(),
+            "multi-scalar logical keys fall back to platform text"
+        );
+        assert_eq!(
+            encode_key(
+                &KeyEvent::composed("e", "É"),
+                modifiers(true, false, true, false),
+                meta
+            ),
+            b"\x1bE"
+        );
     }
 
     #[test]
@@ -677,6 +805,17 @@ mod tests {
                 modifiers(false, true, true, false),
                 TermInputModes::default()
             ),
+            b"1"
+        );
+        assert_eq!(
+            encode_key(
+                &KeyEvent::character("1"),
+                modifiers(false, true, true, false),
+                TermInputModes {
+                    option_as_meta: true,
+                    ..TermInputModes::default()
+                }
+            ),
             b"\x1b1"
         );
         assert_eq!(
@@ -701,11 +840,193 @@ mod tests {
     }
 
     #[test]
-    fn paste_matches_raw_swift_path_and_bracketed_extension() {
-        let text = "one\ntwo λ";
-        assert_eq!(paste(text, false), text.as_bytes());
-        assert_eq!(paste(text, true), b"\x1b[200~one\ntwo \xce\xbb\x1b[201~");
+    fn paste_matches_zed_line_normalization_and_bracket_safety() {
+        let text = "one\r\ntwo\nλ";
+        assert_eq!(paste(text, false), "one\rtwo\rλ".as_bytes());
+        assert_eq!(
+            paste("one\x1b[201~two\nλ", true),
+            b"\x1b[200~one[201~two\n\xce\xbb\x1b[201~"
+        );
         assert_eq!(paste("", false), b"");
         assert_eq!(paste("", true), b"\x1b[200~\x1b[201~");
+    }
+
+    #[test]
+    fn alternate_scroll_repeats_ss3_cursor_keys() {
+        assert_eq!(alternate_scroll(true, 3), b"\x1bOA\x1bOA\x1bOA");
+        assert_eq!(alternate_scroll(false, 2), b"\x1bOB\x1bOB");
+        assert!(alternate_scroll(true, 0).is_empty());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn encoded_matrix_reaches_a_raw_pty_exactly_once() {
+        let plain = Modifiers::default();
+        let ctrl = modifiers(false, true, false, false);
+        let alt = modifiers(false, false, true, false);
+        let cmd = modifiers(false, false, false, true);
+        let application = TermInputModes {
+            application_cursor_keys: true,
+            ..TermInputModes::default()
+        };
+        let meta = TermInputModes {
+            option_as_meta: true,
+            ..TermInputModes::default()
+        };
+        let cases: Vec<(Vec<u8>, &[u8])> = vec![
+            (
+                encode_key(
+                    &event(NamedKey::Backspace),
+                    plain,
+                    TermInputModes::default(),
+                ),
+                b"\x7f",
+            ),
+            (
+                encode_key(&event(NamedKey::Backspace), ctrl, TermInputModes::default()),
+                b"\x08",
+            ),
+            (
+                encode_key(&event(NamedKey::Backspace), alt, TermInputModes::default()),
+                b"\x1b\x7f",
+            ),
+            (
+                encode_key(&event(NamedKey::Backspace), cmd, TermInputModes::default()),
+                b"\x15",
+            ),
+            (
+                encode_key(&event(NamedKey::Delete), plain, TermInputModes::default()),
+                b"\x1b[3~",
+            ),
+            (
+                encode_key(&event(NamedKey::ArrowUp), plain, TermInputModes::default()),
+                b"\x1b[A",
+            ),
+            (
+                encode_key(&event(NamedKey::ArrowUp), plain, application),
+                b"\x1bOA",
+            ),
+            (
+                encode_key(&event(NamedKey::Home), plain, application),
+                b"\x1bOH",
+            ),
+            (
+                encode_key(
+                    &event(NamedKey::Tab),
+                    modifiers(true, false, false, false),
+                    TermInputModes::default(),
+                ),
+                b"\x1b[Z",
+            ),
+            (
+                encode_key(
+                    &event(NamedKey::Enter),
+                    modifiers(true, false, false, false),
+                    TermInputModes::default(),
+                ),
+                b"\n",
+            ),
+            (
+                encode_key(&event(NamedKey::Escape), plain, TermInputModes::default()),
+                b"\x1b",
+            ),
+            (
+                encode_key(&event(NamedKey::F20), plain, TermInputModes::default()),
+                b"\x1b[34~",
+            ),
+            (
+                encode_key(&KeyEvent::character("c"), ctrl, TermInputModes::default()),
+                b"\x03",
+            ),
+            (encode_key(&KeyEvent::character("x"), alt, meta), b"\x1bx"),
+            (
+                encode_key(
+                    &KeyEvent::composed("e", "é"),
+                    alt,
+                    TermInputModes::default(),
+                ),
+                "é".as_bytes(),
+            ),
+            (
+                encode_key(
+                    &KeyEvent::composed("e", "é"),
+                    plain,
+                    TermInputModes::default(),
+                ),
+                "é".as_bytes(),
+            ),
+            // A held key is delivered as repeated key-down events. Two
+            // encodes must remain two complete sequences at the PTY boundary.
+            (
+                encode_key(&event(NamedKey::ArrowRight), plain, application),
+                b"\x1bOC",
+            ),
+            (
+                encode_key(&event(NamedKey::ArrowRight), plain, application),
+                b"\x1bOC",
+            ),
+            (paste("a\nb", false), b"a\rb"),
+            (
+                paste("pasted\x1b[31m", true),
+                b"\x1b[200~pasted[31m\x1b[201~",
+            ),
+        ];
+
+        let mut expected = Vec::new();
+        for (actual, expected_case) in &cases {
+            assert_eq!(actual, expected_case);
+            expected.extend_from_slice(expected_case);
+        }
+
+        let count = expected.len().to_string();
+        let script =
+            "stty raw -echo; printf READY; dd bs=1 count=\"$1\" 2>/dev/null | od -An -t u1";
+        let spec = PtySpec::new(
+            vec![
+                "/bin/sh".into(),
+                "-c".into(),
+                script.into(),
+                "zeus-raw-input-fixture".into(),
+                count,
+            ],
+            "/",
+        )
+        .env("PATH", "/usr/bin:/bin");
+        let mut pty = Pty::spawn(&spec).expect("spawn raw PTY fixture");
+        let mut reader = pty.reader().expect("PTY reader");
+        reader.set_nonblocking(true).expect("nonblocking reader");
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut output = Vec::new();
+        while !output.ends_with(b"READY") {
+            assert!(
+                Instant::now() < deadline,
+                "raw PTY fixture never became ready"
+            );
+            match reader.read_to_end(&mut output) {
+                Ok(_) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {}
+                Err(error) => panic!("read raw PTY readiness: {error}"),
+            }
+            std::thread::sleep(Duration::from_millis(2));
+        }
+
+        let mut writer = pty.writer().expect("PTY writer");
+        writer.write_all(&expected).expect("write encoded matrix");
+        writer.flush().expect("flush encoded matrix");
+        reader.set_nonblocking(false).expect("blocking reader");
+        reader
+            .read_to_end(&mut output)
+            .expect("read child byte dump");
+        assert_eq!(
+            pty.wait().expect("wait for raw PTY fixture"),
+            zeus_pty::Exit::Code(0)
+        );
+
+        let received: Vec<u8> = std::str::from_utf8(&output[b"READY".len()..])
+            .expect("od output is ASCII")
+            .split_whitespace()
+            .map(|number| number.parse::<u8>().expect("od byte"))
+            .collect();
+        assert_eq!(received, expected);
     }
 }

--- a/zeus/crates/zeus-term/src/lib.rs
+++ b/zeus/crates/zeus-term/src/lib.rs
@@ -5,6 +5,7 @@ pub mod element;
 pub mod find;
 pub mod keys;
 pub mod metrics;
+pub mod mouse;
 pub mod repaint;
 pub mod scrollback;
 pub mod selection;

--- a/zeus/crates/zeus-term/src/mouse.rs
+++ b/zeus/crates/zeus-term/src/mouse.rs
@@ -1,0 +1,489 @@
+//! Platform-independent terminal mouse report encoding.
+//!
+//! Callers translate their UI toolkit's pointer events into the small Zeus
+//! types here. Cell coordinates are always zero-based; terminal protocols are
+//! converted to their one-based wire representation only while encoding.
+
+use std::iter::repeat_n;
+
+/// Mouse modes currently advertised by the foreground terminal application.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct MouseModes {
+    /// Whether the application requested any mouse reporting.
+    pub reporting: bool,
+    /// SGR extended-coordinate encoding (DECSET 1006).
+    pub sgr: bool,
+    /// UTF-8 extended-coordinate encoding (DECSET 1005).
+    pub utf8: bool,
+    /// Button-motion reporting (DECSET 1002).
+    pub drag: bool,
+    /// All-motion reporting (DECSET 1003).
+    pub motion: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MouseButton {
+    Left,
+    Middle,
+    Right,
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct MouseModifiers {
+    pub shift: bool,
+    pub alt: bool,
+    pub control: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MouseFormat {
+    Sgr,
+    Normal { utf8: bool },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+enum ReportButton {
+    Left = 0,
+    Middle = 1,
+    Right = 2,
+    LeftMove = 32,
+    MiddleMove = 33,
+    RightMove = 34,
+    NoneMove = 35,
+    ScrollUp = 64,
+    ScrollDown = 65,
+}
+
+impl MouseModes {
+    const fn format(self) -> MouseFormat {
+        if self.sgr {
+            MouseFormat::Sgr
+        } else {
+            MouseFormat::Normal { utf8: self.utf8 }
+        }
+    }
+}
+
+impl MouseButton {
+    const fn press_code(self) -> ReportButton {
+        match self {
+            Self::Left => ReportButton::Left,
+            Self::Middle => ReportButton::Middle,
+            Self::Right => ReportButton::Right,
+        }
+    }
+
+    const fn motion_code(self) -> ReportButton {
+        match self {
+            Self::Left => ReportButton::LeftMove,
+            Self::Middle => ReportButton::MiddleMove,
+            Self::Right => ReportButton::RightMove,
+        }
+    }
+}
+
+impl MouseModifiers {
+    const fn wire_bits(self) -> u8 {
+        (if self.shift { 4 } else { 0 })
+            + (if self.alt { 8 } else { 0 })
+            + (if self.control { 16 } else { 0 })
+    }
+}
+
+/// Encodes a button press at a zero-based terminal cell.
+#[must_use]
+pub fn press_report(
+    col: usize,
+    row: usize,
+    button: MouseButton,
+    modifiers: MouseModifiers,
+    modes: MouseModes,
+) -> Option<Vec<u8>> {
+    report(col, row, button.press_code(), true, modifiers, modes)
+}
+
+/// Encodes a button release at a zero-based terminal cell.
+///
+/// SGR identifies the released button and terminates with `m`. Legacy normal
+/// and UTF-8 formats use the protocol's generic release button code 3.
+#[must_use]
+pub fn release_report(
+    col: usize,
+    row: usize,
+    button: MouseButton,
+    modifiers: MouseModifiers,
+    modes: MouseModes,
+) -> Option<Vec<u8>> {
+    report(col, row, button.press_code(), false, modifiers, modes)
+}
+
+/// Encodes pointer motion at a zero-based terminal cell.
+///
+/// `pressed_button` is the button currently held, if any. Drag mode suppresses
+/// unpressed motion; all-motion mode accepts it and emits button code 35.
+#[must_use]
+pub fn motion_report(
+    col: usize,
+    row: usize,
+    pressed_button: Option<MouseButton>,
+    modifiers: MouseModifiers,
+    modes: MouseModes,
+) -> Option<Vec<u8>> {
+    if !modes.reporting || !(modes.drag || modes.motion) {
+        return None;
+    }
+    if modes.drag && pressed_button.is_none() {
+        return None;
+    }
+    let button = pressed_button.map_or(ReportButton::NoneMove, MouseButton::motion_code);
+    report(col, row, button, true, modifiers, modes)
+}
+
+/// Encodes `lines` identical wheel reports at a zero-based terminal cell.
+///
+/// `up` selects X11 wheel button 4; `false` selects button 5. An enabled mode
+/// with zero lines returns an empty iterator, while disabled or out-of-range
+/// coordinates return `None`.
+#[must_use]
+pub fn wheel_reports(
+    col: usize,
+    row: usize,
+    up: bool,
+    lines: usize,
+    modifiers: MouseModifiers,
+    modes: MouseModes,
+) -> Option<impl Iterator<Item = Vec<u8>>> {
+    let button = if up {
+        ReportButton::ScrollUp
+    } else {
+        ReportButton::ScrollDown
+    };
+    let report = report(col, row, button, true, modifiers, modes)?;
+    Some(repeat_n(report, lines))
+}
+
+fn report(
+    col: usize,
+    row: usize,
+    button: ReportButton,
+    pressed: bool,
+    modifiers: MouseModifiers,
+    modes: MouseModes,
+) -> Option<Vec<u8>> {
+    if !modes.reporting {
+        return None;
+    }
+    let modifier_bits = modifiers.wire_bits();
+    match modes.format() {
+        MouseFormat::Sgr => sgr_report(
+            col,
+            row,
+            (button as u8).checked_add(modifier_bits)?,
+            pressed,
+        ),
+        MouseFormat::Normal { utf8 } => {
+            let button = if pressed {
+                (button as u8).checked_add(modifier_bits)?
+            } else {
+                3_u8.checked_add(modifier_bits)?
+            };
+            normal_report(col, row, button, utf8)
+        }
+    }
+}
+
+fn sgr_report(col: usize, row: usize, button: u8, pressed: bool) -> Option<Vec<u8>> {
+    let col = col.checked_add(1)?;
+    let row = row.checked_add(1)?;
+    let terminator = if pressed { 'M' } else { 'm' };
+    Some(format!("\x1b[<{button};{col};{row}{terminator}").into_bytes())
+}
+
+fn normal_report(col: usize, row: usize, button: u8, utf8: bool) -> Option<Vec<u8>> {
+    let max_coordinate = if utf8 { 2015 } else { 223 };
+    if col >= max_coordinate || row >= max_coordinate {
+        return None;
+    }
+
+    let mut report = vec![b'\x1b', b'[', b'M', 32_u8.checked_add(button)?];
+    encode_normal_coordinate(col, utf8, &mut report)?;
+    encode_normal_coordinate(row, utf8, &mut report)?;
+    Some(report)
+}
+
+fn encode_normal_coordinate(coordinate: usize, utf8: bool, output: &mut Vec<u8>) -> Option<()> {
+    let encoded = coordinate.checked_add(33)?;
+    if utf8 && coordinate >= 95 {
+        output.push(u8::try_from(0xc0 + encoded / 64).ok()?);
+        output.push(u8::try_from(0x80 + (encoded & 63)).ok()?);
+    } else {
+        output.push(u8::try_from(encoded).ok()?);
+    }
+    Some(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const NORMAL: MouseModes = MouseModes {
+        reporting: true,
+        sgr: false,
+        utf8: false,
+        drag: false,
+        motion: false,
+    };
+    const SGR: MouseModes = MouseModes {
+        sgr: true,
+        ..NORMAL
+    };
+    const UTF8: MouseModes = MouseModes {
+        utf8: true,
+        ..NORMAL
+    };
+
+    #[test]
+    fn disabled_reporting_suppresses_every_report_kind() {
+        let disabled = MouseModes::default();
+        assert_eq!(
+            press_report(0, 0, MouseButton::Left, MouseModifiers::default(), disabled),
+            None
+        );
+        assert_eq!(
+            release_report(0, 0, MouseButton::Left, MouseModifiers::default(), disabled),
+            None
+        );
+        assert_eq!(
+            motion_report(
+                0,
+                0,
+                Some(MouseButton::Left),
+                MouseModifiers::default(),
+                MouseModes {
+                    drag: true,
+                    ..disabled
+                }
+            ),
+            None
+        );
+        assert!(wheel_reports(0, 0, true, 1, MouseModifiers::default(), disabled).is_none());
+    }
+
+    #[test]
+    fn sgr_press_and_release_keep_button_identity_and_use_one_based_coordinates() {
+        let modifiers = MouseModifiers {
+            shift: true,
+            alt: true,
+            control: true,
+        };
+        assert_eq!(
+            press_report(4, 6, MouseButton::Left, modifiers, SGR),
+            Some(b"\x1b[<28;5;7M".to_vec())
+        );
+        assert_eq!(
+            release_report(4, 6, MouseButton::Right, modifiers, SGR),
+            Some(b"\x1b[<30;5;7m".to_vec())
+        );
+        assert_eq!(
+            press_report(0, 0, MouseButton::Middle, MouseModifiers::default(), SGR),
+            Some(b"\x1b[<1;1;1M".to_vec())
+        );
+    }
+
+    #[test]
+    fn legacy_normal_uses_generic_release_and_modifier_bits() {
+        assert_eq!(
+            press_report(0, 0, MouseButton::Left, MouseModifiers::default(), NORMAL),
+            Some(vec![0x1b, b'[', b'M', 32, 33, 33])
+        );
+        let modifiers = MouseModifiers {
+            shift: true,
+            alt: true,
+            control: true,
+        };
+        assert_eq!(
+            press_report(2, 3, MouseButton::Right, modifiers, NORMAL),
+            Some(vec![0x1b, b'[', b'M', 62, 35, 36])
+        );
+        assert_eq!(
+            release_report(2, 3, MouseButton::Right, modifiers, NORMAL),
+            Some(vec![0x1b, b'[', b'M', 63, 35, 36])
+        );
+    }
+
+    #[test]
+    fn modifier_bits_are_independent() {
+        for (modifiers, expected_code) in [
+            (
+                MouseModifiers {
+                    shift: true,
+                    ..MouseModifiers::default()
+                },
+                4,
+            ),
+            (
+                MouseModifiers {
+                    alt: true,
+                    ..MouseModifiers::default()
+                },
+                8,
+            ),
+            (
+                MouseModifiers {
+                    control: true,
+                    ..MouseModifiers::default()
+                },
+                16,
+            ),
+        ] {
+            assert_eq!(
+                press_report(0, 0, MouseButton::Left, modifiers, SGR),
+                Some(format!("\x1b[<{expected_code};1;1M").into_bytes())
+            );
+            assert_eq!(
+                press_report(0, 0, MouseButton::Left, modifiers, NORMAL),
+                Some(vec![0x1b, b'[', b'M', 32 + expected_code, 33, 33])
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_and_utf8_coordinate_boundaries_match_xterm() {
+        let no_modifiers = MouseModifiers::default();
+        assert_eq!(
+            press_report(222, 222, MouseButton::Left, no_modifiers, NORMAL),
+            Some(vec![0x1b, b'[', b'M', 32, 255, 255])
+        );
+        assert!(press_report(223, 0, MouseButton::Left, no_modifiers, NORMAL).is_none());
+        assert!(press_report(0, 223, MouseButton::Left, no_modifiers, NORMAL).is_none());
+
+        assert_eq!(
+            press_report(94, 94, MouseButton::Left, no_modifiers, UTF8),
+            Some(vec![0x1b, b'[', b'M', 32, 127, 127])
+        );
+        assert_eq!(
+            press_report(95, 95, MouseButton::Left, no_modifiers, UTF8),
+            Some(vec![0x1b, b'[', b'M', 32, 0xc2, 0x80, 0xc2, 0x80])
+        );
+        assert_eq!(
+            press_report(2014, 2014, MouseButton::Left, no_modifiers, UTF8),
+            Some(vec![0x1b, b'[', b'M', 32, 0xdf, 0xbf, 0xdf, 0xbf])
+        );
+        assert!(press_report(2015, 0, MouseButton::Left, no_modifiers, UTF8).is_none());
+        assert!(press_report(0, 2015, MouseButton::Left, no_modifiers, UTF8).is_none());
+    }
+
+    #[test]
+    fn sgr_takes_precedence_and_supports_extended_coordinates() {
+        let modes = MouseModes { utf8: true, ..SGR };
+        assert_eq!(
+            press_report(
+                5_000,
+                6_000,
+                MouseButton::Right,
+                MouseModifiers::default(),
+                modes
+            ),
+            Some(b"\x1b[<2;5001;6001M".to_vec())
+        );
+        assert!(
+            press_report(
+                usize::MAX,
+                0,
+                MouseButton::Left,
+                MouseModifiers::default(),
+                modes
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn motion_distinguishes_drag_and_all_motion_modes() {
+        let drag = MouseModes { drag: true, ..SGR };
+        assert_eq!(
+            motion_report(
+                2,
+                4,
+                Some(MouseButton::Left),
+                MouseModifiers::default(),
+                drag
+            ),
+            Some(b"\x1b[<32;3;5M".to_vec())
+        );
+        assert_eq!(
+            motion_report(2, 4, None, MouseModifiers::default(), drag),
+            None
+        );
+
+        let motion = MouseModes {
+            motion: true,
+            ..SGR
+        };
+        assert_eq!(
+            motion_report(2, 4, None, MouseModifiers::default(), motion),
+            Some(b"\x1b[<35;3;5M".to_vec())
+        );
+        assert_eq!(
+            motion_report(
+                2,
+                4,
+                Some(MouseButton::Middle),
+                MouseModifiers {
+                    control: true,
+                    ..MouseModifiers::default()
+                },
+                motion
+            ),
+            Some(b"\x1b[<49;3;5M".to_vec())
+        );
+        assert_eq!(
+            motion_report(
+                2,
+                4,
+                Some(MouseButton::Right),
+                MouseModifiers::default(),
+                SGR
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn drag_suppression_wins_if_drag_and_motion_are_both_set() {
+        let modes = MouseModes {
+            drag: true,
+            motion: true,
+            ..SGR
+        };
+        assert_eq!(
+            motion_report(0, 0, None, MouseModifiers::default(), modes),
+            None
+        );
+    }
+
+    #[test]
+    fn wheel_reports_repeat_direction_and_modifiers() {
+        let modifiers = MouseModifiers {
+            shift: true,
+            ..MouseModifiers::default()
+        };
+        let up: Vec<_> = wheel_reports(3, 7, true, 3, modifiers, SGR)
+            .expect("mouse reporting is enabled")
+            .collect();
+        assert_eq!(up, vec![b"\x1b[<68;4;8M".to_vec(); 3]);
+
+        let down: Vec<_> = wheel_reports(0, 0, false, 2, MouseModifiers::default(), NORMAL)
+            .expect("mouse reporting is enabled")
+            .collect();
+        assert_eq!(down, vec![vec![0x1b, b'[', b'M', 97, 33, 33]; 2]);
+
+        assert_eq!(
+            wheel_reports(0, 0, true, 0, MouseModifiers::default(), SGR)
+                .expect("enabled zero-line wheel is an empty iterator")
+                .count(),
+            0
+        );
+    }
+}

--- a/zeus/crates/zeus-term/src/scrollback.rs
+++ b/zeus/crates/zeus-term/src/scrollback.rs
@@ -454,6 +454,7 @@ impl ScrollbackViewport {
 pub struct TerminalModes {
     pub alt_screen: bool,
     pub mouse_reporting: bool,
+    pub alternate_scroll: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -476,11 +477,15 @@ pub enum WheelRoute {
     Local {
         lines: i64,
     },
-    Daemon {
-        direction: u8,
+    Mouse {
+        up: bool,
         lines: u16,
         col: u16,
         row: u16,
+    },
+    AlternateScroll {
+        up: bool,
+        lines: u16,
     },
 }
 
@@ -496,16 +501,24 @@ impl ScrollRouter {
             WheelDelta::PrecisePoints(delta) => self.precise_steps(delta, event.line_height),
             WheelDelta::Lines(delta) => classic_steps(delta, event.visible_rows),
         }?;
-        if !modes.alt_screen && !modes.mouse_reporting {
-            return Some(WheelRoute::Local {
-                lines: i64::from(steps),
+        if modes.mouse_reporting {
+            return Some(WheelRoute::Mouse {
+                up: steps > 0,
+                lines: steps.unsigned_abs().min(u16::MAX.into()) as u16,
+                col: event.col,
+                row: event.row,
             });
         }
-        Some(WheelRoute::Daemon {
-            direction: u8::from(steps < 0),
-            lines: steps.unsigned_abs().min(u16::MAX.into()) as u16,
-            col: event.col,
-            row: event.row,
+        if modes.alt_screen {
+            return modes
+                .alternate_scroll
+                .then_some(WheelRoute::AlternateScroll {
+                    up: steps > 0,
+                    lines: steps.unsigned_abs().min(u16::MAX.into()) as u16,
+                });
+        }
+        Some(WheelRoute::Local {
+            lines: i64::from(steps),
         })
     }
 
@@ -895,15 +908,38 @@ mod tests {
                 TerminalModes {
                     alt_screen: false,
                     mouse_reporting: true,
+                    alternate_scroll: false,
                 },
                 event(-12.0),
             ),
-            Some(WheelRoute::Daemon {
-                direction: 1,
+            Some(WheelRoute::Mouse {
+                up: false,
                 lines: 1,
                 col: 3,
                 row: 4,
             })
+        );
+        assert_eq!(
+            router.route(
+                TerminalModes {
+                    alt_screen: true,
+                    mouse_reporting: false,
+                    alternate_scroll: true,
+                },
+                event(12.0),
+            ),
+            Some(WheelRoute::AlternateScroll { up: true, lines: 1 })
+        );
+        assert_eq!(
+            router.route(
+                TerminalModes {
+                    alt_screen: true,
+                    mouse_reporting: false,
+                    alternate_scroll: false,
+                },
+                event(12.0),
+            ),
+            None
         );
     }
 }

--- a/zeus/crates/zeus-term/src/selection.rs
+++ b/zeus/crates/zeus-term/src/selection.rs
@@ -65,6 +65,19 @@ impl TerminalSelection {
         }
     }
 
+    /// Extends a simple selection without moving its existing anchor.
+    ///
+    /// Shift-click with no selection starts an empty selection at the clicked
+    /// point, matching the escape-hatch behavior used by terminals while an
+    /// application owns mouse reporting. A following drag can then extend it.
+    pub fn extend_to(&mut self, point: SelectionPoint) {
+        if self.anchor.is_some() {
+            self.head = Some(point);
+        } else {
+            self.begin(point);
+        }
+    }
+
     pub fn set_from_window(
         &mut self,
         viewport: &ScrollbackViewport,
@@ -115,6 +128,30 @@ impl TerminalSelection {
         self.head = Some(SelectionPoint {
             row: absolute_row,
             col: end,
+        });
+    }
+
+    /// Selects one complete terminal row. The head is the exclusive column
+    /// after the final cell, so extraction and paint spans share exact bounds.
+    pub fn select_line(
+        &mut self,
+        viewport: &ScrollbackViewport,
+        buffer: &GridBuffer,
+        window_row: usize,
+    ) {
+        let cols = usize::from(buffer.cols);
+        if cols == 0 {
+            self.clear();
+            return;
+        }
+        let absolute_row = viewport.absolute_row(window_row);
+        self.anchor = Some(SelectionPoint {
+            row: absolute_row,
+            col: 0,
+        });
+        self.head = Some(SelectionPoint {
+            row: absolute_row,
+            col: cols,
         });
     }
 
@@ -308,5 +345,95 @@ mod tests {
         selection.select_word(&viewport, &buffer, 0, 6);
 
         assert_eq!(selection.selected_text(&viewport, &buffer), "two_three");
+    }
+
+    #[test]
+    fn shift_extension_moves_only_the_head_in_both_directions() {
+        let viewport = ScrollbackViewport::default();
+        let mut buffer = GridBuffer::new(8, 2);
+        buffer.cells = [row("abcdefgh", 8), row("ijklmnop", 8)].concat();
+
+        let forward_anchor = SelectionPoint { row: 0, col: 2 };
+        let mut forward = TerminalSelection::default();
+        forward.begin(forward_anchor);
+        forward.extend_to(SelectionPoint { row: 1, col: 3 });
+        assert_eq!(forward.anchor(), Some(forward_anchor));
+        assert_eq!(forward.head(), Some(SelectionPoint { row: 1, col: 3 }));
+        assert_eq!(forward.selected_text(&viewport, &buffer), "cdefgh\nijk");
+        assert_eq!(
+            forward.visible_spans(&viewport, 2, 8),
+            vec![
+                SelectionSpan {
+                    row: 0,
+                    start_col: 2,
+                    end_col_exclusive: 8,
+                },
+                SelectionSpan {
+                    row: 1,
+                    start_col: 0,
+                    end_col_exclusive: 3,
+                },
+            ]
+        );
+
+        let reverse_anchor = SelectionPoint { row: 1, col: 6 };
+        let mut reverse = TerminalSelection::default();
+        reverse.begin(reverse_anchor);
+        reverse.extend_to(SelectionPoint { row: 0, col: 4 });
+        assert_eq!(reverse.anchor(), Some(reverse_anchor));
+        assert_eq!(reverse.head(), Some(SelectionPoint { row: 0, col: 4 }));
+        assert_eq!(reverse.selected_text(&viewport, &buffer), "efgh\nijklmn");
+        assert_eq!(
+            reverse.visible_spans(&viewport, 2, 8),
+            vec![
+                SelectionSpan {
+                    row: 0,
+                    start_col: 4,
+                    end_col_exclusive: 8,
+                },
+                SelectionSpan {
+                    row: 1,
+                    start_col: 0,
+                    end_col_exclusive: 6,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn shift_extension_without_an_anchor_starts_a_drag_anchor() {
+        let point = SelectionPoint { row: 3, col: 5 };
+        let mut selection = TerminalSelection::default();
+        selection.extend_to(point);
+
+        assert_eq!(selection.anchor(), Some(point));
+        assert_eq!(selection.head(), Some(point));
+        assert_eq!(selection.range(), None);
+    }
+
+    #[test]
+    fn triple_click_selects_one_whole_row_with_an_exclusive_endpoint() {
+        let viewport = ScrollbackViewport::default();
+        let mut buffer = GridBuffer::new(8, 3);
+        buffer.cells = [row("first", 8), row("middle", 8), row("last", 8)].concat();
+        let mut selection = TerminalSelection::default();
+        selection.select_line(&viewport, &buffer, 1);
+
+        assert_eq!(
+            selection.range(),
+            Some(SelectionRange {
+                start: SelectionPoint { row: 1, col: 0 },
+                end: SelectionPoint { row: 1, col: 8 },
+            })
+        );
+        assert_eq!(selection.selected_text(&viewport, &buffer), "middle");
+        assert_eq!(
+            selection.visible_spans(&viewport, 3, 8),
+            vec![SelectionSpan {
+                row: 1,
+                start_col: 0,
+                end_col_exclusive: 8,
+            }]
+        );
     }
 }

--- a/zeus/crates/zeus-terminal-state/src/lib.rs
+++ b/zeus/crates/zeus-terminal-state/src/lib.rs
@@ -21,6 +21,7 @@ use alacritty_terminal::index::{Column, Line};
 use alacritty_terminal::term::cell::{Cell, Flags};
 use alacritty_terminal::term::{Config, Term, TermMode};
 use alacritty_terminal::vte::ansi::{Color, NamedColor, Processor, Rgb};
+use zeus_proto::frames::TerminalModes;
 use zeus_proto::grid::{ChangedRow, GridCell, GridRowCodec, GridUpdate, TermColor, TermStyle};
 
 /// Receiver-side authority for a remote terminal stream. A mirror accepts a
@@ -36,9 +37,7 @@ pub struct GridMirror {
     cursor_row: u16,
     cursor_visible: bool,
     sequence: Option<u64>,
-    alt_screen: bool,
-    bracketed_paste: bool,
-    mouse_reporting: bool,
+    modes: TerminalModes,
 }
 
 impl GridMirror {
@@ -51,9 +50,7 @@ impl GridMirror {
         &mut self,
         sequence: u64,
         grid: &GridUpdate,
-        alt_screen: bool,
-        bracketed_paste: bool,
-        mouse_reporting: bool,
+        modes: TerminalModes,
     ) -> Result<(), MirrorError> {
         if !grid.is_full_snapshot {
             return Err(MirrorError::SnapshotRequired);
@@ -62,9 +59,7 @@ impl GridMirror {
         grid.apply(&mut self.cells);
         self.update_metadata(grid);
         self.sequence = Some(sequence);
-        self.alt_screen = alt_screen;
-        self.bracketed_paste = bracketed_paste;
-        self.mouse_reporting = mouse_reporting;
+        self.modes = modes;
         Ok(())
     }
 
@@ -72,9 +67,7 @@ impl GridMirror {
         &mut self,
         sequence: u64,
         grid: &GridUpdate,
-        alt_screen: bool,
-        bracketed_paste: bool,
-        mouse_reporting: bool,
+        modes: TerminalModes,
     ) -> Result<(), MirrorError> {
         let Some(previous) = self.sequence else {
             return Err(MirrorError::SnapshotRequired);
@@ -95,9 +88,7 @@ impl GridMirror {
         grid.apply(&mut self.cells);
         self.update_metadata(grid);
         self.sequence = Some(sequence);
-        self.alt_screen = alt_screen;
-        self.bracketed_paste = bracketed_paste;
-        self.mouse_reporting = mouse_reporting;
+        self.modes = modes;
         Ok(())
     }
 
@@ -130,8 +121,8 @@ impl GridMirror {
     }
 
     #[must_use]
-    pub const fn modes(&self) -> (bool, bool, bool) {
-        (self.alt_screen, self.bracketed_paste, self.mouse_reporting)
+    pub const fn modes(&self) -> TerminalModes {
+        self.modes
     }
 
     #[must_use]
@@ -395,6 +386,24 @@ impl HeadlessScreen {
             .contains(alacritty_terminal::term::TermMode::BRACKETED_PASTE)
     }
 
+    /// Whether the child enabled DEC application cursor keys (DECCKM).
+    /// Unmodified arrows, Home, and End must use SS3 while this is active.
+    pub fn application_cursor_keys(&self) -> bool {
+        self.term.mode().contains(TermMode::APP_CURSOR)
+    }
+
+    /// Whether wheel input on the alternate screen is translated into
+    /// application-cursor up/down keys (DEC private mode 1007).
+    pub fn alternate_scroll(&self) -> bool {
+        self.term.mode().contains(TermMode::ALTERNATE_SCROLL)
+    }
+
+    /// Whether the child requested focus-in/focus-out reports (DEC private
+    /// mode 1004).
+    pub fn focus_reporting(&self) -> bool {
+        self.term.mode().contains(TermMode::FOCUS_IN_OUT)
+    }
+
     /// The current grid geometry.
     pub fn size(&self) -> (usize, usize) {
         (self.geometry.cols, self.geometry.rows)
@@ -403,6 +412,26 @@ impl HeadlessScreen {
     /// Whether the child asked for mouse reporting (any flavor).
     pub fn mouse_reporting(&self) -> bool {
         self.term.mode().intersects(TermMode::MOUSE_MODE)
+    }
+
+    /// Whether mouse reports use the modern SGR coordinate format.
+    pub fn mouse_sgr(&self) -> bool {
+        self.term.mode().contains(TermMode::SGR_MOUSE)
+    }
+
+    /// Whether legacy mouse reports use UTF-8 extended coordinates.
+    pub fn mouse_utf8(&self) -> bool {
+        self.term.mode().contains(TermMode::UTF8_MOUSE)
+    }
+
+    /// Whether the child requested button-drag motion reports.
+    pub fn mouse_drag(&self) -> bool {
+        self.term.mode().contains(TermMode::MOUSE_DRAG)
+    }
+
+    /// Whether the child requested all pointer motion reports.
+    pub fn mouse_motion(&self) -> bool {
+        self.term.mode().contains(TermMode::MOUSE_MOTION)
     }
 
     /// Cursor (col, row, visible) without touching cell data.
@@ -519,9 +548,7 @@ impl HeadlessScreen {
         &mut self,
         history: &[Vec<GridCell>],
         update: &GridUpdate,
-        alt_screen: bool,
-        bracketed_paste: bool,
-        mouse_reporting: bool,
+        modes: TerminalModes,
     ) -> bool {
         let cols = self.geometry.cols;
         let rows = self.geometry.rows;
@@ -554,7 +581,7 @@ impl HeadlessScreen {
         }
 
         let mut bytes = Vec::with_capacity(cols * rows * 2);
-        if alt_screen {
+        if modes.alt_screen {
             bytes.extend_from_slice(b"\x1b[?1049h");
         }
         bytes.extend_from_slice(b"\x1b[H\x1b[2J");
@@ -590,11 +617,22 @@ impl HeadlessScreen {
         }
 
         bytes.extend_from_slice(b"\x1b[0m");
-        if bracketed_paste {
+        if modes.application_cursor_keys {
+            bytes.extend_from_slice(b"\x1b[?1h");
+        }
+        if modes.bracketed_paste {
             bytes.extend_from_slice(b"\x1b[?2004h");
         }
-        if mouse_reporting {
+        if modes.mouse_reporting {
             bytes.extend_from_slice(b"\x1b[?1000h\x1b[?1006h");
+        }
+        bytes.extend_from_slice(if modes.alternate_scroll {
+            b"\x1b[?1007h"
+        } else {
+            b"\x1b[?1007l"
+        });
+        if modes.focus_reporting {
+            bytes.extend_from_slice(b"\x1b[?1004h");
         }
         bytes.extend_from_slice(if update.cursor_visible {
             b"\x1b[?25h"
@@ -1069,19 +1107,36 @@ mod tests {
     #[test]
     fn a_restored_snapshot_reproduces_the_screen_and_modes() {
         let mut original = HeadlessScreen::new(40, 10);
-        original.feed(b"\x1b[?2004h\x1b[?1000h\x1b[?1006h");
+        original.feed(b"\x1b[?1h\x1b[?2004h\x1b[?1000h\x1b[?1006h\x1b[?1007h\x1b[?1004h");
         original.feed(b"\x1b[1;31mred alert\x1b[0m\r\nplain line\r\n");
         original.feed("wide: ▶ done\r\n".as_bytes());
         let snapshot = original.full_snapshot();
 
         let mut restored = HeadlessScreen::new(40, 10);
         assert!(
-            restored.restore(&[], &snapshot, false, true, true),
+            restored.restore(
+                &[],
+                &snapshot,
+                TerminalModes {
+                    application_cursor_keys: true,
+                    bracketed_paste: true,
+                    mouse_reporting: true,
+                    alternate_scroll: true,
+                    focus_reporting: true,
+                    ..TerminalModes::default()
+                }
+            ),
             "restorable"
         );
         assert_eq!(restored.lines(), original.lines());
         assert!(restored.bracketed_paste(), "bracketed paste mode carried");
+        assert!(
+            restored.application_cursor_keys(),
+            "application cursor mode carried"
+        );
         assert!(restored.mouse_reporting(), "mouse mode carried");
+        assert!(restored.alternate_scroll(), "alternate scroll mode carried");
+        assert!(restored.focus_reporting(), "focus reporting mode carried");
         assert!(!restored.is_alt_screen());
         assert_eq!(restored.cursor(), original.cursor());
         // Attribute fidelity, not just text: the restored grid's cells match.
@@ -1096,7 +1151,7 @@ mod tests {
 
         let mut smaller = HeadlessScreen::new(39, 10);
         assert!(
-            !smaller.restore(&[], &snapshot, false, false, false),
+            !smaller.restore(&[], &snapshot, TerminalModes::default()),
             "a checkpoint from another geometry is a cache miss"
         );
     }
@@ -1114,7 +1169,7 @@ mod tests {
 
         let mut restored = HeadlessScreen::new(12, 2);
         assert!(
-            restored.restore(&history, &snapshot, false, false, false),
+            restored.restore(&history, &snapshot, TerminalModes::default()),
             "restorable"
         );
         assert_eq!(restored.scrollback(), original.scrollback());
@@ -1142,11 +1197,32 @@ mod tests {
         let snapshot = screen.full_snapshot();
         let mut mirror = GridMirror::new();
         mirror
-            .apply_snapshot(9, &snapshot, false, true, false)
+            .apply_snapshot(
+                9,
+                &snapshot,
+                TerminalModes {
+                    application_cursor_keys: true,
+                    bracketed_paste: true,
+                    mouse_reporting: true,
+                    mouse_sgr: true,
+                    mouse_drag: true,
+                    ..TerminalModes::default()
+                },
+            )
             .expect("snapshot");
         assert_eq!(mirror.sequence(), Some(9));
         assert_eq!(mirror.size(), (8, 2));
-        assert_eq!(mirror.modes(), (false, true, false));
+        assert_eq!(
+            mirror.modes(),
+            TerminalModes {
+                application_cursor_keys: true,
+                bracketed_paste: true,
+                mouse_reporting: true,
+                mouse_sgr: true,
+                mouse_drag: true,
+                ..TerminalModes::default()
+            }
+        );
 
         let mut delta_source = HeadlessScreen::new(8, 2);
         delta_source.feed(b"one");
@@ -1154,11 +1230,30 @@ mod tests {
         delta_source.feed(b" two");
         let delta = delta_source.grid_update(false);
         mirror
-            .apply_delta(10, &delta, true, false, true)
+            .apply_delta(
+                10,
+                &delta,
+                TerminalModes {
+                    alt_screen: true,
+                    mouse_reporting: true,
+                    mouse_utf8: true,
+                    mouse_motion: true,
+                    ..TerminalModes::default()
+                },
+            )
             .expect("contiguous delta");
-        assert_eq!(mirror.modes(), (true, false, true));
+        assert_eq!(
+            mirror.modes(),
+            TerminalModes {
+                alt_screen: true,
+                mouse_reporting: true,
+                mouse_utf8: true,
+                mouse_motion: true,
+                ..TerminalModes::default()
+            }
+        );
         assert!(matches!(
-            mirror.apply_delta(12, &delta, false, false, false),
+            mirror.apply_delta(12, &delta, TerminalModes::default()),
             Err(MirrorError::SequenceGap {
                 expected: 11,
                 actual: 12


### PR DESCRIPTION
## Summary

Complete terminal mouse and input-mode handling so local and remote sessions encode the same key, paste, focus, wheel, and pointer input after attach and reconnect.

- Protocol 1.5 carries application-cursor, bracketed-paste, alternate-scroll, focus-reporting, and detailed mouse-reporting state (click, drag, motion, SGR, UTF-8) on snapshots and deltas.
- The app reports SGR/legacy mouse, alternate-scroll, and focus in/out from the live modes instead of a reduced boolean.
- Workbench horizontal layout stays on the settled terminal width so panel slides do not resize the PTY every frame.
- PTY geometry comes only from that settled viewport estimate. A second painted-box measurement disagreed by a few chrome pixels and ping-ponged row/column counts, which flickered the grid with full snapshots.

## Verification

- [x] `./scripts/check.sh` (repo has `check.sh`, not `checks.sh`)
- [x] Sessions still survive app/daemon restart, or migration is documented
- [x] Security/privacy impact considered (processes, IPC, logs, updates, remote)
- [x] User-facing docs updated when behavior or setup changed (`REMOTE_PORT.md`, settings for Option-as-Meta and copy-on-select)
