### PR TITLE
feat(ui): Add contextual file tree to Code inspector

### DIFF
--- a/docs/src/workbench.md
+++ b/docs/src/workbench.md
@@ -61,11 +61,22 @@ conducting.
 |-----|-----|
 | **Info** | Kind, cwd, host, timing, and usage for today / this month |
 | **Review** | Live git diff for this worktree. Stage, commit, and open a PR from here when the repo allows it |
-| **Code** | File viewer bound to the same tree. Word wrap is a Settings toggle |
+| **Code** | Worktree-scoped Changed / All files tree and the existing file viewer. Word wrap is a Settings toggle |
 | **Artifacts** | Ports the session opened, pull requests it mentioned, and other finds |
 
 Review is how Zeus earns the "accept the work" claim. Let the agent finish,
 then read the diff in the same window you used to watch it.
+
+Code opens on **Changed**, using the same staged, working-tree, rename,
+conflict, and untracked status data as Review. Switch to **All files** to browse
+the selected local session's repository; directories load only when expanded,
+and Git-ignored entries stay out of the tree. Opening a path from Review,
+Quick Open, or a terminal reference reveals it in the tree and reuses the same
+viewer below it. `⌘⇧E` opens Code and focuses the tree. Type to filter, use
+`↑` / `↓` to move, `→` / `←` to expand or collapse, Return to open, and Esc
+or Tab to return focus to the viewer. Non-repository sessions can still use
+All files, while Changed explains that Git status is unavailable. Remote
+sessions remain view-only and are not browsed through the local filesystem.
 
 ## Session overview
 

--- a/zeus/crates/zeus-app/src/code_viewer.rs
+++ b/zeus/crates/zeus-app/src/code_viewer.rs
@@ -5,8 +5,9 @@
 //! line targeting, virtualization, and lightweight lexical color.
 
 use std::cell::Cell;
+use std::collections::HashSet;
 use std::ops::Range;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
@@ -23,6 +24,11 @@ use crate::code_intelligence::{
     CodeIntelligence, CodeIntelligenceError, SearchHit, SearchHitKind, SourceLine, SourceSnapshot,
     source_lines,
 };
+use crate::file_tree::{
+    ChangedSnapshot, FileTreeIntent, FileTreeMode, FileTreeModel, FileTreeWorkspace, TreeEntryKind,
+    VisibleTreeRow,
+};
+use crate::git_review::ChangeKind;
 use crate::macos::sf_symbols::{SymbolWeight, sf_symbol, sf_symbol_weighted};
 use crate::query_editor::{self, ClipboardEdit, Edit, LocalEdit, Motion, QueryEditor};
 use zeus_ui::{FloatingSurface, Ink, Metrics, Radius, SemanticColors, Typo};
@@ -32,12 +38,30 @@ use crate::code_intelligence::SourceTarget;
 
 const SOURCE_ROW_HEIGHT: f32 = 20.0;
 const SOURCE_GUTTER_WIDTH: f32 = 52.0;
+const FILE_TREE_HEIGHT: f32 = 226.0;
+const FILE_TREE_ROW_HEIGHT: f32 = 23.0;
+const MAX_DIRECTORY_LOADS: usize = 2;
 
 enum ViewerState {
     Empty,
     Loading { reference: String },
     Ready(Box<SourceDocument>),
     Error { reference: String, message: String },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum TreeWorkspaceState {
+    NoWorkspace,
+    Loading,
+    Ready,
+    Error(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum ChangedTreeState {
+    Loading,
+    Ready { truncated: bool },
+    Unavailable(String),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -366,12 +390,29 @@ pub struct CodeViewer {
     focus: FocusHandle,
     workspace_cwd: Option<PathBuf>,
     intelligence: Option<Arc<CodeIntelligence>>,
+    tree_workspace: Option<Arc<FileTreeWorkspace>>,
+    tree_workspace_state: TreeWorkspaceState,
+    changed_tree_state: ChangedTreeState,
+    tree_model: FileTreeModel,
+    tree_focused: bool,
+    tree_query: QueryEditor,
+    tree_scroll: UniformListScrollHandle,
+    tree_generation: u64,
+    tree_directory_loads: usize,
+    tree_loading_directories: HashSet<PathBuf>,
+    tree_notice: Option<String>,
+    pending_tree_reference: Option<String>,
+    pending_tree_path: Option<PathBuf>,
+    pending_changed_snapshot: Option<ChangedSnapshot>,
+    pending_changed_message: Option<String>,
     state: ViewerState,
     scroll: UniformListScrollHandle,
     generation: u64,
     _load_task: Option<Task<()>>,
     _search_task: Option<Task<()>>,
     _save_task: Option<Task<()>>,
+    _tree_workspace_task: Option<Task<()>>,
+    _tree_reveal_task: Option<Task<()>>,
     search_generation: u64,
     picker_open: bool,
     query: QueryEditor,
@@ -401,12 +442,29 @@ impl CodeViewer {
             focus: cx.focus_handle(),
             workspace_cwd: None,
             intelligence: None,
+            tree_workspace: None,
+            tree_workspace_state: TreeWorkspaceState::NoWorkspace,
+            changed_tree_state: ChangedTreeState::Loading,
+            tree_model: FileTreeModel::default(),
+            tree_focused: false,
+            tree_query: QueryEditor::default(),
+            tree_scroll: UniformListScrollHandle::new(),
+            tree_generation: 0,
+            tree_directory_loads: 0,
+            tree_loading_directories: HashSet::new(),
+            tree_notice: None,
+            pending_tree_reference: None,
+            pending_tree_path: None,
+            pending_changed_snapshot: None,
+            pending_changed_message: None,
             state: ViewerState::Empty,
             scroll: UniformListScrollHandle::new(),
             generation: 0,
             _load_task: None,
             _search_task: None,
             _save_task: None,
+            _tree_workspace_task: None,
+            _tree_reveal_task: None,
             search_generation: 0,
             picker_open: false,
             query: QueryEditor::default(),
@@ -470,6 +528,7 @@ impl CodeViewer {
     fn toggle_picker(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.picker_open = !self.picker_open;
         if self.picker_open {
+            self.tree_focused = false;
             window.focus(&self.focus, cx);
             self.schedule_search(cx);
         } else {
@@ -537,8 +596,28 @@ impl CodeViewer {
     }
 
     fn apply_workspace(&mut self, cwd: Option<PathBuf>, cx: &mut Context<Self>) {
-        self.workspace_cwd = cwd;
+        let pending_changed_snapshot = self.pending_changed_snapshot.take();
+        let pending_changed_message = self.pending_changed_message.take();
+        self.workspace_cwd = cwd.clone();
         self.intelligence = None;
+        self.tree_workspace = None;
+        self.tree_workspace_state = if cwd.is_some() {
+            TreeWorkspaceState::Loading
+        } else {
+            TreeWorkspaceState::NoWorkspace
+        };
+        self.changed_tree_state = ChangedTreeState::Loading;
+        self.tree_model.reset();
+        self.tree_focused = false;
+        self.tree_query.clear();
+        self.tree_scroll = UniformListScrollHandle::new();
+        self.tree_generation = self.tree_generation.wrapping_add(1);
+        self.tree_directory_loads = 0;
+        self.tree_loading_directories.clear();
+        self.tree_notice = None;
+        self.pending_tree_reference = None;
+        self.pending_tree_path = None;
+        self._tree_reveal_task = None;
         self.state = ViewerState::Empty;
         self.scroll = UniformListScrollHandle::new();
         self.generation = self.generation.wrapping_add(1);
@@ -550,7 +629,265 @@ impl CodeViewer {
         self.history.clear();
         self.history_index = 0;
         self.pending_transition = None;
+        if let Some(snapshot) = pending_changed_snapshot {
+            let truncated = snapshot.truncated;
+            self.tree_model.set_changed(snapshot);
+            self.changed_tree_state = ChangedTreeState::Ready { truncated };
+        } else if let Some(message) = pending_changed_message {
+            self.changed_tree_state = ChangedTreeState::Unavailable(message);
+        }
+        if let Some(cwd) = cwd {
+            self.load_tree_workspace(cwd, cx);
+        } else {
+            self._tree_workspace_task = None;
+        }
         cx.notify();
+    }
+
+    /// Review owns Git refresh cadence; Code consumes the exact same parsed
+    /// snapshot rather than invoking or interpreting a second status format.
+    pub fn set_changed_loading(&mut self, cx: &mut Context<Self>) {
+        if self.workspace_transition_pending() {
+            return;
+        }
+        if !matches!(self.changed_tree_state, ChangedTreeState::Ready { .. }) {
+            self.changed_tree_state = ChangedTreeState::Loading;
+            cx.notify();
+        }
+    }
+
+    pub fn set_changed_snapshot(&mut self, snapshot: ChangedSnapshot, cx: &mut Context<Self>) {
+        if self.workspace_transition_pending() {
+            self.pending_changed_snapshot = Some(snapshot);
+            self.pending_changed_message = None;
+            return;
+        }
+        let truncated = snapshot.truncated;
+        self.tree_model.set_changed(snapshot);
+        self.changed_tree_state = ChangedTreeState::Ready { truncated };
+        if let Some(reference) = self.pending_tree_reference.take()
+            && let Some(path) = self.tree_model.changed_reference(&reference)
+        {
+            self.reveal_tree_path(path, cx);
+        }
+        self.scroll_tree_selection();
+        cx.notify();
+    }
+
+    pub fn set_changed_unavailable(&mut self, message: impl Into<String>, cx: &mut Context<Self>) {
+        let message = message.into();
+        if self.workspace_transition_pending() {
+            self.pending_changed_snapshot = None;
+            self.pending_changed_message = Some(message);
+            return;
+        }
+        self.changed_tree_state = ChangedTreeState::Unavailable(message);
+        cx.notify();
+    }
+
+    pub fn focus_file_tree(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.tree_focused = true;
+        self.picker_open = false;
+        window.focus(&self.focus, cx);
+        self.scroll_tree_selection();
+        cx.notify();
+    }
+
+    fn load_tree_workspace(&mut self, cwd: PathBuf, cx: &mut Context<Self>) {
+        let generation = self.tree_generation;
+        self._tree_workspace_task = Some(cx.spawn(async move |this, cx| {
+            let result = cx
+                .background_spawn(async move {
+                    FileTreeWorkspace::for_session(cwd)
+                        .map(Arc::new)
+                        .map_err(|error| error.to_string())
+                })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                if this.tree_generation != generation {
+                    return;
+                }
+                match result {
+                    Ok(workspace) => {
+                        if matches!(this.changed_tree_state, ChangedTreeState::Loading)
+                            && let Some(message) = workspace.changed_unavailable_message()
+                        {
+                            this.changed_tree_state = ChangedTreeState::Unavailable(message);
+                        }
+                        this.tree_workspace = Some(workspace);
+                        this.tree_workspace_state = TreeWorkspaceState::Ready;
+                        if this.tree_model.mode() == FileTreeMode::All {
+                            this.ensure_tree_root(cx);
+                        }
+                        if let Some(path) = this.pending_tree_path.take() {
+                            this.schedule_tree_reveal(path, cx);
+                        }
+                    }
+                    Err(message) => {
+                        this.tree_workspace_state = TreeWorkspaceState::Error(message);
+                    }
+                }
+                cx.notify();
+            });
+        }));
+    }
+
+    fn set_tree_mode(&mut self, mode: FileTreeMode, cx: &mut Context<Self>) {
+        if self.tree_model.mode() == mode {
+            return;
+        }
+        self.tree_model.set_mode(mode);
+        self.tree_scroll = UniformListScrollHandle::new();
+        self.tree_notice = None;
+        if mode == FileTreeMode::All {
+            self.ensure_tree_root(cx);
+        }
+        self.scroll_tree_selection();
+        cx.notify();
+    }
+
+    fn ensure_tree_root(&mut self, cx: &mut Context<Self>) {
+        if !self.tree_model.has_listing(Path::new("")) {
+            self.load_tree_directory(PathBuf::new(), cx);
+        }
+    }
+
+    fn load_tree_directory(&mut self, directory: PathBuf, cx: &mut Context<Self>) {
+        if self.tree_model.has_listing(&directory)
+            || self.tree_loading_directories.contains(&directory)
+            || self.tree_directory_loads >= MAX_DIRECTORY_LOADS
+        {
+            return;
+        }
+        let Some(workspace) = self.tree_workspace.clone() else {
+            if matches!(self.tree_workspace_state, TreeWorkspaceState::Ready) {
+                self.tree_notice = Some("The workspace is unavailable".to_owned());
+            }
+            return;
+        };
+        self.tree_directory_loads += 1;
+        self.tree_loading_directories.insert(directory.clone());
+        self.tree_notice = None;
+        let generation = self.tree_generation;
+        cx.spawn(async move |this, cx| {
+            let task_directory = directory.clone();
+            let result = cx
+                .background_spawn(async move {
+                    workspace
+                        .load_directory(&task_directory)
+                        .map_err(|error| error.to_string())
+                })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                if this.tree_generation != generation {
+                    return;
+                }
+                this.tree_directory_loads = this.tree_directory_loads.saturating_sub(1);
+                this.tree_loading_directories.remove(&directory);
+                match result {
+                    Ok(listing) => {
+                        if listing.truncated {
+                            this.tree_notice = Some(format!(
+                                "{} is capped at {} entries",
+                                if directory.as_os_str().is_empty() {
+                                    ".".to_owned()
+                                } else {
+                                    directory.to_string_lossy().into_owned()
+                                },
+                                crate::file_tree::MAX_DIRECTORY_ENTRIES
+                            ));
+                        }
+                        this.tree_model.insert_listing(listing);
+                        this.scroll_tree_selection();
+                    }
+                    Err(message) => this.tree_notice = Some(message),
+                }
+                cx.notify();
+            });
+        })
+        .detach();
+        cx.notify();
+    }
+
+    fn reveal_tree_path(&mut self, path: PathBuf, cx: &mut Context<Self>) {
+        self.tree_query.clear();
+        self.tree_model.clear_filter();
+        if self.tree_model.changed_contains(&path) {
+            self.tree_model.set_mode(FileTreeMode::Changed);
+            self.tree_model.select_path(path);
+            self.pending_tree_path = None;
+            self.scroll_tree_selection();
+            cx.notify();
+            return;
+        }
+        self.tree_model.set_mode(FileTreeMode::All);
+        self.schedule_tree_reveal(path, cx);
+    }
+
+    fn schedule_tree_reveal(&mut self, path: PathBuf, cx: &mut Context<Self>) {
+        let Some(workspace) = self.tree_workspace.clone() else {
+            self.pending_tree_path = Some(path);
+            return;
+        };
+        self.pending_tree_path = Some(path.clone());
+        self.tree_notice = None;
+        let generation = self.tree_generation;
+        self._tree_reveal_task = Some(cx.spawn(async move |this, cx| {
+            let reveal_path = path.clone();
+            let result = cx
+                .background_spawn(async move {
+                    workspace
+                        .reveal(&reveal_path)
+                        .map_err(|error| error.to_string())
+                })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                if this.tree_generation != generation
+                    || this.pending_tree_path.as_ref() != Some(&path)
+                {
+                    return;
+                }
+                this.pending_tree_path = None;
+                match result {
+                    Ok(listings) => {
+                        for listing in listings {
+                            this.tree_model.insert_listing(listing);
+                        }
+                        this.tree_model.expand_ancestors(&path);
+                        this.tree_model.select_path(path);
+                        this.scroll_tree_selection();
+                    }
+                    Err(message) => this.tree_notice = Some(message),
+                }
+                cx.notify();
+            });
+        }));
+    }
+
+    fn process_tree_intent(&mut self, intent: FileTreeIntent, cx: &mut Context<Self>) {
+        match intent {
+            FileTreeIntent::None => {}
+            FileTreeIntent::OpenFile(path) => {
+                let Some(cwd) = self.workspace_cwd.clone() else {
+                    return;
+                };
+                let reference = path.to_string_lossy().into_owned();
+                self.pending_tree_reference = Some(reference.clone());
+                self.open_reference_inner(cwd, reference, true, cx);
+            }
+            FileTreeIntent::LoadDirectory(directory) => {
+                self.load_tree_directory(directory, cx);
+            }
+        }
+        self.scroll_tree_selection();
+        cx.notify();
+    }
+
+    fn scroll_tree_selection(&self) {
+        if let Some(index) = self.tree_model.selected_index() {
+            self.tree_scroll
+                .scroll_to_item(index, ScrollStrategy::Nearest);
+        }
     }
 
     fn must_preserve_document(&self) -> bool {
@@ -559,6 +896,14 @@ impl CodeViewer {
             ViewerState::Ready(document)
                 if document.is_dirty() || document.save_status == SaveStatus::Saving
         )
+    }
+
+    fn workspace_transition_pending(&self) -> bool {
+        match &self.pending_transition {
+            Some(PendingTransition::Workspace(cwd)) => self.workspace_cwd != *cwd,
+            Some(PendingTransition::Open { cwd, .. }) => self.workspace_cwd.as_ref() != Some(cwd),
+            None => false,
+        }
     }
 
     fn open_highlighted(&mut self, cx: &mut Context<Self>) {
@@ -580,17 +925,80 @@ impl CodeViewer {
         self.open_reference_inner(cwd, reference, true, cx);
     }
 
+    fn handle_tree_key_down(&mut self, event: &KeyDownEvent, cx: &mut Context<Self>) -> bool {
+        match event.keystroke.key.as_str() {
+            "escape" => {
+                if self.tree_query.is_empty() {
+                    self.tree_focused = false;
+                } else {
+                    self.tree_query.clear();
+                    self.tree_model.clear_filter();
+                }
+            }
+            "tab" => self.tree_focused = false,
+            "up" => self.tree_model.move_selection(-1),
+            "down" => self.tree_model.move_selection(1),
+            "left" => self.tree_model.collapse_selected(),
+            "right" => {
+                let intent = self.tree_model.expand_selected();
+                self.process_tree_intent(intent, cx);
+            }
+            "enter" => {
+                let intent = self.tree_model.activate_selected();
+                self.process_tree_intent(intent, cx);
+            }
+            _ => {
+                let Some(edit) = query_editor::edit_for(&event.keystroke) else {
+                    return false;
+                };
+                let changed = match edit {
+                    Edit::Local(local) => self.tree_query.apply(local),
+                    Edit::Clipboard(ClipboardEdit::Copy) => {
+                        query_editor::copy_selection(&self.tree_query, cx);
+                        false
+                    }
+                    Edit::Clipboard(ClipboardEdit::Cut) => {
+                        query_editor::cut_selection(&mut self.tree_query, cx)
+                    }
+                    Edit::Clipboard(ClipboardEdit::Paste) => cx
+                        .read_from_clipboard()
+                        .and_then(|item| item.text())
+                        .is_some_and(|text| self.tree_query.insert(&text)),
+                };
+                if changed {
+                    self.tree_model.set_filter(self.tree_query.text());
+                }
+            }
+        }
+        self.scroll_tree_selection();
+        cx.notify();
+        true
+    }
+
     fn handle_key_down(
         &mut self,
         event: &KeyDownEvent,
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if event.keystroke.modifiers.platform
+            && event.keystroke.modifiers.shift
+            && event.keystroke.key == "e"
+        {
+            self.focus_file_tree(_window, cx);
+            cx.stop_propagation();
+            return;
+        }
         if event.keystroke.modifiers.platform && event.keystroke.key == "s" {
             if matches!(self.state, ViewerState::Ready(_)) {
                 self.save_document(cx);
                 cx.stop_propagation();
             }
+            return;
+        }
+
+        if self.tree_focused && self.handle_tree_key_down(event, cx) {
+            cx.stop_propagation();
             return;
         }
 
@@ -821,6 +1229,10 @@ impl CodeViewer {
         if self.workspace_cwd.as_ref() != Some(&cwd) {
             self.set_workspace(Some(cwd.clone()), cx);
         }
+        self.pending_tree_reference = Some(reference.clone());
+        if let Some(path) = self.tree_model.changed_reference(&reference) {
+            self.reveal_tree_path(path, cx);
+        }
         self.open_reference_inner(cwd, reference, true, cx);
     }
 
@@ -883,6 +1295,7 @@ impl CodeViewer {
                     Ok((intelligence, snapshot)) => {
                         this.workspace_cwd = Some(history_cwd.clone());
                         this.intelligence = Some(Arc::new(intelligence));
+                        let revealed_path = snapshot.relative_path.clone();
                         let target_line = snapshot.target.map(|target| target.line);
                         if record_history {
                             if this.history_index + 1 < this.history.len() {
@@ -908,6 +1321,7 @@ impl CodeViewer {
                             this.scroll.scroll_to_item(item, ScrollStrategy::Center);
                         }
                         this.state = ViewerState::Ready(Box::new(document));
+                        this.reveal_tree_path(revealed_path, cx);
                     }
                     Err(message) => {
                         this.state = ViewerState::Error { reference, message };
@@ -928,7 +1342,12 @@ impl CodeViewer {
                 cwd,
                 reference,
                 record_history,
-            } => self.begin_open_reference(cwd, reference, record_history, cx),
+            } => {
+                if self.workspace_cwd.as_ref() != Some(&cwd) {
+                    self.apply_workspace(Some(cwd.clone()), cx);
+                }
+                self.begin_open_reference(cwd, reference, record_history, cx);
+            }
         }
     }
 
@@ -946,6 +1365,242 @@ impl CodeViewer {
         self.history_index = next;
         let (cwd, reference) = self.history[next].clone();
         self.open_reference_inner(cwd, reference, false, cx);
+    }
+
+    fn render_tree_mode_option(
+        &self,
+        mode: FileTreeMode,
+        label: String,
+        colors: SemanticColors,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let selected = self.tree_model.mode() == mode;
+        div()
+            .id(match mode {
+                FileTreeMode::Changed => "code-tree-changed",
+                FileTreeMode::All => "code-tree-all",
+            })
+            .h(px(23.0))
+            .px(px(7.0))
+            .flex()
+            .items_center()
+            .rounded(px(Radius::CHIP))
+            .bg(if selected {
+                colors.primary.alpha(0.10)
+            } else {
+                colors.primary.alpha(0.0)
+            })
+            .cursor_pointer()
+            .hover(move |button| button.bg(colors.primary.alpha(0.08)))
+            .text_size(px(9.5))
+            .font_weight(if selected {
+                FontWeight::SEMIBOLD
+            } else {
+                FontWeight::MEDIUM
+            })
+            .text_color(if selected {
+                colors.primary
+            } else {
+                colors.tertiary
+            })
+            .child(label)
+            .on_click(cx.listener(move |this, _, window, cx| {
+                this.focus_file_tree(window, cx);
+                this.set_tree_mode(mode, cx);
+                cx.stop_propagation();
+            }))
+            .into_any_element()
+    }
+
+    fn render_file_tree(
+        &self,
+        colors: SemanticColors,
+        window: &Window,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let rows = self.tree_model.rows_arc();
+        let selected = self.tree_model.selected_path().map(Path::to_path_buf);
+        let tree = cx.entity();
+        let row_count = rows.len();
+        let body = if rows.is_empty() {
+            let filtering = !self.tree_query.is_empty();
+            let message = if filtering {
+                "No loaded files match this filter".to_owned()
+            } else {
+                match self.tree_model.mode() {
+                    FileTreeMode::Changed => match &self.changed_tree_state {
+                        ChangedTreeState::Loading => "Reading Git status…".to_owned(),
+                        ChangedTreeState::Ready { .. } => "No changed files".to_owned(),
+                        ChangedTreeState::Unavailable(message) => message.clone(),
+                    },
+                    FileTreeMode::All => match &self.tree_workspace_state {
+                        TreeWorkspaceState::NoWorkspace => "Select a local session".to_owned(),
+                        TreeWorkspaceState::Loading => "Locating the workspace…".to_owned(),
+                        TreeWorkspaceState::Error(message) => message.clone(),
+                        TreeWorkspaceState::Ready
+                            if self.tree_loading_directories.contains(Path::new("")) =>
+                        {
+                            "Loading repository root…".to_owned()
+                        }
+                        TreeWorkspaceState::Ready => "This directory is empty".to_owned(),
+                    },
+                }
+            };
+            div()
+                .size_full()
+                .px(px(18.0))
+                .flex()
+                .items_center()
+                .justify_center()
+                .text_center()
+                .text_size(px(10.0))
+                .text_color(colors.tertiary)
+                .child(message)
+                .into_any_element()
+        } else {
+            let visible_rows = Arc::clone(&rows);
+            uniform_list("code-file-tree-rows", row_count, move |range, _, cx| {
+                range
+                    .map(|index| {
+                        let row = visible_rows[index].clone();
+                        let expanded = row.kind == TreeEntryKind::Directory
+                            && tree.read(cx).tree_model.is_expanded(&row.relative_path);
+                        render_file_tree_row(
+                            row,
+                            index,
+                            selected.as_ref(),
+                            expanded,
+                            colors,
+                            tree.clone(),
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .track_scroll(&self.tree_scroll)
+            .size_full()
+            .into_any_element()
+        };
+        let changed_label = format!("Changed {}", self.tree_model.changed_count());
+        let query = if self.tree_query.is_empty() {
+            div()
+                .text_color(colors.tertiary)
+                .child("Filter files  ·  ⌘⇧E")
+                .into_any_element()
+        } else {
+            crate::navigation::query_label(&self.tree_query)
+        };
+        let root = self
+            .tree_workspace
+            .as_ref()
+            .and_then(|workspace| workspace.root().file_name())
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "Workspace".to_owned());
+        let notice = self.tree_notice.clone().or_else(|| {
+            matches!(
+                self.changed_tree_state,
+                ChangedTreeState::Ready { truncated: true }
+            )
+            .then(|| {
+                format!(
+                    "Changed files capped at {}",
+                    crate::file_tree::MAX_VISIBLE_ROWS
+                )
+            })
+        });
+        let focused = self.tree_focused && self.focus.is_focused(window);
+
+        div()
+            .h(px(FILE_TREE_HEIGHT))
+            .flex_none()
+            .flex()
+            .flex_col()
+            .border_b_1()
+            .border_color(colors.primary.alpha(0.09))
+            .bg(colors.background)
+            .child(
+                div()
+                    .h(px(32.0))
+                    .flex_none()
+                    .px(px(8.0))
+                    .flex()
+                    .items_center()
+                    .gap(px(2.0))
+                    .child(self.render_tree_mode_option(
+                        FileTreeMode::Changed,
+                        changed_label,
+                        colors,
+                        cx,
+                    ))
+                    .child(self.render_tree_mode_option(
+                        FileTreeMode::All,
+                        "All files".to_owned(),
+                        colors,
+                        cx,
+                    ))
+                    .child(
+                        div()
+                            .ml(px(4.0))
+                            .min_w(px(0.0))
+                            .flex_1()
+                            .truncate()
+                            .text_right()
+                            .text_size(px(9.0))
+                            .text_color(colors.primary.alpha(0.28))
+                            .child(root),
+                    ),
+            )
+            .child(
+                div()
+                    .id("code-tree-filter")
+                    .h(px(30.0))
+                    .mx(px(8.0))
+                    .mb(px(4.0))
+                    .px(px(8.0))
+                    .flex_none()
+                    .flex()
+                    .items_center()
+                    .gap(px(6.0))
+                    .rounded(px(Radius::CHIP))
+                    .bg(colors.primary.alpha(if focused { 0.065 } else { 0.035 }))
+                    .border_1()
+                    .border_color(colors.primary.alpha(if focused { 0.16 } else { 0.055 }))
+                    .cursor_text()
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(|this, _, window, cx| {
+                            this.focus_file_tree(window, cx);
+                            cx.stop_propagation();
+                        }),
+                    )
+                    .child(sf_symbol("magnifyingglass", 9.5, colors.tertiary))
+                    .child(
+                        div()
+                            .min_w(px(0.0))
+                            .flex_1()
+                            .font_family(crate::fonts::mono_family())
+                            .text_size(px(10.0))
+                            .text_color(colors.primary)
+                            .child(query),
+                    ),
+            )
+            .child(div().min_h(px(0.0)).flex_1().overflow_hidden().child(body))
+            .when_some(notice, |tree, notice| {
+                tree.child(
+                    div()
+                        .h(px(22.0))
+                        .flex_none()
+                        .px(px(9.0))
+                        .flex()
+                        .items_center()
+                        .truncate()
+                        .border_t_1()
+                        .border_color(colors.primary.alpha(0.055))
+                        .text_size(px(8.5))
+                        .text_color(Ink::ATTENTION)
+                        .child(notice),
+                )
+            })
+            .into_any_element()
     }
 
     fn render_toolbar(
@@ -1501,6 +2156,113 @@ impl Focusable for CodeViewer {
     }
 }
 
+fn render_file_tree_row(
+    row: VisibleTreeRow,
+    index: usize,
+    selected: Option<&PathBuf>,
+    expanded: bool,
+    colors: SemanticColors,
+    tree: gpui::Entity<CodeViewer>,
+) -> AnyElement {
+    let is_selected = selected == Some(&row.relative_path);
+    let path = row.relative_path.clone();
+    let kind = row.kind;
+    let status = row.status.clone();
+    let status_badge = status.as_ref().map(|status| {
+        let color = file_status_color(status.primary_kind());
+        div()
+            .flex_none()
+            .font_family(crate::fonts::mono_family())
+            .text_size(px(8.5))
+            .font_weight(FontWeight::SEMIBOLD)
+            .text_color(color)
+            .child(status.decoration())
+            .into_any_element()
+    });
+    div()
+        .id(("code-file-tree-row", index))
+        .h(px(FILE_TREE_ROW_HEIGHT))
+        .w_full()
+        .pl(px(7.0 + row.depth as f32 * 13.0))
+        .pr(px(8.0))
+        .flex()
+        .items_center()
+        .gap(px(5.0))
+        .bg(if is_selected {
+            colors.primary.alpha(0.085)
+        } else {
+            colors.primary.alpha(0.0)
+        })
+        .cursor_pointer()
+        .hover(move |item| item.bg(colors.primary.alpha(0.065)))
+        .child(
+            div()
+                .w(px(10.0))
+                .flex_none()
+                .flex()
+                .items_center()
+                .justify_center()
+                .when(kind == TreeEntryKind::Directory, |slot| {
+                    slot.child(sf_symbol(
+                        if expanded {
+                            "chevron.down"
+                        } else {
+                            "chevron.right"
+                        },
+                        7.5,
+                        colors.tertiary,
+                    ))
+                }),
+        )
+        .child(sf_symbol(
+            if kind == TreeEntryKind::Directory {
+                if expanded { "folder.fill" } else { "folder" }
+            } else {
+                "doc.text"
+            },
+            10.5,
+            if kind == TreeEntryKind::Directory {
+                colors.secondary
+            } else {
+                colors.tertiary
+            },
+        ))
+        .child(
+            div()
+                .min_w(px(0.0))
+                .flex_1()
+                .truncate()
+                .font_family(crate::fonts::mono_family())
+                .text_size(px(9.5))
+                .text_color(if is_selected {
+                    colors.primary
+                } else {
+                    colors.secondary
+                })
+                .child(row.label),
+        )
+        .when_some(status_badge, |item, badge| item.child(badge))
+        .on_click(move |_, window, cx| {
+            tree.update(cx, |this, cx| {
+                this.focus_file_tree(window, cx);
+                this.tree_model.select_path(path.clone());
+                let intent = this.tree_model.activate_selected();
+                this.process_tree_intent(intent, cx);
+            });
+            cx.stop_propagation();
+        })
+        .into_any_element()
+}
+
+fn file_status_color(kind: ChangeKind) -> gpui::Rgba {
+    match kind {
+        ChangeKind::Added => Ink::FRESH,
+        ChangeKind::Deleted | ChangeKind::Unmerged => Ink::DANGER,
+        ChangeKind::Renamed | ChangeKind::Copied => rgba(0xc792eaff),
+        ChangeKind::Modified | ChangeKind::TypeChanged | ChangeKind::Unknown(_) => Ink::ATTENTION,
+    }
+}
+
 impl Render for CodeViewer {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let colors = SemanticColors::dark();
@@ -1547,6 +2309,7 @@ impl Render for CodeViewer {
                 MouseButton::Left,
                 cx.listener(|this, _, _, _| this.selection_dragging = false),
             )
+            .child(self.render_file_tree(colors, window, cx))
             .child(self.render_toolbar(document, colors, cx))
             .child(div().min_h(px(0.0)).flex_1().overflow_hidden().child(body))
             .when_some(picker, |viewer, picker| viewer.child(picker))
@@ -1760,6 +2523,7 @@ fn source_row(
                     click_range.start + source_offset_at_x(&source, x, colors.primary, window);
                 click_editor.update(cx, |this, cx| {
                     window.focus(&this.focus, cx);
+                    this.tree_focused = false;
                     this.selection_dragging = true;
                     this.place_cursor(
                         line_index,

--- a/zeus/crates/zeus-app/src/file_tree.rs
+++ b/zeus/crates/zeus-app/src/file_tree.rs
@@ -1,0 +1,980 @@
+//! Worktree-scoped data model for the Code inspector's contextual file tree.
+//!
+//! The UI crosses two blocking seams: discover one workspace, then read one
+//! directory (or the ancestor chain required by an explicit reveal). Changed
+//! rows are projections of Review's porcelain-v2 [`ReviewStatus`], so Code and
+//! Review cannot disagree about staged, working, rename, conflict, or
+//! untracked semantics. Traversal is lazy, Git-ignore-aware, symlink-safe, and
+//! bounded before it reaches GPUI.
+
+use std::collections::{BTreeMap, HashSet};
+use std::ffi::OsStr;
+use std::fmt;
+use std::fs;
+use std::io;
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+
+use crate::git_review::{ChangeKind, GitRepository, GitReviewError, ReviewStatus};
+
+pub const MAX_DIRECTORY_ENTRIES: usize = 2_000;
+pub const MAX_DIRECTORY_SCAN: usize = 10_000;
+pub const MAX_VISIBLE_ROWS: usize = 20_000;
+pub const MAX_REVEAL_DEPTH: usize = 64;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum FileTreeMode {
+    #[default]
+    Changed,
+    All,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TreeEntryKind {
+    Directory,
+    File,
+}
+
+#[derive(Clone, Debug)]
+pub struct FileTreeWorkspace {
+    root: PathBuf,
+    repository: Option<GitRepository>,
+    repository_error: Option<String>,
+}
+
+impl FileTreeWorkspace {
+    pub fn for_session(cwd: impl AsRef<Path>) -> Result<Self, FileTreeError> {
+        let requested = cwd.as_ref();
+        let canonical =
+            fs::canonicalize(requested).map_err(|error| FileTreeError::Unavailable {
+                path: requested.to_path_buf(),
+                message: error.to_string(),
+            })?;
+        let session_cwd = if canonical.is_file() {
+            canonical
+                .parent()
+                .map(Path::to_path_buf)
+                .ok_or_else(|| FileTreeError::Unavailable {
+                    path: canonical.clone(),
+                    message: "the session path has no parent directory".to_owned(),
+                })?
+        } else if canonical.is_dir() {
+            canonical
+        } else {
+            return Err(FileTreeError::Unavailable {
+                path: canonical,
+                message: "the session path is not a directory".to_owned(),
+            });
+        };
+
+        match GitRepository::discover(&session_cwd) {
+            Ok(repository) => Ok(Self {
+                root: repository.root().to_path_buf(),
+                repository: Some(repository),
+                repository_error: None,
+            }),
+            Err(GitReviewError::NotRepository(_)) => Ok(Self {
+                root: session_cwd,
+                repository: None,
+                repository_error: None,
+            }),
+            Err(error) => Ok(Self {
+                root: session_cwd,
+                repository: None,
+                repository_error: Some(error.to_string()),
+            }),
+        }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn changed_unavailable_message(&self) -> Option<String> {
+        self.repository_error.clone().or_else(|| {
+            self.repository.is_none().then(|| {
+                "This session is not inside a Git repository. All files is still available."
+                    .to_owned()
+            })
+        })
+    }
+
+    pub fn load_directory(&self, directory: &Path) -> Result<DirectoryListing, FileTreeError> {
+        self.load_directory_with_limits(directory, MAX_DIRECTORY_ENTRIES, MAX_DIRECTORY_SCAN)
+    }
+
+    fn load_directory_with_limits(
+        &self,
+        directory: &Path,
+        entry_limit: usize,
+        scan_limit: usize,
+    ) -> Result<DirectoryListing, FileTreeError> {
+        validate_relative(directory, true)?;
+        let absolute = self.root.join(directory);
+        let metadata = fs::symlink_metadata(&absolute)
+            .map_err(|error| directory_error(directory, "inspect", error))?;
+        if metadata.file_type().is_symlink() || !metadata.is_dir() {
+            return Err(FileTreeError::NotDirectory(directory.to_path_buf()));
+        }
+        let canonical = fs::canonicalize(&absolute)
+            .map_err(|error| directory_error(directory, "resolve", error))?;
+        if !canonical.starts_with(&self.root) {
+            return Err(FileTreeError::OutsideWorkspace(canonical));
+        }
+
+        let reader =
+            fs::read_dir(&absolute).map_err(|error| directory_error(directory, "read", error))?;
+        let mut candidates = Vec::new();
+        let mut truncated = false;
+        for (scanned, entry) in reader.enumerate() {
+            if scanned >= scan_limit {
+                truncated = true;
+                break;
+            }
+            let entry = entry.map_err(|error| directory_error(directory, "read", error))?;
+            let name = entry.file_name();
+            if name == OsStr::new(".git") {
+                continue;
+            }
+            let file_type = entry
+                .file_type()
+                .map_err(|error| directory_error(directory, "inspect an entry in", error))?;
+            if file_type.is_symlink() {
+                continue;
+            }
+            let kind = if file_type.is_dir() {
+                TreeEntryKind::Directory
+            } else if file_type.is_file() {
+                TreeEntryKind::File
+            } else {
+                continue;
+            };
+            let relative_path = directory.join(&name);
+            candidates.push(DirectoryEntry {
+                relative_path,
+                name: name.to_string_lossy().into_owned(),
+                kind,
+            });
+        }
+
+        if let Some(repository) = &self.repository {
+            let paths: Vec<_> = candidates
+                .iter()
+                .map(|entry| entry.relative_path.clone())
+                .collect();
+            let ignored = repository.ignored_paths(&paths)?;
+            candidates.retain(|entry| !ignored.contains(&entry.relative_path));
+        }
+        candidates.sort_by(|left, right| {
+            left.kind
+                .cmp(&right.kind)
+                .then_with(|| left.relative_path.cmp(&right.relative_path))
+        });
+        if candidates.len() > entry_limit {
+            candidates.truncate(entry_limit);
+            truncated = true;
+        }
+        Ok(DirectoryListing {
+            directory: directory.to_path_buf(),
+            entries: candidates,
+            truncated,
+        })
+    }
+
+    /// Loads only the directories needed to expose `relative_path`.
+    pub fn reveal(&self, relative_path: &Path) -> Result<Vec<DirectoryListing>, FileTreeError> {
+        validate_relative(relative_path, false)?;
+        let parent = relative_path.parent().unwrap_or_else(|| Path::new(""));
+        let mut directories = vec![PathBuf::new()];
+        let mut current = PathBuf::new();
+        for component in parent.components() {
+            let Component::Normal(component) = component else {
+                return Err(FileTreeError::UnsafePath(relative_path.to_path_buf()));
+            };
+            current.push(component);
+            directories.push(current.clone());
+            if directories.len() > MAX_REVEAL_DEPTH {
+                return Err(FileTreeError::RevealTooDeep {
+                    path: relative_path.to_path_buf(),
+                    limit: MAX_REVEAL_DEPTH,
+                });
+            }
+        }
+
+        let mut listings = Vec::with_capacity(directories.len());
+        for (index, directory) in directories.iter().enumerate() {
+            let listing = self.load_directory(directory)?;
+            let wanted = directories
+                .get(index + 1)
+                .map_or(relative_path, PathBuf::as_path);
+            if !listing
+                .entries
+                .iter()
+                .any(|entry| entry.relative_path == wanted)
+            {
+                return Err(FileTreeError::RevealUnavailable {
+                    path: relative_path.to_path_buf(),
+                    directory: directory.clone(),
+                    truncated: listing.truncated,
+                });
+            }
+            listings.push(listing);
+        }
+        Ok(listings)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DirectoryEntry {
+    pub relative_path: PathBuf,
+    pub name: String,
+    pub kind: TreeEntryKind,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DirectoryListing {
+    pub directory: PathBuf,
+    pub entries: Vec<DirectoryEntry>,
+    pub truncated: bool,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct FileStatus {
+    pub staged: Option<ChangeKind>,
+    pub working: Option<ChangeKind>,
+    pub untracked: bool,
+    pub conflicted: bool,
+    pub original_path: Option<PathBuf>,
+}
+
+impl FileStatus {
+    /// Two-column Git decoration: index first, working tree second.
+    pub fn decoration(&self) -> String {
+        if self.conflicted {
+            return "UU".to_owned();
+        }
+        if self.untracked {
+            return "??".to_owned();
+        }
+        format!(
+            "{}{}",
+            self.staged.map_or('·', change_code),
+            self.working.map_or('·', change_code)
+        )
+    }
+
+    pub fn primary_kind(&self) -> ChangeKind {
+        if self.conflicted {
+            ChangeKind::Unmerged
+        } else if self.untracked {
+            ChangeKind::Added
+        } else {
+            self.working
+                .or(self.staged)
+                .unwrap_or(ChangeKind::Unknown('?'))
+        }
+    }
+}
+
+fn change_code(kind: ChangeKind) -> char {
+    match kind {
+        ChangeKind::Added => 'A',
+        ChangeKind::Modified => 'M',
+        ChangeKind::Deleted => 'D',
+        ChangeKind::Renamed => 'R',
+        ChangeKind::Copied => 'C',
+        ChangeKind::TypeChanged => 'T',
+        ChangeKind::Unmerged => 'U',
+        ChangeKind::Unknown(value) => value,
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChangedFile {
+    pub relative_path: PathBuf,
+    pub status: FileStatus,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ChangedSnapshot {
+    pub repo_root: PathBuf,
+    pub files: Vec<ChangedFile>,
+    pub truncated: bool,
+    rows: Arc<Vec<VisibleTreeRow>>,
+}
+
+impl From<&ReviewStatus> for ChangedSnapshot {
+    fn from(status: &ReviewStatus) -> Self {
+        let mut files: BTreeMap<PathBuf, FileStatus> = BTreeMap::new();
+        for change in &status.staged {
+            let entry = files.entry(change.path.clone()).or_default();
+            entry.staged = Some(change.kind);
+            entry.original_path = change.original_path.clone();
+        }
+        for change in &status.unstaged {
+            let entry = files.entry(change.path.clone()).or_default();
+            entry.working = Some(change.kind);
+            if change.original_path.is_some() {
+                entry.original_path = change.original_path.clone();
+            }
+        }
+        for change in &status.untracked {
+            let entry = files.entry(change.path.clone()).or_default();
+            entry.untracked = true;
+        }
+        for change in &status.conflicted {
+            let entry = files.entry(change.path.clone()).or_default();
+            entry.conflicted = true;
+            entry.original_path = change.original_path.clone();
+        }
+        let truncated = files.len() > MAX_VISIBLE_ROWS;
+        let files: Vec<ChangedFile> = files
+            .into_iter()
+            .take(MAX_VISIBLE_ROWS)
+            .map(|(relative_path, status)| ChangedFile {
+                relative_path,
+                status,
+            })
+            .collect();
+        let rows = Arc::new(
+            files
+                .iter()
+                .map(|file| VisibleTreeRow {
+                    relative_path: file.relative_path.clone(),
+                    label: file.relative_path.to_string_lossy().into_owned(),
+                    depth: 0,
+                    kind: TreeEntryKind::File,
+                    status: Some(file.status.clone()),
+                })
+                .collect(),
+        );
+        Self {
+            repo_root: status.repo_root.clone(),
+            files,
+            truncated,
+            rows,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VisibleTreeRow {
+    pub relative_path: PathBuf,
+    pub label: String,
+    pub depth: usize,
+    pub kind: TreeEntryKind,
+    pub status: Option<FileStatus>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FileTreeIntent {
+    None,
+    OpenFile(PathBuf),
+    LoadDirectory(PathBuf),
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct FileTreeModel {
+    mode: FileTreeMode,
+    filter: String,
+    changed: Vec<ChangedFile>,
+    changed_rows: Arc<Vec<VisibleTreeRow>>,
+    listings: BTreeMap<PathBuf, DirectoryListing>,
+    expanded: HashSet<PathBuf>,
+    selected: Option<PathBuf>,
+}
+
+impl FileTreeModel {
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+
+    pub const fn mode(&self) -> FileTreeMode {
+        self.mode
+    }
+
+    pub fn set_mode(&mut self, mode: FileTreeMode) {
+        self.mode = mode;
+        self.ensure_selection();
+    }
+
+    pub fn set_filter(&mut self, filter: impl Into<String>) {
+        self.filter = filter.into();
+        self.ensure_selection();
+    }
+
+    pub fn clear_filter(&mut self) {
+        self.filter.clear();
+        self.ensure_selection();
+    }
+
+    pub fn set_changed(&mut self, snapshot: ChangedSnapshot) {
+        self.changed = snapshot.files;
+        self.changed_rows = snapshot.rows;
+        self.ensure_selection();
+    }
+
+    pub fn changed_count(&self) -> usize {
+        self.changed.len()
+    }
+
+    pub fn changed_contains(&self, path: &Path) -> bool {
+        self.changed.iter().any(|file| file.relative_path == path)
+    }
+
+    pub fn changed_reference(&self, reference: &str) -> Option<PathBuf> {
+        let normalized = reference.replace('\\', "/");
+        self.changed
+            .iter()
+            .filter_map(|file| {
+                let path = file.relative_path.to_string_lossy().replace('\\', "/");
+                normalized
+                    .contains(&path)
+                    .then_some((path.len(), file.relative_path.clone()))
+            })
+            .max_by_key(|(length, _)| *length)
+            .map(|(_, path)| path)
+    }
+
+    pub fn has_listing(&self, directory: &Path) -> bool {
+        self.listings.contains_key(directory)
+    }
+
+    pub fn insert_listing(&mut self, listing: DirectoryListing) {
+        self.listings.insert(listing.directory.clone(), listing);
+        self.ensure_selection();
+    }
+
+    pub fn expand_ancestors(&mut self, path: &Path) {
+        let mut current = PathBuf::new();
+        if let Some(parent) = path.parent() {
+            for component in parent.components() {
+                if let Component::Normal(component) = component {
+                    current.push(component);
+                    self.expanded.insert(current.clone());
+                }
+            }
+        }
+    }
+
+    pub fn select_path(&mut self, path: impl Into<PathBuf>) {
+        self.selected = Some(path.into());
+        self.ensure_selection();
+    }
+
+    pub fn selected_path(&self) -> Option<&Path> {
+        self.selected.as_deref()
+    }
+
+    pub fn selected_index(&self) -> Option<usize> {
+        let selected = self.selected.as_ref()?;
+        self.rows_arc()
+            .iter()
+            .position(|row| &row.relative_path == selected)
+    }
+
+    pub fn move_selection(&mut self, delta: isize) {
+        let rows = self.rows();
+        if rows.is_empty() {
+            self.selected = None;
+            return;
+        }
+        let current = self
+            .selected
+            .as_ref()
+            .and_then(|path| rows.iter().position(|row| &row.relative_path == path))
+            .unwrap_or(0);
+        let next = current
+            .saturating_add_signed(delta)
+            .min(rows.len().saturating_sub(1));
+        self.selected = Some(rows[next].relative_path.clone());
+    }
+
+    pub fn activate_selected(&mut self) -> FileTreeIntent {
+        let Some(row) = self.selected_row() else {
+            return FileTreeIntent::None;
+        };
+        match row.kind {
+            TreeEntryKind::File => FileTreeIntent::OpenFile(row.relative_path),
+            TreeEntryKind::Directory => self.toggle_directory(&row.relative_path),
+        }
+    }
+
+    pub fn expand_selected(&mut self) -> FileTreeIntent {
+        let Some(row) = self.selected_row() else {
+            return FileTreeIntent::None;
+        };
+        if row.kind == TreeEntryKind::File {
+            return FileTreeIntent::OpenFile(row.relative_path);
+        }
+        if self.expanded.insert(row.relative_path.clone()) {
+            if !self.has_listing(&row.relative_path) {
+                return FileTreeIntent::LoadDirectory(row.relative_path);
+            }
+            return FileTreeIntent::None;
+        }
+        let rows = self.rows();
+        if let Some(index) = rows
+            .iter()
+            .position(|candidate| candidate.relative_path == row.relative_path)
+            && let Some(child) = rows.get(index + 1)
+            && child.depth == row.depth + 1
+        {
+            self.selected = Some(child.relative_path.clone());
+        }
+        FileTreeIntent::None
+    }
+
+    pub fn collapse_selected(&mut self) {
+        let Some(row) = self.selected_row() else {
+            return;
+        };
+        if row.kind == TreeEntryKind::Directory && self.expanded.remove(&row.relative_path) {
+            return;
+        }
+        let Some(parent) = row
+            .relative_path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        else {
+            return;
+        };
+        if self
+            .rows()
+            .iter()
+            .any(|candidate| candidate.relative_path == parent)
+        {
+            self.selected = Some(parent.to_path_buf());
+        }
+    }
+
+    pub fn is_expanded(&self, path: &Path) -> bool {
+        self.expanded.contains(path)
+    }
+
+    pub fn rows(&self) -> Vec<VisibleTreeRow> {
+        self.rows_arc().as_ref().clone()
+    }
+
+    pub fn rows_arc(&self) -> Arc<Vec<VisibleTreeRow>> {
+        if self.mode == FileTreeMode::Changed && self.filter.trim().is_empty() {
+            return Arc::clone(&self.changed_rows);
+        }
+        let mut rows = match self.mode {
+            FileTreeMode::Changed => self.changed_rows.as_ref().clone(),
+            FileTreeMode::All => {
+                let mut rows = Vec::new();
+                self.collect_directory(Path::new(""), 0, &mut rows);
+                rows
+            }
+        };
+        if !self.filter.trim().is_empty() {
+            rows.retain(|row| matches_filter(&row.relative_path, &self.filter));
+        }
+        rows.truncate(MAX_VISIBLE_ROWS);
+        Arc::new(rows)
+    }
+
+    fn selected_row(&self) -> Option<VisibleTreeRow> {
+        let selected = self.selected.as_ref()?;
+        self.rows()
+            .into_iter()
+            .find(|row| &row.relative_path == selected)
+    }
+
+    fn toggle_directory(&mut self, path: &Path) -> FileTreeIntent {
+        if !self.expanded.insert(path.to_path_buf()) {
+            self.expanded.remove(path);
+            return FileTreeIntent::None;
+        }
+        if self.has_listing(path) {
+            FileTreeIntent::None
+        } else {
+            FileTreeIntent::LoadDirectory(path.to_path_buf())
+        }
+    }
+
+    fn ensure_selection(&mut self) {
+        let rows = self.rows_arc();
+        if self
+            .selected
+            .as_ref()
+            .is_some_and(|selected| rows.iter().any(|row| &row.relative_path == selected))
+        {
+            return;
+        }
+        self.selected = rows.first().map(|row| row.relative_path.clone());
+    }
+
+    fn collect_directory(&self, directory: &Path, depth: usize, rows: &mut Vec<VisibleTreeRow>) {
+        if rows.len() >= MAX_VISIBLE_ROWS {
+            return;
+        }
+        let Some(listing) = self.listings.get(directory) else {
+            return;
+        };
+        for entry in &listing.entries {
+            if rows.len() >= MAX_VISIBLE_ROWS {
+                return;
+            }
+            rows.push(VisibleTreeRow {
+                relative_path: entry.relative_path.clone(),
+                label: entry.name.clone(),
+                depth,
+                kind: entry.kind,
+                status: None,
+            });
+            if entry.kind == TreeEntryKind::Directory
+                && self.expanded.contains(&entry.relative_path)
+            {
+                self.collect_directory(&entry.relative_path, depth + 1, rows);
+            }
+        }
+    }
+}
+
+fn matches_filter(path: &Path, filter: &str) -> bool {
+    let path = path.to_string_lossy().to_lowercase();
+    filter
+        .to_lowercase()
+        .split_whitespace()
+        .all(|token| path.contains(token))
+}
+
+fn validate_relative(path: &Path, allow_empty: bool) -> Result<(), FileTreeError> {
+    if path.as_os_str().is_empty() {
+        return if allow_empty {
+            Ok(())
+        } else {
+            Err(FileTreeError::UnsafePath(path.to_path_buf()))
+        };
+    }
+    if path.is_absolute()
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        return Err(FileTreeError::UnsafePath(path.to_path_buf()));
+    }
+    Ok(())
+}
+
+fn directory_error(directory: &Path, operation: &'static str, error: io::Error) -> FileTreeError {
+    FileTreeError::DirectoryIo {
+        directory: directory.to_path_buf(),
+        operation,
+        message: error.to_string(),
+    }
+}
+
+#[derive(Debug)]
+pub enum FileTreeError {
+    Unavailable {
+        path: PathBuf,
+        message: String,
+    },
+    UnsafePath(PathBuf),
+    OutsideWorkspace(PathBuf),
+    NotDirectory(PathBuf),
+    DirectoryIo {
+        directory: PathBuf,
+        operation: &'static str,
+        message: String,
+    },
+    Git(GitReviewError),
+    RevealTooDeep {
+        path: PathBuf,
+        limit: usize,
+    },
+    RevealUnavailable {
+        path: PathBuf,
+        directory: PathBuf,
+        truncated: bool,
+    },
+}
+
+impl fmt::Display for FileTreeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Unavailable { path, message } => {
+                write!(formatter, "Cannot browse {}: {message}", path.display())
+            }
+            Self::UnsafePath(path) => {
+                write!(
+                    formatter,
+                    "Refusing to browse unsafe path {}",
+                    path.display()
+                )
+            }
+            Self::OutsideWorkspace(path) => write!(
+                formatter,
+                "Refusing to browse a directory outside the workspace: {}",
+                path.display()
+            ),
+            Self::NotDirectory(path) => {
+                write!(formatter, "{} is not a browsable directory", path.display())
+            }
+            Self::DirectoryIo {
+                directory,
+                operation,
+                message,
+            } => write!(
+                formatter,
+                "Could not {operation} directory {}: {message}",
+                if directory.as_os_str().is_empty() {
+                    Path::new(".")
+                } else {
+                    directory
+                }
+                .display()
+            ),
+            Self::Git(error) => error.fmt(formatter),
+            Self::RevealTooDeep { path, limit } => write!(
+                formatter,
+                "Cannot reveal {}: the path exceeds the {limit}-directory limit",
+                path.display()
+            ),
+            Self::RevealUnavailable {
+                path,
+                directory,
+                truncated,
+            } => write!(
+                formatter,
+                "Cannot reveal {} below {}{}",
+                path.display(),
+                if directory.as_os_str().is_empty() {
+                    Path::new(".")
+                } else {
+                    directory
+                }
+                .display(),
+                if *truncated {
+                    " because that directory exceeds the bounded tree limit"
+                } else {
+                    " because it is missing, ignored, or unreadable"
+                }
+            ),
+        }
+    }
+}
+
+impl std::error::Error for FileTreeError {}
+
+impl From<GitReviewError> for FileTreeError {
+    fn from(error: GitReviewError) -> Self {
+        Self::Git(error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::git_review::{BranchInfo, FileChange};
+    use std::process::Command;
+
+    fn change(path: &str, original: Option<&str>, kind: ChangeKind) -> FileChange {
+        FileChange {
+            path: PathBuf::from(path),
+            original_path: original.map(PathBuf::from),
+            kind,
+        }
+    }
+
+    fn listing(directory: &str, entries: &[(&str, TreeEntryKind)]) -> DirectoryListing {
+        let directory = PathBuf::from(directory);
+        DirectoryListing {
+            directory: directory.clone(),
+            entries: entries
+                .iter()
+                .map(|(name, kind)| DirectoryEntry {
+                    relative_path: directory.join(name),
+                    name: (*name).to_owned(),
+                    kind: *kind,
+                })
+                .collect(),
+            truncated: false,
+        }
+    }
+
+    fn write(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn changed_projection_uses_review_status_and_git_xy_decorations() {
+        let status = ReviewStatus {
+            repo_root: PathBuf::from("/repo"),
+            branch: BranchInfo::default(),
+            staged: vec![
+                change("both.rs", None, ChangeKind::Added),
+                change("new.rs", None, ChangeKind::Added),
+                change("renamed.rs", Some("old.rs"), ChangeKind::Renamed),
+            ],
+            unstaged: vec![
+                change("both.rs", None, ChangeKind::Modified),
+                change("deleted.rs", None, ChangeKind::Deleted),
+                change("modified.rs", None, ChangeKind::Modified),
+            ],
+            untracked: vec![change("scratch.rs", None, ChangeKind::Added)],
+            conflicted: vec![change("conflict.rs", None, ChangeKind::Unmerged)],
+        };
+
+        let snapshot = ChangedSnapshot::from(&status);
+        let decorations: Vec<_> = snapshot
+            .files
+            .iter()
+            .map(|file| {
+                (
+                    file.relative_path.to_string_lossy().into_owned(),
+                    file.status.decoration(),
+                )
+            })
+            .collect();
+        assert_eq!(
+            decorations,
+            vec![
+                ("both.rs".to_owned(), "AM".to_owned()),
+                ("conflict.rs".to_owned(), "UU".to_owned()),
+                ("deleted.rs".to_owned(), "·D".to_owned()),
+                ("modified.rs".to_owned(), "·M".to_owned()),
+                ("new.rs".to_owned(), "A·".to_owned()),
+                ("renamed.rs".to_owned(), "R·".to_owned()),
+                ("scratch.rs".to_owned(), "??".to_owned()),
+            ]
+        );
+        assert_eq!(
+            snapshot.files[5].status.original_path.as_deref(),
+            Some(Path::new("old.rs"))
+        );
+    }
+
+    #[test]
+    fn model_defaults_to_changed_and_supports_reveal_and_keyboard_navigation() {
+        let status = ReviewStatus {
+            repo_root: PathBuf::from("/repo"),
+            branch: BranchInfo::default(),
+            unstaged: vec![change("src/lib.rs", None, ChangeKind::Modified)],
+            ..ReviewStatus::default()
+        };
+        let mut model = FileTreeModel::default();
+        model.set_changed(ChangedSnapshot::from(&status));
+        assert_eq!(model.mode(), FileTreeMode::Changed);
+        assert_eq!(
+            model.changed_reference(" --> src/lib.rs:12:3"),
+            Some(PathBuf::from("src/lib.rs"))
+        );
+
+        model.set_mode(FileTreeMode::All);
+        model.insert_listing(listing("", &[("src", TreeEntryKind::Directory)]));
+        model.insert_listing(listing(
+            "src",
+            &[
+                ("lib.rs", TreeEntryKind::File),
+                ("main.rs", TreeEntryKind::File),
+            ],
+        ));
+        model.select_path("src");
+        assert_eq!(
+            model.expand_selected(),
+            FileTreeIntent::None,
+            "the loaded directory expands without another I/O request"
+        );
+        model.expand_selected();
+        assert_eq!(model.selected_path(), Some(Path::new("src/lib.rs")));
+        model.move_selection(1);
+        assert_eq!(model.selected_path(), Some(Path::new("src/main.rs")));
+        model.collapse_selected();
+        assert_eq!(model.selected_path(), Some(Path::new("src")));
+        model.set_filter("main");
+        assert_eq!(model.rows().len(), 1);
+        assert_eq!(model.selected_path(), Some(Path::new("src/main.rs")));
+    }
+
+    #[test]
+    fn directory_load_is_lazy_ignore_aware_and_bounded() {
+        let temporary = tempfile::tempdir().unwrap();
+        assert!(
+            Command::new("git")
+                .args(["init", "-q"])
+                .current_dir(temporary.path())
+                .status()
+                .unwrap()
+                .success()
+        );
+        write(
+            &temporary.path().join(".gitignore"),
+            "ignored.rs\nignored-dir/\n",
+        );
+        write(&temporary.path().join("visible.rs"), "visible\n");
+        write(&temporary.path().join("ignored.rs"), "ignored\n");
+        write(&temporary.path().join(":magic.rs"), "ignored magic\n");
+        write(&temporary.path().join("ignored-dir/hidden.rs"), "ignored\n");
+        write(&temporary.path().join("nested/child.rs"), "child\n");
+        write(&temporary.path().join("tracked-ignored.rs"), "tracked\n");
+        write(
+            &temporary.path().join(".gitignore"),
+            "ignored.rs\n:magic.rs\nignored-dir/\ntracked-ignored.rs\n",
+        );
+        assert!(
+            Command::new("git")
+                .args(["add", "-f", "tracked-ignored.rs"])
+                .current_dir(temporary.path())
+                .status()
+                .unwrap()
+                .success()
+        );
+
+        let workspace = FileTreeWorkspace::for_session(temporary.path()).unwrap();
+        let root = workspace.load_directory(Path::new("")).unwrap();
+        let paths: Vec<_> = root
+            .entries
+            .iter()
+            .map(|entry| entry.relative_path.as_path())
+            .collect();
+        assert!(paths.contains(&Path::new("visible.rs")));
+        assert!(paths.contains(&Path::new("tracked-ignored.rs")));
+        assert!(paths.contains(&Path::new("nested")));
+        assert!(!paths.contains(&Path::new("ignored.rs")));
+        assert!(!paths.contains(&Path::new(":magic.rs")));
+        assert!(!paths.contains(&Path::new("ignored-dir")));
+        assert!(!paths.contains(&Path::new(".git")));
+        assert!(
+            root.entries
+                .iter()
+                .all(|entry| entry.relative_path != Path::new("nested/child.rs")),
+            "the root load must not eagerly traverse nested directories"
+        );
+
+        let bounded = workspace
+            .load_directory_with_limits(Path::new(""), 2, 100)
+            .unwrap();
+        assert_eq!(bounded.entries.len(), 2);
+        assert!(bounded.truncated);
+    }
+
+    #[test]
+    fn reveal_loads_only_the_ancestor_chain() {
+        let temporary = tempfile::tempdir().unwrap();
+        write(&temporary.path().join("src/deep/file.rs"), "source\n");
+        write(&temporary.path().join("other/untouched.rs"), "other\n");
+        let workspace = FileTreeWorkspace::for_session(temporary.path()).unwrap();
+
+        let listings = workspace.reveal(Path::new("src/deep/file.rs")).unwrap();
+        let directories: Vec<_> = listings
+            .iter()
+            .map(|listing| listing.directory.as_path())
+            .collect();
+        assert_eq!(
+            directories,
+            vec![Path::new(""), Path::new("src"), Path::new("src/deep")]
+        );
+        assert!(
+            listings
+                .iter()
+                .all(|listing| listing.directory != Path::new("other"))
+        );
+    }
+}

--- a/zeus/crates/zeus-app/src/git_review.rs
+++ b/zeus/crates/zeus-app/src/git_review.rs
@@ -5,6 +5,7 @@
 //! porcelain formats, literal pathspec rules, subprocess hardening, timeouts,
 //! and output limits stay local to this implementation.
 
+use std::collections::HashSet;
 use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::io::{self, Read, Write};
@@ -310,6 +311,54 @@ impl GitRepository {
         )?;
         ensure_success(output, "reading status")
             .and_then(|output| parse_status(&self.root, &output.stdout))
+    }
+
+    /// Returns the repository-relative paths Git currently ignores.
+    ///
+    /// File browsing batches a single directory through this seam so it uses
+    /// the same repository, subprocess hardening, literal path handling, and
+    /// ignore rules as Review. Tracked paths are intentionally not reported
+    /// by `check-ignore`, even if a later ignore rule happens to match them.
+    pub fn ignored_paths(&self, paths: &[PathBuf]) -> Result<HashSet<PathBuf>, GitReviewError> {
+        if paths.is_empty() {
+            return Ok(HashSet::new());
+        }
+        let paths = validate_paths(paths)?;
+        let mut input = Vec::new();
+        for path in paths {
+            // `check-ignore --stdin` does not accept Git's `literal`
+            // pathspec magic. A `./` prefix keeps a leading `:` or `!` in a
+            // filename from being interpreted as magic while remaining
+            // repository-relative and round-trippable below.
+            input.extend_from_slice(b"./");
+            #[cfg(unix)]
+            input.extend_from_slice(path.as_bytes());
+            #[cfg(not(unix))]
+            input.extend_from_slice(path.to_string_lossy().as_bytes());
+            input.push(0);
+        }
+        let output = run_git(
+            &self.root,
+            ["check-ignore", "-z", "--stdin"],
+            Some(&input),
+            "checking ignored paths",
+        )?;
+        // `check-ignore` exits 1 when none of the inputs are ignored. That is
+        // a successful empty answer, not a failed Git operation.
+        if !output.status.success() && output.status.code() != Some(1) {
+            return Err(output.failure("checking ignored paths"));
+        }
+        Ok(output
+            .stdout
+            .split(|byte| *byte == 0)
+            .filter(|path| !path.is_empty())
+            .map(|path| path.strip_prefix(b"./").unwrap_or(path))
+            .map(path_from_bytes)
+            .collect())
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
     }
 
     /// Every requested path, plus the source of any staged rename whose

--- a/zeus/crates/zeus-app/src/inspector.rs
+++ b/zeus/crates/zeus-app/src/inspector.rs
@@ -31,6 +31,7 @@ use crate::diff::{
     DiffFile, DiffHunk, DiffLayer, DiffRow, DiffRowKind, DiffSnapshot, load_local_diff,
     preview_diff_snapshot, snapshot_from_read_diff,
 };
+use crate::file_tree::ChangedSnapshot;
 use crate::git_review::{
     GitRepository, GitReviewError, PatchMutation, ReviewStatus, preview_review_status,
 };
@@ -186,6 +187,7 @@ pub struct WorkbenchInspector {
     review_state: ReviewLoadState,
     review_generation: u64,
     review_task: Option<Task<()>>,
+    review_loading: bool,
     review_action_task: Option<Task<()>>,
     review_action_busy: bool,
     review_feedback: Option<(bool, String)>,
@@ -276,6 +278,7 @@ impl WorkbenchInspector {
             review_state: ReviewLoadState::NoSession,
             review_generation: 0,
             review_task: None,
+            review_loading: false,
             review_action_task: None,
             review_action_busy: false,
             review_feedback: None,
@@ -359,7 +362,11 @@ impl WorkbenchInspector {
     }
 
     fn reconcile_diff_polling(&mut self, cx: &mut Context<Self>) {
-        let should_poll = self.visible && self.selected_tab == InspectorTab::Changes;
+        let should_poll = self.visible
+            && matches!(
+                self.selected_tab,
+                InspectorTab::Changes | InspectorTab::Code
+            );
         if !should_poll {
             // Dropping a GPUI Task cancels its timer/future. Info and Artifacts
             // therefore perform no periodic Git work and have no idle wakeup.
@@ -374,8 +381,17 @@ impl WorkbenchInspector {
                 cx.background_executor().timer(REFRESH_INTERVAL).await;
                 if this
                     .update(cx, |this, cx| {
-                        if this.visible && this.selected_tab == InspectorTab::Changes {
-                            this.refresh(false, cx);
+                        if !this.visible {
+                            return;
+                        }
+                        match this.selected_tab {
+                            InspectorTab::Changes => this.refresh(false, cx),
+                            InspectorTab::Code => {
+                                if let Some(context) = this.context.clone() {
+                                    this.refresh_review(&context, false, cx);
+                                }
+                            }
+                            InspectorTab::Info | InspectorTab::Artifacts => {}
                         }
                     })
                     .is_err()
@@ -408,6 +424,12 @@ impl WorkbenchInspector {
     /// without weakening the normal session gate for Info/Review/Artifacts.
     pub const fn is_code_destination(&self) -> bool {
         matches!(self.selected_tab, InspectorTab::Code)
+    }
+
+    pub fn focus_code_tree(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.select_tab(InspectorTab::Code, cx);
+        self.code_viewer
+            .update(cx, |viewer, cx| viewer.focus_file_tree(window, cx));
     }
 
     fn selected_context(&self) -> Option<DiffContext> {
@@ -462,8 +484,14 @@ impl WorkbenchInspector {
         }
         self.comparison_menu_open = false;
         self.tab_transition_generation = self.tab_transition_generation.wrapping_add(1);
-        if tab == InspectorTab::Changes {
-            self.refresh(true, cx);
+        match tab {
+            InspectorTab::Changes => self.refresh(true, cx),
+            InspectorTab::Code => {
+                if let Some(context) = self.context.clone() {
+                    self.refresh_review(&context, true, cx);
+                }
+            }
+            InspectorTab::Info | InspectorTab::Artifacts => {}
         }
         self.reconcile_diff_polling(cx);
         cx.notify();
@@ -533,8 +561,13 @@ impl WorkbenchInspector {
             self.context = None;
             self.state = LoadState::NoSession;
             self.review_state = ReviewLoadState::NoSession;
-            self.code_viewer
-                .update(cx, |viewer, cx| viewer.set_workspace(None, cx));
+            self.review_generation = self.review_generation.wrapping_add(1);
+            self.review_task = None;
+            self.review_loading = false;
+            self.code_viewer.update(cx, |viewer, cx| {
+                viewer.set_workspace(None, cx);
+                viewer.set_changed_unavailable("Select a local session", cx);
+            });
             cx.notify();
             return;
         };
@@ -555,8 +588,15 @@ impl WorkbenchInspector {
         self.context = Some(context.clone());
         if self.preview_account {
             self.loading = false;
+            self.review_generation = self.review_generation.wrapping_add(1);
+            self.review_task = None;
+            self.review_loading = false;
             self.state = LoadState::Ready(Arc::new(preview_diff_snapshot(context.cwd)));
-            self.review_state = ReviewLoadState::Ready(Arc::new(preview_review_status()));
+            let status = Arc::new(preview_review_status());
+            let tree = ChangedSnapshot::from(status.as_ref());
+            self.review_state = ReviewLoadState::Ready(Arc::clone(&status));
+            self.code_viewer
+                .update(cx, |viewer, cx| viewer.set_changed_snapshot(tree, cx));
             self.refresh_task = None;
             cx.notify();
             return;
@@ -618,23 +658,40 @@ impl WorkbenchInspector {
     fn refresh_review(&mut self, context: &DiffContext, force: bool, cx: &mut Context<Self>) {
         if context.remote {
             self.review_state = ReviewLoadState::Remote;
+            self.review_generation = self.review_generation.wrapping_add(1);
+            self.review_task = None;
+            self.review_loading = false;
+            self.code_viewer.update(cx, |viewer, cx| {
+                viewer.set_changed_unavailable(
+                    "Remote file browsing is unavailable in this local Code inspector",
+                    cx,
+                );
+            });
             return;
         }
         if self.review_action_busy && !force {
             return;
         }
+        if self.review_loading && !force {
+            return;
+        }
+        self.review_loading = true;
         self.review_generation = self.review_generation.wrapping_add(1);
         let generation = self.review_generation;
         let cwd = context.cwd.clone();
         if !matches!(self.review_state, ReviewLoadState::Ready(_)) {
             self.review_state = ReviewLoadState::Loading;
+            self.code_viewer
+                .update(cx, |viewer, cx| viewer.set_changed_loading(cx));
         }
         let tokio = self.tokio.clone();
         self.review_task = Some(cx.spawn(async move |this, cx| {
             let result = tokio
                 .spawn_blocking(move || {
                     let repository = GitRepository::discover(&cwd)?;
-                    repository.status()
+                    let status = repository.status()?;
+                    let tree = ChangedSnapshot::from(&status);
+                    Ok::<_, GitReviewError>((status, tree))
                 })
                 .await
                 .map_err(|error| format!("Git status worker stopped: {error}"))
@@ -643,10 +700,22 @@ impl WorkbenchInspector {
                 if this.review_generation != generation {
                     return;
                 }
-                this.review_state = match result {
-                    Ok(status) => ReviewLoadState::Ready(Arc::new(status)),
-                    Err(error) => ReviewLoadState::Error(error),
-                };
+                this.review_loading = false;
+                match result {
+                    Ok((status, tree)) => {
+                        let status = Arc::new(status);
+                        this.review_state = ReviewLoadState::Ready(Arc::clone(&status));
+                        this.code_viewer.update(cx, |viewer, cx| {
+                            viewer.set_changed_snapshot(tree, cx);
+                        });
+                    }
+                    Err(error) => {
+                        this.review_state = ReviewLoadState::Error(error.clone());
+                        this.code_viewer.update(cx, |viewer, cx| {
+                            viewer.set_changed_unavailable(error, cx);
+                        });
+                    }
+                }
                 cx.notify();
             });
         }));

--- a/zeus/crates/zeus-app/src/main.rs
+++ b/zeus/crates/zeus-app/src/main.rs
@@ -7,6 +7,7 @@ mod code_viewer;
 mod daemon_launch;
 mod dev_build;
 pub mod diff;
+mod file_tree;
 pub mod fonts;
 pub mod fuzzy;
 mod git_review;

--- a/zeus/crates/zeus-app/src/root.rs
+++ b/zeus/crates/zeus-app/src/root.rs
@@ -771,6 +771,16 @@ impl RootView {
             }
             "b" => self.sidebar.update(cx, |sidebar, cx| sidebar.toggle(cx)),
             "d" if event.keystroke.modifiers.shift => self.toggle_inspector(cx),
+            "e" if event.keystroke.modifiers.shift => {
+                let inspector = self.inspector.clone();
+                self.reveal_inspector(cx);
+                let Some(inspector) = inspector else {
+                    return;
+                };
+                inspector.update(cx, |inspector, cx| {
+                    inspector.focus_code_tree(_window, cx);
+                });
+            }
             key @ ("t" | "n") => match new_session_shortcut(key, event.keystroke.modifiers) {
                 Some(NewSessionShortcut::Default) => {
                     if !self.spawn_default() {


### PR DESCRIPTION
Closes #51

## Summary
- add a worktree-scoped Changed default backed by Review Git status semantics
- add a lazy, Git-ignore-aware All files tree with bounded background traversal
- reuse the Code viewer for tree, Review, Quick Open, and terminal reveal flows
- add keyboard navigation, deterministic coverage, and workbench documentation

## Verification
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo build --workspace --release