### PR TITLE
feat: Add a dedicated native MCP screenshot tool

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -26,4 +26,5 @@
 # Reference
 
 - [Support](support.md)
+- [Screenshot soak test](screenshot-soak.md)
 - [Roadmap](roadmap.md)

--- a/docs/src/screenshot-soak.md
+++ b/docs/src/screenshot-soak.md
@@ -1,0 +1,14 @@
+# Screenshot soak test
+
+The default Rust test suite uses a fake capturer and never requests macOS
+Screen Recording permission. To exercise a real Zeus window deliberately, run
+this from `zeus/` while the Zeus app has an open window:
+
+```sh
+ZEUS_SCREENSHOT_SOAK=1 cargo test -p zeus-engine real_window_soak_is_explicitly_opt_in
+```
+
+macOS may ask for Screen Recording permission for Zeus. The test captures one
+720p JPEG in memory, stops the stream immediately, and writes no screenshot
+file, so there is no artifact cleanup. Remove Zeus under **System Settings →
+Privacy & Security → Screen Recording** if you also want to clear the grant.

--- a/zeus/Cargo.lock
+++ b/zeus/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
  "rustix 1.1.4",
  "rustix-openpty",
  "signal-hook",
- "unicode-width",
+ "unicode-width 0.2.2",
  "vte",
  "windows-sys 0.59.0",
 ]
@@ -187,12 +187,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alsa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.13.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "annotate-snippets"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccaf7e9dfbb6ab22c82e473cd1a8a7bd313c19a5b7e40970f3d89ef5a5c9e81e"
+dependencies = [
+ "unicode-width 0.1.14",
+ "yansi-term",
 ]
 
 [[package]]
@@ -562,6 +594,27 @@ checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "annotate-snippets",
+ "bitflags 2.13.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex 1.3.0",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "bindgen"
 version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
@@ -572,6 +625,24 @@ dependencies = [
  "itertools 0.13.0",
  "log",
  "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.3",
+ "shlex 1.3.0",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.13.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -823,12 +894,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom 7.1.3",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -865,6 +952,22 @@ dependencies = [
  "wasm-bindgen",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "cidre"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7a105a9a8dd9e625e1e5938aa8442f63551990bfb2ab4bd606b1b30ccbfd8cf"
+dependencies = [
+ "cidre-macros",
+ "parking_lot",
+]
+
+[[package]]
+name = "cidre-macros"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f07a383a232853874a9b0b3e80e6eefe9bea73495b8ab4bdd960bc7c1db4c6d"
 
 [[package]]
 name = "cipher"
@@ -956,7 +1059,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -974,6 +1077,16 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "combine"
+version = "4.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "compression-codecs"
@@ -1020,6 +1133,15 @@ checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
@@ -1034,6 +1156,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie-factory"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
+dependencies = [
+ "futures",
 ]
 
 [[package]]
@@ -1172,6 +1303,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "coreaudio-rs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation-sys",
+ "coreaudio-sys",
+]
+
+[[package]]
+name = "coreaudio-sys"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b4739a805a62757a83e5654fa3faabec0442666b263bb2287d5a8185bfd953"
+dependencies = [
+ "bindgen 0.72.1",
+]
+
+[[package]]
 name = "cosmic-text"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,6 +1344,29 @@ dependencies = [
  "unicode-linebreak",
  "unicode-script",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cpal"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+dependencies = [
+ "alsa",
+ "core-foundation-sys",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni",
+ "js-sys",
+ "libc",
+ "mach2 0.4.3",
+ "ndk",
+ "ndk-context",
+ "oboe",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -1298,10 +1472,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27ae1dd37df86211c42e150270f82743308803d90a6f6e6651cd730d5e1732f"
 
 [[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
 name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
+name = "dbus"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "deranged"
@@ -2081,7 +2272,7 @@ dependencies = [
  "async-channel",
  "async-task",
  "backtrace",
- "bindgen",
+ "bindgen 0.71.1",
  "bitflags 2.13.1",
  "block",
  "cbindgen",
@@ -2112,7 +2303,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "lyon",
- "mach2",
+ "mach2 0.5.0",
  "media",
  "metal",
  "num_cpus",
@@ -2219,7 +2410,7 @@ dependencies = [
  "itertools 0.14.0",
  "libc",
  "log",
- "mach2",
+ "mach2 0.5.0",
  "media",
  "metal",
  "objc",
@@ -2803,6 +2994,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -2824,6 +3024,22 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
 
 [[package]]
 name = "jni-sys"
@@ -2930,6 +3146,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leak"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2961,6 +3183,15 @@ name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2995,6 +3226,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libspa"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65f3a4b81b2a2d8c7f300643676202debd1b7c929dbf5c9bb89402ea11d19810"
+dependencies = [
+ "bitflags 2.13.1",
+ "cc",
+ "convert_case 0.6.0",
+ "cookie-factory",
+ "libc",
+ "libspa-sys",
+ "nix",
+ "nom 7.1.3",
+ "system-deps",
+]
+
+[[package]]
+name = "libspa-sys"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0d9716420364790e85cbb9d3ac2c950bde16a7dd36f3209b7dfdfc4a24d01f"
+dependencies = [
+ "bindgen 0.69.5",
+ "cc",
+ "system-deps",
 ]
 
 [[package]]
@@ -3146,6 +3405,15 @@ dependencies = [
 
 [[package]]
 name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach2"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
@@ -3188,7 +3456,7 @@ version = "0.1.0"
 source = "git+https://github.com/zed-industries/zed.git?rev=dc2a339d5d043da448a3f7ddc7c0a85c63864aad#dc2a339d5d043da448a3f7ddc7c0a85c63864aad"
 dependencies = [
  "anyhow",
- "bindgen",
+ "bindgen 0.71.1",
  "core-foundation 0.10.1",
  "core-video",
  "ctor",
@@ -3310,6 +3578,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+dependencies = [
+ "bitflags 2.13.1",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys 0.3.1",
+]
+
+[[package]]
 name = "ndk-sys"
 version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3323,6 +3620,17 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "no_std_io2"
@@ -3534,6 +3842,28 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3777,6 +4107,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "oboe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+dependencies = [
+ "jni",
+ "ndk",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "oboe-sys",
+]
+
+[[package]]
+name = "oboe-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4012,6 +4365,34 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
+]
+
+[[package]]
+name = "pipewire"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08e645ba5c45109106d56610b3ee60eb13a6f2beb8b74f8dc8186cf261788dda"
+dependencies = [
+ "anyhow",
+ "bitflags 2.13.1",
+ "libc",
+ "libspa",
+ "libspa-sys",
+ "nix",
+ "once_cell",
+ "pipewire-sys",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "pipewire-sys"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "849e188f90b1dda88fe2bfe1ad31fe5f158af2c98f80fb5d13726c44f3f01112"
+dependencies = [
+ "bindgen 0.69.5",
+ "libspa-sys",
+ "system-deps",
 ]
 
 [[package]]
@@ -4824,6 +5205,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "scap"
+version = "0.1.0-beta.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36b5187a2336cbb98d29647050d336ce16bf4806da8fcf04934a4c8788bc17bc"
+dependencies = [
+ "cidre",
+ "cocoa 0.25.0",
+ "core-graphics-helmer-fork",
+ "cpal",
+ "dbus",
+ "futures",
+ "objc",
+ "pipewire",
+ "rand 0.8.7",
+ "sysinfo 0.30.13",
+ "thiserror 2.0.19",
+ "windows 0.58.0",
+ "windows-capture",
+]
+
+[[package]]
 name = "scheduler"
 version = "0.1.0"
 source = "git+https://github.com/zed-industries/zed.git?rev=dc2a339d5d043da448a3f7ddc7c0a85c63864aad#dc2a339d5d043da448a3f7ddc7c0a85c63864aad"
@@ -5480,6 +5882,21 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows 0.52.0",
+]
+
+[[package]]
+name = "sysinfo"
 version = "0.31.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "355dbe4f8799b304b05e1b0f05fc59b2a18d36645cf169607da45bde2f69a1be"
@@ -5490,6 +5907,19 @@ dependencies = [
  "ntapi",
  "rayon",
  "windows 0.57.0",
+]
+
+[[package]]
+name = "system-deps"
+version = "6.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
+dependencies = [
+ "cfg-expr",
+ "heck 0.5.0",
+ "pkg-config",
+ "toml 0.8.23",
+ "version-compare",
 ]
 
 [[package]]
@@ -5517,6 +5947,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
 name = "tauri-winrt-notification"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5534,7 +5970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -5929,6 +6365,12 @@ checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
@@ -6059,6 +6501,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "version_check"
@@ -6360,7 +6808,7 @@ dependencies = [
  "libloading",
  "log",
  "naga",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
@@ -6457,11 +6905,41 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
  "windows-core 0.57.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
  "windows-targets 0.52.6",
 ]
 
@@ -6523,6 +7001,25 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
@@ -6530,6 +7027,19 @@ dependencies = [
  "windows-implement 0.57.0",
  "windows-interface 0.57.0",
  "windows-result 0.1.2",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
  "windows-targets 0.52.6",
 ]
 
@@ -6594,6 +7104,17 @@ dependencies = [
 
 [[package]]
 name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
@@ -6608,6 +7129,17 @@ name = "windows-interface"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6679,6 +7211,15 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
@@ -6697,6 +7238,16 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
@@ -6711,6 +7262,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -6738,6 +7298,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6802,6 +7377,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -6814,6 +7395,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -6823,6 +7410,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6850,6 +7443,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6859,6 +7458,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6874,6 +7479,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6883,6 +7494,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6990,6 +7607,15 @@ name = "y4m"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
+name = "yansi-term"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "yazi"
@@ -7165,7 +7791,7 @@ dependencies = [
  "rand 0.8.7",
  "screencapturekit",
  "screencapturekit-sys",
- "sysinfo",
+ "sysinfo 0.31.4",
  "tao-core-video-sys",
  "windows 0.61.3",
  "windows-capture",
@@ -7332,13 +7958,17 @@ version = "0.2.0"
 dependencies = [
  "alacritty_terminal",
  "base64 0.23.1",
+ "cidre",
+ "futures",
  "getrandom 0.4.3",
+ "image",
  "libc",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
  "plist",
  "regex",
+ "scap",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/zeus/Cargo.toml
+++ b/zeus/Cargo.toml
@@ -43,6 +43,7 @@ notify = "8.2"
 plist = "1"
 smallvec = { version = "1.6", features = ["union", "const_new"] }
 futures-core = "0.3"
+futures = "0.3"
 getrandom = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/zeus/assets/Info.plist
+++ b/zeus/assets/Info.plist
@@ -10,6 +10,8 @@
     <false/>
     <key>NSHighResolutionCapable</key>
     <true/>
+    <key>NSScreenCaptureUsageDescription</key>
+    <string>Zeus captures a window when a hosted coding agent asks to see the local interface.</string>
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
     <key>NSUserNotificationAlertStyle</key>

--- a/zeus/crates/zeus-cli/src/mcp.rs
+++ b/zeus/crates/zeus-cli/src/mcp.rs
@@ -30,6 +30,7 @@ pub fn call(tool: &str, args: &Value) -> Result<Value, CliError> {
         "send_prompt" => send_prompt(args),
         "wait_for_agent" => wait_for_agent(args),
         "read_output" => read_output(args),
+        "screenshot" => screenshot(args),
         "get_artifacts" => get_artifacts(args),
         "create_worktree" => create_worktree(args),
         "list_worktrees" => list_worktrees(args),
@@ -94,7 +95,10 @@ fn handle_message(message: Value) -> Option<Value> {
         "tools/list" => id.map(|id| success(id, tools_json())),
         "tools/call" => id.map(|id| {
             let Some(name) = params.get("name").and_then(Value::as_str) else {
-                return success(id, tool_content(Err("tools/call missing 'name'".into())));
+                return success(
+                    id,
+                    tool_content(None, Err("tools/call missing 'name'".into())),
+                );
             };
             let arguments = params
                 .get("arguments")
@@ -102,7 +106,10 @@ fn handle_message(message: Value) -> Option<Value> {
                 .unwrap_or_else(|| json!({}));
             success(
                 id,
-                tool_content(call(name, &arguments).map_err(|error| error.to_string())),
+                tool_content(
+                    Some(name),
+                    call(name, &arguments).map_err(|error| error.to_string()),
+                ),
             )
         }),
         _ if id.is_none() => None,
@@ -154,16 +161,37 @@ fn success(id: Value, result: Value) -> Value {
     json!({"jsonrpc":"2.0","id":id,"result":result})
 }
 
-fn tool_content(result: Result<Value, String>) -> Value {
-    let (value, is_error) = match result {
-        Ok(value) => (value, false),
-        Err(message) => (Value::String(message), true),
+fn tool_content(tool: Option<&str>, result: Result<Value, String>) -> Value {
+    let mut value = match result {
+        Ok(value) => value,
+        Err(message) => {
+            return json!({"content":[{"type":"text","text":message}],"isError":true});
+        }
     };
+    if tool == Some("screenshot")
+        && let Some(object) = value.as_object_mut()
+        && let Some(data) = object.remove("data")
+    {
+        let Some(mime_type) = object.remove("mimeType") else {
+            return json!({"content":[{"type":"text","text":"screenshot result omitted mimeType"}],"isError":true});
+        };
+        if !data.is_string() || !mime_type.is_string() {
+            return json!({"content":[{"type":"text","text":"screenshot result contained invalid image content"}],"isError":true});
+        }
+        let text = serde_json::to_string(&value).unwrap_or_else(|_| "null".into());
+        return json!({
+            "content":[
+                {"type":"text","text":text},
+                {"type":"image","mimeType":mime_type,"data":data}
+            ],
+            "isError":false
+        });
+    }
     let text = value
         .as_str()
         .map(str::to_owned)
         .unwrap_or_else(|| serde_json::to_string(&value).unwrap_or_else(|_| "null".into()));
-    json!({"content":[{"type":"text","text":text}],"isError":is_error})
+    json!({"content":[{"type":"text","text":text}],"isError":false})
 }
 
 fn tool_definitions() -> Vec<Value> {
@@ -212,6 +240,18 @@ fn tool_definitions() -> Vec<Value> {
             "read_output",
             "Read an agent session's output.",
             json!({"type":"object","properties":{"session_id":{"type":"string"},"mode":{"type":"string","enum":["screen","tail"]},"lines":{"type":"number","default":50}},"required":["session_id"]}),
+        ),
+        tool(
+            "screenshot",
+            "Capture a screenshot of a local window (default: the Zeus window hosting this session). USE THIS instead of writing a Playwright script, calling `screencapture`, or using `browser` with `action: \"screenshot\"`. Returns the image directly. For terminal text use `read_output`. For a page inside the session Playwright browser, use `browser`.",
+            json!({
+                "type":"object",
+                "properties":{
+                    "window":{"type":"string","description":"Substring match on window title. Omit to capture the Zeus window."},
+                    "display":{"type":"integer","description":"Capture this display id. Do not use unless the user asked for a full display."},
+                    "list":{"type":"boolean","description":"If true, return capturable windows/displays and take no image."}
+                }
+            }),
         ),
         tool(
             "create_worktree",
@@ -696,6 +736,12 @@ fn browser(args: &Value) -> Result<Value, CliError> {
     })
 }
 
+fn screenshot(args: &Value) -> Result<Value, CliError> {
+    conn::with_conn(Duration::from_secs(20), |conn| {
+        conn.request_value(Method::SCREENSHOT_CAPTURE, args, Duration::from_secs(20))
+    })
+}
+
 fn test_run(args: &Value) -> Result<Value, CliError> {
     let url = require_string(args, "url")?;
     let steps = args
@@ -1043,6 +1089,7 @@ mod tests {
             "spawn_agent",
             "get_artifacts",
             "browser",
+            "screenshot",
             "whoami",
             "report_to_parent",
             "summarize_children",
@@ -1053,6 +1100,63 @@ mod tests {
             );
         }
         assert!(!names.contains(&"test_run"));
+    }
+
+    #[test]
+    fn screenshot_has_a_small_object_schema_and_returns_image_content() {
+        let tools = tool_definitions();
+        let screenshot = tools
+            .iter()
+            .find(|tool| tool["name"] == "screenshot")
+            .expect("screenshot tool");
+        assert_eq!(screenshot["inputSchema"]["type"], "object");
+        assert_eq!(
+            screenshot["inputSchema"]["properties"]
+                .as_object()
+                .expect("properties")
+                .len(),
+            3
+        );
+
+        let content = tool_content(
+            Some("screenshot"),
+            Ok(json!({
+                "target":"zeus",
+                "width":2,
+                "height":1,
+                "mimeType":"image/jpeg",
+                "data":"/9j/2Q=="
+            })),
+        );
+        assert_eq!(content["isError"], false);
+        assert_eq!(content["content"][1]["type"], "image");
+        assert_eq!(content["content"][1]["mimeType"], "image/jpeg");
+        assert_eq!(content["content"][1]["data"], "/9j/2Q==");
+        assert!(
+            !content["content"][0]["text"]
+                .as_str()
+                .expect("metadata")
+                .contains("/9j/2Q==")
+        );
+
+        let listed = tool_content(
+            Some("screenshot"),
+            Ok(json!({"targets":[{"id":11,"title":"Zeus","kind":"window"}]})),
+        );
+        assert_eq!(listed["content"].as_array().expect("content").len(), 1);
+        assert_eq!(listed["content"][0]["type"], "text");
+
+        let denied = tool_content(
+            Some("screenshot"),
+            Err("screen_recording_denied: enable Screen Recording for Zeus".into()),
+        );
+        assert_eq!(denied["isError"], true);
+        assert!(
+            denied["content"][0]["text"]
+                .as_str()
+                .expect("error")
+                .contains("screen_recording_denied")
+        );
     }
 
     #[test]

--- a/zeus/crates/zeus-engine/Cargo.toml
+++ b/zeus/crates/zeus-engine/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 [dependencies]
 alacritty_terminal.workspace = true
 base64.workspace = true
+image = { workspace = true, features = ["jpeg"] }
 zeus-proto.workspace = true
 zeus-pty.workspace = true
 zeus-terminal-state.workspace = true
@@ -22,6 +23,16 @@ sha2.workspace = true
 libc = "0.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
+# scap's native stack buys an in-process ScreenCaptureKit path with no
+# Playwright, Node, or shell screenshot helper. Keep it out of every remote
+# and terminal crate: local Engine capture is its only purpose.
+scap = "=0.1.0-beta.1"
+cidre = { version = "=0.10.1", default-features = false, features = [
+    "async",
+    "macos_13_1",
+    "sc",
+] }
+futures.workspace = true
 objc2 = "=0.6.4"
 objc2-app-kit = { version = "=0.3.2", default-features = false, features = [
     "NSAlert",

--- a/zeus/crates/zeus-engine/src/bin/zeusd-rs.rs
+++ b/zeus/crates/zeus-engine/src/bin/zeusd-rs.rs
@@ -31,6 +31,10 @@ fn main() {
 
 #[cfg(unix)]
 fn main() {
+    if zeus_engine::screenshot::run_worker_if_requested() {
+        return;
+    }
+
     // Stamp process start on stderr: captured into zeusd.boot.log by the
     // app's launcher, and our only visibility for pre-log failures.
     eprintln!(

--- a/zeus/crates/zeus-engine/src/control.rs
+++ b/zeus/crates/zeus-engine/src/control.rs
@@ -688,6 +688,7 @@ impl ControlServer {
             Method::GIT_PR_OPEN => self.git_pr_open(params),
             Method::TEST_RUN => self.browser_call("run", params),
             "browser.act" => self.browser_call("browser", params),
+            Method::SCREENSHOT_CAPTURE => self.screenshot_capture(params),
             Method::EVENTS_WAIT => self.events_wait(params),
             Method::HOST_SYNC_PREFS => self.host_sync_prefs(params),
             Method::HOST_INITIALIZE => self.host_initialize(params),
@@ -1169,6 +1170,15 @@ impl ControlServer {
             code: "browser_pool".into(),
             message: error,
         })
+    }
+
+    /// One-shot native local-window capture for the MCP `screenshot` tool.
+    /// The capture module owns the bounded helper process and never writes an
+    /// artifact path or image bytes to Engine logs.
+    fn screenshot_capture(&self, params: Option<JsonValue>) -> Result<JsonValue, ControlError> {
+        let params = params.unwrap_or_else(|| json!({}));
+        crate::screenshot::capture(&params)
+            .map_err(|error| ControlError::new(error.code, error.message))
     }
 
     /// The aggregated staleness view: every worktree of every project,

--- a/zeus/crates/zeus-engine/src/lib.rs
+++ b/zeus/crates/zeus-engine/src/lib.rs
@@ -46,6 +46,7 @@ pub mod pty;
 pub mod registry;
 pub mod remote;
 pub mod screen;
+pub mod screenshot;
 pub mod session;
 pub mod status;
 

--- a/zeus/crates/zeus-engine/src/mcp/host.rs
+++ b/zeus/crates/zeus-engine/src/mcp/host.rs
@@ -306,6 +306,10 @@ impl ToolHost for RegistryHost {
                 self.wait_for_children(&caller, timeout)
             }
 
+            "screenshot" => {
+                crate::screenshot::capture(arguments).map_err(|error| error.to_string())
+            }
+
             // spawn_agent is served by the control layer, which owns log paths
             "spawn_agent" => self.spawn_agent(arguments),
 

--- a/zeus/crates/zeus-engine/src/mcp/mod.rs
+++ b/zeus/crates/zeus-engine/src/mcp/mod.rs
@@ -116,18 +116,42 @@ impl<H: ToolHost> McpServer<H> {
             .unwrap_or_else(|| json!({}));
 
         match self.host.call(name, &arguments) {
-            Ok(value) => json!({
-                "content": [{ "type": "text", "text": render(&value) }],
-                "isError": false,
-            }),
+            Ok(value) => tool_success(name, value),
             // A failing tool is a result the agent reads, not a broken channel.
             Err(message) => tool_error(&message),
         }
     }
 }
 
-/// Tool results are rendered as text because that is what an MCP client shows
-/// the model. Strings pass through unquoted; anything else is pretty JSON.
+fn tool_success(tool: &str, mut value: Value) -> Value {
+    if tool == "screenshot"
+        && let Some(object) = value.as_object_mut()
+        && let Some(data) = object.remove("data")
+    {
+        let Some(mime_type) = object.remove("mimeType") else {
+            return tool_error("screenshot result omitted mimeType");
+        };
+        if !data.is_string() || !mime_type.is_string() {
+            return tool_error("screenshot result contained invalid image content");
+        }
+        return json!({
+            "content": [
+                { "type": "text", "text": serde_json::to_string(&value).unwrap_or_else(|_| "null".into()) },
+                { "type": "image", "mimeType": mime_type, "data": data },
+            ],
+            "isError": false,
+        });
+    }
+
+    json!({
+        "content": [{ "type": "text", "text": render(&value) }],
+        "isError": false,
+    })
+}
+
+/// Non-image tool results are rendered as text because that is what an MCP
+/// client shows the model. Strings pass through unquoted; anything else is
+/// pretty JSON.
 fn render(value: &Value) -> String {
     match value {
         Value::String(text) => text.clone(),
@@ -164,6 +188,7 @@ mod tests {
     struct RecordingHost {
         calls: Mutex<Vec<(String, Value)>>,
         fail_with: Option<String>,
+        result: Option<Value>,
     }
 
     impl ToolHost for RecordingHost {
@@ -174,7 +199,10 @@ mod tests {
                 .push((tool.to_string(), arguments.clone()));
             match &self.fail_with {
                 Some(message) => Err(message.clone()),
-                None => Ok(json!({ "ok": true, "tool": tool })),
+                None => Ok(self
+                    .result
+                    .clone()
+                    .unwrap_or_else(|| json!({ "ok": true, "tool": tool }))),
             }
         }
     }
@@ -242,6 +270,7 @@ mod tests {
             "read_output",
             "release_agent",
             "create_worktree",
+            "screenshot",
             "whoami",
         ] {
             assert!(
@@ -299,6 +328,60 @@ mod tests {
         assert_eq!(
             response["result"]["content"][0]["text"],
             "no session s_missing"
+        );
+    }
+
+    #[test]
+    fn screenshot_results_preserve_mcp_image_content() {
+        let host = RecordingHost {
+            result: Some(json!({
+                "target": "zeus",
+                "width": 2,
+                "height": 1,
+                "mimeType": "image/jpeg",
+                "data": "/9j/2Q==",
+            })),
+            ..Default::default()
+        };
+        let server = McpServer::new(tool_definitions(), host);
+        let response = server
+            .handle(&request(
+                "tools/call",
+                json!({ "name": "screenshot", "arguments": {} }),
+            ))
+            .expect("a reply");
+
+        assert_eq!(response["result"]["isError"], false);
+        assert_eq!(response["result"]["content"][1]["type"], "image");
+        assert_eq!(response["result"]["content"][1]["mimeType"], "image/jpeg");
+        assert_eq!(response["result"]["content"][1]["data"], "/9j/2Q==");
+        let metadata = response["result"]["content"][0]["text"]
+            .as_str()
+            .expect("metadata text");
+        assert!(!metadata.contains("/9j/2Q=="));
+        assert!(metadata.contains("\"target\":\"zeus\""));
+    }
+
+    #[test]
+    fn screenshot_permission_denial_is_an_mcp_error_with_its_code() {
+        let host = RecordingHost {
+            fail_with: Some("screen_recording_denied: enable Screen Recording for Zeus".into()),
+            ..Default::default()
+        };
+        let server = McpServer::new(tool_definitions(), host);
+        let response = server
+            .handle(&request(
+                "tools/call",
+                json!({ "name": "screenshot", "arguments": {} }),
+            ))
+            .expect("a reply");
+
+        assert_eq!(response["result"]["isError"], true);
+        assert!(
+            response["result"]["content"][0]["text"]
+                .as_str()
+                .expect("error text")
+                .contains("screen_recording_denied")
         );
     }
 

--- a/zeus/crates/zeus-engine/src/mcp/tools.rs
+++ b/zeus/crates/zeus-engine/src/mcp/tools.rs
@@ -121,6 +121,18 @@ pub fn tool_definitions_for(kinds: &[String]) -> Vec<ToolDefinition> {
             }),
         ),
         tool(
+            "screenshot",
+            "Capture a screenshot of a local window (default: the Zeus window hosting this session). USE THIS instead of writing a Playwright script, calling `screencapture`, or using `browser` with `action: \"screenshot\"`. Returns the image directly. For terminal text use `read_output`. For a page inside the session Playwright browser, use `browser`.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "window": { "type": "string", "description": "Substring match on window title. Omit to capture the Zeus window." },
+                    "display": { "type": "integer", "description": "Capture this display id. Do not use unless the user asked for a full display." },
+                    "list": { "type": "boolean", "description": "If true, return capturable windows/displays and take no image." }
+                }
+            }),
+        ),
+        tool(
             "release_agent",
             "End a session and kill its process tree. The record stays in the list.",
             json!({

--- a/zeus/crates/zeus-engine/src/screenshot.rs
+++ b/zeus/crates/zeus-engine/src/screenshot.rs
@@ -1,0 +1,882 @@
+//! Native local-window screenshots for the Zeus MCP tool.
+//!
+//! ScreenCaptureKit can block while macOS decides Screen Recording permission,
+//! and `scap` exposes its next frame as a blocking receive. Production capture
+//! therefore runs in a short-lived child of the app-launched Engine. The
+//! Engine bounds that process and kills it on timeout, which also guarantees a
+//! stuck capturer cannot leave the recording indicator or stream running.
+
+use std::fmt;
+
+use base64::Engine as _;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+const JPEG_QUALITY: u8 = 60;
+const MAX_IMAGE_EDGE: u32 = 1_280;
+const MAX_JPEG_BYTES: usize = 2_500_000;
+#[cfg(target_os = "macos")]
+const MAX_WORKER_OUTPUT_BYTES: usize = 3_750_000;
+#[cfg(target_os = "macos")]
+const WORKER_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// Private argument used only when the Engine launches its bounded capture
+/// worker. It is not a user-facing CLI command.
+pub const WORKER_ARGUMENT: &str = "--zeus-screenshot-worker";
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(default, deny_unknown_fields)]
+struct ScreenshotRequest {
+    window: Option<String>,
+    display: Option<u32>,
+    list: bool,
+}
+
+impl ScreenshotRequest {
+    fn parse(arguments: &Value) -> Result<Self, ScreenshotError> {
+        let request: Self = serde_json::from_value(arguments.clone()).map_err(|error| {
+            ScreenshotError::new(
+                "bad_request",
+                format!("invalid screenshot arguments: {error}"),
+            )
+        })?;
+        request.validate()?;
+        Ok(request)
+    }
+
+    fn validate(&self) -> Result<(), ScreenshotError> {
+        if self.window.is_some() && self.display.is_some() {
+            return Err(ScreenshotError::new(
+                "bad_request",
+                "`window` and `display` are mutually exclusive",
+            ));
+        }
+        if self
+            .window
+            .as_deref()
+            .is_some_and(|window| window.trim().is_empty())
+        {
+            return Err(ScreenshotError::new(
+                "bad_request",
+                "`window` must contain a non-empty title substring",
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct ScreenshotError {
+    pub code: String,
+    pub message: String,
+}
+
+impl ScreenshotError {
+    fn new(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+
+    fn unsupported() -> Self {
+        Self::new(
+            "screen_capture_unsupported",
+            "native screenshots are supported only by the local macOS Zeus app",
+        )
+    }
+
+    fn permission_denied(message: impl Into<String>) -> Self {
+        Self::new("screen_recording_denied", message)
+    }
+
+    fn capture_failed(message: impl Into<String>) -> Self {
+        Self::new("screenshot_failed", message)
+    }
+}
+
+impl fmt::Display for ScreenshotError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for ScreenshotError {}
+
+/// Captures one local target, or lists targets when `list` is true.
+///
+/// On macOS this delegates to a bounded child of the Engine so a permission
+/// dialog or a stalled first frame can never hang the MCP control connection.
+pub fn capture(arguments: &Value) -> Result<Value, ScreenshotError> {
+    let request = ScreenshotRequest::parse(arguments)?;
+
+    #[cfg(target_os = "macos")]
+    {
+        capture_via_worker(&request)
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = request;
+        Err(ScreenshotError::unsupported())
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct WorkerEnvelope {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ok: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<ScreenshotError>,
+}
+
+impl WorkerEnvelope {
+    fn from_result(result: Result<Value, ScreenshotError>) -> Self {
+        match result {
+            Ok(value) => Self {
+                ok: Some(value),
+                error: None,
+            },
+            Err(error) => Self {
+                ok: None,
+                error: Some(error),
+            },
+        }
+    }
+}
+
+/// Handles the private capture-worker mode before normal daemon startup.
+/// Returns true when the current process was a worker and normal startup must
+/// stop. The worker writes pixels only to stdout; image bytes are never logged.
+pub fn run_worker_if_requested() -> bool {
+    if std::env::args_os().nth(1).as_deref() != Some(std::ffi::OsStr::new(WORKER_ARGUMENT)) {
+        return false;
+    }
+
+    let result = std::panic::catch_unwind(|| {
+        let request: ScreenshotRequest =
+            serde_json::from_reader(std::io::Read::take(std::io::stdin().lock(), 64 * 1024))
+                .map_err(|error| {
+                    ScreenshotError::new("bad_request", format!("invalid worker request: {error}"))
+                })?;
+        request.validate()?;
+        capture_in_process(&request)
+    })
+    .unwrap_or_else(|_| {
+        Err(ScreenshotError::capture_failed(
+            "native capture stopped unexpectedly",
+        ))
+    });
+
+    let envelope = WorkerEnvelope::from_result(result);
+    let _ = serde_json::to_writer(std::io::stdout().lock(), &envelope);
+    true
+}
+
+#[cfg(target_os = "macos")]
+fn capture_via_worker(request: &ScreenshotRequest) -> Result<Value, ScreenshotError> {
+    use std::io::{Read, Write};
+    use std::process::{Command, Stdio};
+    use std::time::Instant;
+
+    let executable = std::env::current_exe().map_err(|error| {
+        ScreenshotError::capture_failed(format!("could not locate the Engine helper: {error}"))
+    })?;
+    let mut child = Command::new(executable)
+        .arg(WORKER_ARGUMENT)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| {
+            ScreenshotError::capture_failed(format!("could not launch capture worker: {error}"))
+        })?;
+
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| ScreenshotError::capture_failed("capture worker stdin was unavailable"))?;
+    serde_json::to_writer(&mut stdin, request).map_err(|error| {
+        ScreenshotError::capture_failed(format!("could not send capture request: {error}"))
+    })?;
+    stdin.flush().map_err(|error| {
+        ScreenshotError::capture_failed(format!("could not send capture request: {error}"))
+    })?;
+    drop(stdin);
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| ScreenshotError::capture_failed("capture worker stdout was unavailable"))?;
+    let output_reader = match std::thread::Builder::new()
+        .name("zeus-screenshot-output".into())
+        .spawn(move || {
+            let mut bytes = Vec::new();
+            stdout
+                .take(MAX_WORKER_OUTPUT_BYTES as u64 + 1)
+                .read_to_end(&mut bytes)
+                .map(|_| bytes)
+        }) {
+        Ok(reader) => reader,
+        Err(error) => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(ScreenshotError::capture_failed(format!(
+                "could not read capture result: {error}"
+            )));
+        }
+    };
+
+    let deadline = Instant::now() + WORKER_TIMEOUT;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break Some(status),
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(std::time::Duration::from_millis(25));
+            }
+            Ok(None) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                break None;
+            }
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(ScreenshotError::capture_failed(format!(
+                    "could not monitor capture worker: {error}"
+                )));
+            }
+        }
+    };
+
+    let bytes = output_reader
+        .join()
+        .map_err(|_| ScreenshotError::capture_failed("capture output reader stopped"))?
+        .map_err(|error| {
+            ScreenshotError::capture_failed(format!("could not read capture result: {error}"))
+        })?;
+
+    let Some(status) = status else {
+        return if scap::has_permission() {
+            Err(ScreenshotError::new(
+                "screenshot_timeout",
+                "native capture did not produce a frame within 15 seconds",
+            ))
+        } else {
+            Err(ScreenshotError::permission_denied(
+                "Screen Recording permission was not granted within 15 seconds. Ask the user to enable Screen Recording for Zeus in System Settings > Privacy & Security.",
+            ))
+        };
+    };
+    if bytes.len() > MAX_WORKER_OUTPUT_BYTES {
+        return Err(ScreenshotError::capture_failed(
+            "capture worker returned an oversized image",
+        ));
+    }
+
+    let envelope: WorkerEnvelope = serde_json::from_slice(&bytes).map_err(|error| {
+        ScreenshotError::capture_failed(format!(
+            "capture worker returned an invalid response (status {status}): {error}"
+        ))
+    })?;
+    match (envelope.ok, envelope.error) {
+        (Some(value), None) => Ok(value),
+        (None, Some(error)) => Err(error),
+        _ => Err(ScreenshotError::capture_failed(
+            "capture worker returned an incomplete response",
+        )),
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TargetKind {
+    Window,
+    Display,
+}
+
+impl TargetKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Window => "window",
+            Self::Display => "display",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct TargetInfo {
+    kind: TargetKind,
+    id: u32,
+    title: String,
+    owner_bundle: Option<String>,
+    active: bool,
+    on_screen: bool,
+}
+
+#[derive(Clone, Debug)]
+struct RawFrame {
+    width: u32,
+    height: u32,
+    bgra: Vec<u8>,
+}
+
+trait CaptureBackend {
+    fn is_supported(&self) -> bool;
+    fn has_permission(&self) -> bool;
+    fn request_permission(&mut self) -> bool;
+    fn targets(&mut self) -> Result<Vec<TargetInfo>, ScreenshotError>;
+    fn capture(&mut self, target: &TargetInfo) -> Result<RawFrame, ScreenshotError>;
+}
+
+fn capture_with_backend(
+    request: &ScreenshotRequest,
+    backend: &mut impl CaptureBackend,
+) -> Result<Value, ScreenshotError> {
+    if !backend.is_supported() {
+        return Err(ScreenshotError::unsupported());
+    }
+    if !backend.has_permission() {
+        let granted = backend.request_permission();
+        if !granted || !backend.has_permission() {
+            return Err(ScreenshotError::permission_denied(
+                "Screen Recording permission was denied. Ask the user to enable Screen Recording for Zeus in System Settings > Privacy & Security.",
+            ));
+        }
+    }
+
+    let targets = backend.targets()?;
+    if request.list {
+        return Ok(json!({
+            "targets": targets.iter().map(|target| json!({
+                "id": target.id,
+                "title": target.title,
+                "kind": target.kind.as_str(),
+            })).collect::<Vec<_>>()
+        }));
+    }
+
+    let resolved = resolve_target(request, &targets)?;
+    let frame = backend.capture(resolved.target)?;
+    let encoded = encode_bgra_as_jpeg(frame)?;
+    if encoded.jpeg.len() > MAX_JPEG_BYTES {
+        return Err(ScreenshotError::capture_failed(format!(
+            "JPEG exceeded the {} byte screenshot limit",
+            MAX_JPEG_BYTES
+        )));
+    }
+
+    Ok(json!({
+        "target": resolved.label,
+        "targetId": resolved.target.id,
+        "targetTitle": resolved.target.title,
+        "width": encoded.width,
+        "height": encoded.height,
+        "mimeType": "image/jpeg",
+        "data": base64::engine::general_purpose::STANDARD.encode(encoded.jpeg),
+    }))
+}
+
+struct ResolvedTarget<'a> {
+    target: &'a TargetInfo,
+    label: String,
+}
+
+fn resolve_target<'a>(
+    request: &ScreenshotRequest,
+    targets: &'a [TargetInfo],
+) -> Result<ResolvedTarget<'a>, ScreenshotError> {
+    if let Some(display_id) = request.display {
+        let target = targets
+            .iter()
+            .find(|target| target.kind == TargetKind::Display && target.id == display_id)
+            .ok_or_else(|| {
+                ScreenshotError::new(
+                    "screenshot_target_not_found",
+                    format!(
+                        "display {display_id} is not capturable; call screenshot with list=true"
+                    ),
+                )
+            })?;
+        return Ok(ResolvedTarget {
+            target,
+            label: format!("display:{display_id}"),
+        });
+    }
+
+    if let Some(window) = request.window.as_deref() {
+        let needle = window.trim().to_lowercase();
+        let matches: Vec<&TargetInfo> = targets
+            .iter()
+            .filter(|target| {
+                target.kind == TargetKind::Window && target.title.to_lowercase().contains(&needle)
+            })
+            .collect();
+        let exact: Vec<&TargetInfo> = matches
+            .iter()
+            .copied()
+            .filter(|target| target.title.eq_ignore_ascii_case(window.trim()))
+            .collect();
+        let target = match (exact.as_slice(), matches.as_slice()) {
+            ([target], _) => *target,
+            ([], [target]) => *target,
+            ([], []) => {
+                return Err(ScreenshotError::new(
+                    "screenshot_target_not_found",
+                    format!(
+                        "no capturable window title contains {window:?}; call screenshot with list=true"
+                    ),
+                ));
+            }
+            _ => {
+                let candidates = matches
+                    .iter()
+                    .map(|target| format!("{} ({})", target.title, target.id))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                return Err(ScreenshotError::new(
+                    "screenshot_target_ambiguous",
+                    format!("window title {window:?} matched multiple targets: {candidates}"),
+                ));
+            }
+        };
+        return Ok(ResolvedTarget {
+            target,
+            label: format!("window:{}", target.id),
+        });
+    }
+
+    let candidates: Vec<&TargetInfo> = targets
+        .iter()
+        .filter(|target| {
+            target.kind == TargetKind::Window
+                && target.on_screen
+                && target.owner_bundle.as_deref().is_some_and(is_zeus_bundle)
+        })
+        .collect();
+    let target = match candidates.as_slice() {
+        [] => {
+            return Err(ScreenshotError::new(
+                "zeus_window_unavailable",
+                "no local Zeus window is capturable. This screenshot tool captures the local Mac, not a remote host.",
+            ));
+        }
+        [target] => *target,
+        _ => {
+            let active: Vec<&TargetInfo> = candidates
+                .iter()
+                .copied()
+                .filter(|target| target.active)
+                .collect();
+            let [target] = active.as_slice() else {
+                return Err(ScreenshotError::new(
+                    "zeus_window_ambiguous",
+                    "multiple local Zeus windows are capturable and no single one is active; call screenshot with list=true, then pass window",
+                ));
+            };
+            *target
+        }
+    };
+    Ok(ResolvedTarget {
+        target,
+        label: "zeus".to_owned(),
+    })
+}
+
+fn is_zeus_bundle(bundle: &str) -> bool {
+    bundle == "com.zeus.zeus" || bundle.starts_with("com.zeus.zeus.")
+}
+
+struct EncodedImage {
+    width: u32,
+    height: u32,
+    jpeg: Vec<u8>,
+}
+
+fn encode_bgra_as_jpeg(frame: RawFrame) -> Result<EncodedImage, ScreenshotError> {
+    let pixels = u64::from(frame.width)
+        .checked_mul(u64::from(frame.height))
+        .ok_or_else(|| ScreenshotError::capture_failed("captured frame dimensions overflow"))?;
+    let expected = pixels
+        .checked_mul(4)
+        .and_then(|bytes| usize::try_from(bytes).ok())
+        .ok_or_else(|| ScreenshotError::capture_failed("captured frame is too large"))?;
+    if frame.width == 0 || frame.height == 0 || frame.bgra.len() != expected {
+        return Err(ScreenshotError::capture_failed(format!(
+            "captured BGRA frame has invalid dimensions or byte length ({}x{}, {} bytes)",
+            frame.width,
+            frame.height,
+            frame.bgra.len()
+        )));
+    }
+
+    let mut rgb = Vec::with_capacity(expected / 4 * 3);
+    for pixel in frame.bgra.chunks_exact(4) {
+        rgb.extend_from_slice(&[pixel[2], pixel[1], pixel[0]]);
+    }
+    let image = image::RgbImage::from_raw(frame.width, frame.height, rgb)
+        .ok_or_else(|| ScreenshotError::capture_failed("could not construct captured image"))?;
+    let (width, height, rgb) = if frame.width.max(frame.height) > MAX_IMAGE_EDGE {
+        let scale = MAX_IMAGE_EDGE as f64 / f64::from(frame.width.max(frame.height));
+        let width = (f64::from(frame.width) * scale).round().max(1.0) as u32;
+        let height = (f64::from(frame.height) * scale).round().max(1.0) as u32;
+        let resized =
+            image::imageops::resize(&image, width, height, image::imageops::FilterType::Triangle);
+        (width, height, resized.into_raw())
+    } else {
+        (frame.width, frame.height, image.into_raw())
+    };
+
+    let mut jpeg = Vec::new();
+    image::codecs::jpeg::JpegEncoder::new_with_quality(&mut jpeg, JPEG_QUALITY)
+        .encode(&rgb, width, height, image::ExtendedColorType::Rgb8)
+        .map_err(|error| {
+            ScreenshotError::capture_failed(format!("could not encode JPEG: {error}"))
+        })?;
+    Ok(EncodedImage {
+        width,
+        height,
+        jpeg,
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn capture_in_process(request: &ScreenshotRequest) -> Result<Value, ScreenshotError> {
+    let mut backend = NativeBackend::default();
+    capture_with_backend(request, &mut backend)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn capture_in_process(_request: &ScreenshotRequest) -> Result<Value, ScreenshotError> {
+    Err(ScreenshotError::unsupported())
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Default)]
+struct NativeBackend {
+    targets: Vec<(TargetInfo, scap::Target)>,
+}
+
+#[cfg(target_os = "macos")]
+impl CaptureBackend for NativeBackend {
+    fn is_supported(&self) -> bool {
+        scap::is_supported()
+    }
+
+    fn has_permission(&self) -> bool {
+        scap::has_permission()
+    }
+
+    fn request_permission(&mut self) -> bool {
+        scap::request_permission()
+    }
+
+    fn targets(&mut self) -> Result<Vec<TargetInfo>, ScreenshotError> {
+        use std::collections::HashMap;
+
+        let content = futures::executor::block_on(cidre::sc::ShareableContent::current()).map_err(
+            |error| {
+                ScreenshotError::capture_failed(format!(
+                    "could not enumerate ScreenCaptureKit content: {error:?}"
+                ))
+            },
+        )?;
+        let window_owners: HashMap<u32, (Option<String>, bool, bool)> = content
+            .windows()
+            .iter()
+            .map(|window| {
+                let owner_bundle = window
+                    .owning_app()
+                    .map(|application| application.bundle_id().to_string());
+                (
+                    window.id(),
+                    (owner_bundle, window.is_active(), window.is_on_screen()),
+                )
+            })
+            .collect();
+
+        self.targets = scap::get_all_targets()
+            .into_iter()
+            .map(|target| {
+                let info = match &target {
+                    scap::Target::Window(window) => {
+                        let (owner_bundle, active, on_screen) = window_owners
+                            .get(&window.id)
+                            .cloned()
+                            .unwrap_or((None, false, false));
+                        TargetInfo {
+                            kind: TargetKind::Window,
+                            id: window.id,
+                            title: window.title.clone(),
+                            owner_bundle,
+                            active,
+                            on_screen,
+                        }
+                    }
+                    scap::Target::Display(display) => TargetInfo {
+                        kind: TargetKind::Display,
+                        id: display.id,
+                        title: display.title.clone(),
+                        owner_bundle: None,
+                        active: false,
+                        on_screen: true,
+                    },
+                };
+                (info, target)
+            })
+            .collect();
+        Ok(self.targets.iter().map(|(info, _)| info.clone()).collect())
+    }
+
+    fn capture(&mut self, target: &TargetInfo) -> Result<RawFrame, ScreenshotError> {
+        use scap::capturer::{Capturer, Options, Resolution};
+        use scap::frame::{Frame, FrameType, VideoFrame};
+
+        let native_target = self
+            .targets
+            .iter()
+            .find(|(candidate, _)| candidate.kind == target.kind && candidate.id == target.id)
+            .map(|(_, target)| target.clone())
+            .ok_or_else(|| {
+                ScreenshotError::new(
+                    "screenshot_target_not_found",
+                    "the selected target disappeared before capture",
+                )
+            })?;
+        let options = Options {
+            fps: 1,
+            show_cursor: false,
+            show_highlight: false,
+            target: Some(native_target),
+            output_type: FrameType::BGRAFrame,
+            output_resolution: Resolution::_720p,
+            captures_audio: false,
+            exclude_current_process_audio: true,
+            ..Default::default()
+        };
+        let mut capturer = Capturer::build(options).map_err(|error| match error {
+            scap::capturer::CapturerBuildError::NotSupported => ScreenshotError::unsupported(),
+            scap::capturer::CapturerBuildError::PermissionNotGranted => {
+                ScreenshotError::permission_denied(
+                    "Screen Recording permission is not granted for Zeus",
+                )
+            }
+        })?;
+
+        capturer.start_capture();
+        let frame = (|| {
+            for _ in 0..3 {
+                match capturer.get_next_frame().map_err(|error| {
+                    ScreenshotError::capture_failed(format!(
+                        "native capture ended before a frame arrived: {error}"
+                    ))
+                })? {
+                    Frame::Video(VideoFrame::BGRA(frame))
+                        if frame.width > 0 && frame.height > 0 && !frame.data.is_empty() =>
+                    {
+                        return Ok(RawFrame {
+                            width: frame.width as u32,
+                            height: frame.height as u32,
+                            bgra: frame.data,
+                        });
+                    }
+                    Frame::Video(VideoFrame::BGRA(_)) => continue,
+                    Frame::Video(_) => {
+                        return Err(ScreenshotError::capture_failed(
+                            "native capturer returned a non-BGRA video frame",
+                        ));
+                    }
+                    Frame::Audio(_) => continue,
+                }
+            }
+            Err(ScreenshotError::capture_failed(
+                "native capturer returned only blank frames",
+            ))
+        })();
+        capturer.stop_capture();
+        frame
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FakeBackend {
+        supported: bool,
+        permitted: bool,
+        grants_permission: bool,
+        targets: Vec<TargetInfo>,
+        frame: Option<RawFrame>,
+        permission_requests: usize,
+        captures: usize,
+    }
+
+    impl CaptureBackend for FakeBackend {
+        fn is_supported(&self) -> bool {
+            self.supported
+        }
+
+        fn has_permission(&self) -> bool {
+            self.permitted
+        }
+
+        fn request_permission(&mut self) -> bool {
+            self.permission_requests += 1;
+            self.permitted = self.grants_permission;
+            self.grants_permission
+        }
+
+        fn targets(&mut self) -> Result<Vec<TargetInfo>, ScreenshotError> {
+            Ok(self.targets.clone())
+        }
+
+        fn capture(&mut self, _target: &TargetInfo) -> Result<RawFrame, ScreenshotError> {
+            self.captures += 1;
+            self.frame
+                .take()
+                .ok_or_else(|| ScreenshotError::capture_failed("fake has no frame"))
+        }
+    }
+
+    fn target(kind: TargetKind, id: u32, title: &str, owner_bundle: Option<&str>) -> TargetInfo {
+        TargetInfo {
+            kind,
+            id,
+            title: title.to_owned(),
+            owner_bundle: owner_bundle.map(str::to_owned),
+            active: false,
+            on_screen: true,
+        }
+    }
+
+    fn backend() -> FakeBackend {
+        FakeBackend {
+            supported: true,
+            permitted: true,
+            grants_permission: false,
+            targets: vec![
+                target(TargetKind::Display, 9, "Main Display", None),
+                target(TargetKind::Window, 10, "Other", Some("com.example.other")),
+                target(TargetKind::Window, 11, "Zeus", Some("com.zeus.zeus")),
+            ],
+            frame: Some(RawFrame {
+                width: 2,
+                height: 1,
+                bgra: vec![0, 0, 255, 255, 0, 255, 0, 255],
+            }),
+            permission_requests: 0,
+            captures: 0,
+        }
+    }
+
+    #[test]
+    fn default_capture_selects_a_zeus_window_and_encodes_jpeg() {
+        let mut backend = backend();
+        let result =
+            capture_with_backend(&ScreenshotRequest::default(), &mut backend).expect("screenshot");
+
+        assert_eq!(result["target"], "zeus");
+        assert_eq!(result["targetId"], 11);
+        assert_eq!(result["mimeType"], "image/jpeg");
+        assert_eq!(backend.captures, 1, "the display must not be captured");
+        let jpeg = base64::engine::general_purpose::STANDARD
+            .decode(result["data"].as_str().expect("base64"))
+            .expect("valid base64");
+        let decoded = image::load_from_memory_with_format(&jpeg, image::ImageFormat::Jpeg)
+            .expect("valid JPEG");
+        assert_eq!((decoded.width(), decoded.height()), (2, 1));
+    }
+
+    #[test]
+    fn list_returns_titles_and_ids_without_encoding_an_image() {
+        let mut backend = backend();
+        let result = capture_with_backend(
+            &ScreenshotRequest {
+                list: true,
+                ..Default::default()
+            },
+            &mut backend,
+        )
+        .expect("target list");
+
+        assert_eq!(result["targets"].as_array().expect("targets").len(), 3);
+        assert!(result.get("data").is_none());
+        assert_eq!(backend.captures, 0);
+    }
+
+    #[test]
+    fn window_and_display_together_are_a_bad_request() {
+        let error = ScreenshotRequest::parse(&json!({"window":"Zeus","display":9}))
+            .expect_err("mutually exclusive");
+        assert_eq!(error.code, "bad_request");
+    }
+
+    #[test]
+    fn denied_permission_is_structured_and_never_captures() {
+        let mut backend = backend();
+        backend.permitted = false;
+        let error =
+            capture_with_backend(&ScreenshotRequest::default(), &mut backend).expect_err("denied");
+
+        assert_eq!(error.code, "screen_recording_denied");
+        assert_eq!(backend.permission_requests, 1);
+        assert_eq!(backend.captures, 0);
+    }
+
+    #[test]
+    fn newly_granted_permission_continues_to_capture() {
+        let mut backend = backend();
+        backend.permitted = false;
+        backend.grants_permission = true;
+        let result = capture_with_backend(&ScreenshotRequest::default(), &mut backend)
+            .expect("permission grant");
+
+        assert_eq!(result["mimeType"], "image/jpeg");
+        assert_eq!(backend.permission_requests, 1);
+        assert_eq!(backend.captures, 1);
+    }
+
+    #[test]
+    fn title_substrings_must_resolve_unambiguously() {
+        let mut backend = backend();
+        backend.targets.push(target(
+            TargetKind::Window,
+            12,
+            "Zeus Settings",
+            Some("com.zeus.zeus"),
+        ));
+        let request = ScreenshotRequest {
+            window: Some("zeu".to_owned()),
+            ..Default::default()
+        };
+        let error = capture_with_backend(&request, &mut backend).expect_err("ambiguous");
+        assert_eq!(error.code, "screenshot_target_ambiguous");
+        assert_eq!(backend.captures, 0);
+    }
+
+    #[test]
+    fn multiple_inactive_zeus_windows_fail_closed() {
+        let mut backend = backend();
+        backend.targets.push(target(
+            TargetKind::Window,
+            12,
+            "Zeus Dev",
+            Some("com.zeus.zeus.dev.abc1234"),
+        ));
+        let error = capture_with_backend(&ScreenshotRequest::default(), &mut backend)
+            .expect_err("ambiguous default");
+        assert_eq!(error.code, "zeus_window_ambiguous");
+        assert_eq!(backend.captures, 0);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn real_window_soak_is_explicitly_opt_in() {
+        if std::env::var("ZEUS_SCREENSHOT_SOAK").ok().as_deref() != Some("1") {
+            return;
+        }
+        let result = capture_in_process(&ScreenshotRequest::default()).expect("real screenshot");
+        assert_eq!(result["mimeType"], "image/jpeg");
+        assert!(result["data"].as_str().is_some_and(|data| !data.is_empty()));
+    }
+}

--- a/zeus/crates/zeus-mcp/src/main.rs
+++ b/zeus/crates/zeus-mcp/src/main.rs
@@ -107,16 +107,37 @@ fn error(id: Value, code: i64, message: impl Into<String>) -> Value {
     json!({"jsonrpc":"2.0","id":id,"error":{"code":code,"message":message.into()}})
 }
 
-fn tool_content(result: Result<Value, String>) -> Value {
-    let (value, is_error) = match result {
-        Ok(value) => (value, false),
-        Err(message) => (Value::String(message), true),
+fn tool_content(tool: Option<&str>, result: Result<Value, String>) -> Value {
+    let mut value = match result {
+        Ok(value) => value,
+        Err(message) => {
+            return json!({"content":[{"type":"text","text":message}],"isError":true});
+        }
     };
+    if tool == Some("screenshot")
+        && let Some(object) = value.as_object_mut()
+        && let Some(data) = object.remove("data")
+    {
+        let Some(mime_type) = object.remove("mimeType") else {
+            return json!({"content":[{"type":"text","text":"screenshot result omitted mimeType"}],"isError":true});
+        };
+        if !data.is_string() || !mime_type.is_string() {
+            return json!({"content":[{"type":"text","text":"screenshot result contained invalid image content"}],"isError":true});
+        }
+        let text = serde_json::to_string(&value).unwrap_or_else(|_| "null".to_owned());
+        return json!({
+            "content":[
+                {"type":"text","text":text},
+                {"type":"image","mimeType":mime_type,"data":data}
+            ],
+            "isError":false
+        });
+    }
     let text = value.as_str().map_or_else(
         || serde_json::to_string(&value).unwrap_or_else(|_| "null".to_owned()),
         str::to_owned,
     );
-    json!({"content":[{"type":"text","text":text}],"isError":is_error})
+    json!({"content":[{"type":"text","text":text}],"isError":false})
 }
 
 fn initialize(params: &Value) -> Value {
@@ -172,14 +193,14 @@ fn handle_message(message: Value, backend: &mut impl ToolBackend) -> Option<Valu
             let Some(name) = params.get("name").and_then(Value::as_str) else {
                 return success(
                     id,
-                    tool_content(Err("tools/call missing 'name'".to_owned())),
+                    tool_content(None, Err("tools/call missing 'name'".to_owned())),
                 );
             };
             let arguments = params
                 .get("arguments")
                 .cloned()
                 .unwrap_or_else(|| json!({}));
-            success(id, tool_content(backend.call(name, &arguments)))
+            success(id, tool_content(Some(name), backend.call(name, &arguments)))
         }),
         _ if id.is_none() => None,
         _ => Some(error(
@@ -239,9 +260,17 @@ mod tests {
         }
 
         fn call(&mut self, name: &str, _: &Value) -> Result<Value, String> {
-            (name == "list_agents")
-                .then(|| json!({"agents":[]}))
-                .ok_or_else(|| "unknown tool".to_owned())
+            match name {
+                "list_agents" => Ok(json!({"agents":[]})),
+                "screenshot" => Ok(json!({
+                    "target":"zeus",
+                    "width":2,
+                    "height":1,
+                    "mimeType":"image/jpeg",
+                    "data":"/9j/2Q=="
+                })),
+                _ => Err("unknown tool".to_owned()),
+            }
         }
     }
 
@@ -286,5 +315,20 @@ mod tests {
         .unwrap();
         assert_eq!(called["result"]["isError"], false);
         assert_eq!(called["result"]["content"][0]["text"], "{\"agents\":[]}");
+
+        let screenshot = handle_message(
+            json!({"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"screenshot","arguments":{}}}),
+            &mut backend,
+        )
+        .unwrap();
+        assert_eq!(screenshot["result"]["isError"], false);
+        assert_eq!(screenshot["result"]["content"][1]["type"], "image");
+        assert_eq!(screenshot["result"]["content"][1]["data"], "/9j/2Q==");
+        assert!(
+            !screenshot["result"]["content"][0]["text"]
+                .as_str()
+                .expect("metadata")
+                .contains("/9j/2Q==")
+        );
     }
 }

--- a/zeus/crates/zeus-proto/src/methods.rs
+++ b/zeus/crates/zeus-proto/src/methods.rs
@@ -69,6 +69,7 @@ impl Method {
     pub const EVENTS_WAIT: &'static str = "events.wait";
     pub const HOOK_REPORT: &'static str = "hook.report";
     pub const TEST_RUN: &'static str = "test.run";
+    pub const SCREENSHOT_CAPTURE: &'static str = "screenshot.capture";
     pub const STATE_SNAPSHOT: &'static str = "state.snapshot";
     pub const DAEMON_PREPARE_SHUTDOWN: &'static str = "daemon.prepare_shutdown";
     pub const DAEMON_SHUTDOWN_IF_IDLE: &'static str = "daemon.shutdown_if_idle";

--- a/zeus/crates/zeus-proto/tests/control_roundtrip.rs
+++ b/zeus/crates/zeus-proto/tests/control_roundtrip.rs
@@ -246,12 +246,13 @@ fn method_name_set_is_complete() {
         Method::EVENTS_WAIT,
         Method::HOOK_REPORT,
         Method::TEST_RUN,
+        Method::SCREENSHOT_CAPTURE,
         Method::STATE_SNAPSHOT,
         Method::DAEMON_PREPARE_SHUTDOWN,
         Method::DAEMON_SHUTDOWN_IF_IDLE,
         Method::DAEMON_SHUTDOWN,
     ];
-    assert_eq!(methods.len(), 51);
+    assert_eq!(methods.len(), 52);
     assert_eq!(methods[0], "hello");
     assert_eq!(methods.last().copied(), Some("daemon.shutdown"));
 }

--- a/zeus/scripts/dev.sh
+++ b/zeus/scripts/dev.sh
@@ -178,6 +178,7 @@ cat > "${contents}/Info.plist" <<PLIST
     <key>LSMinimumSystemVersion</key><string>15.0</string>
     <key>NSHighResolutionCapable</key><true/>
     <key>NSPrincipalClass</key><string>NSApplication</string>
+    <key>NSScreenCaptureUsageDescription</key><string>Zeus captures a window when a hosted coding agent asks to see the local interface.</string>
 </dict>
 </plist>
 PLIST


### PR DESCRIPTION
Closes #62

## Summary
- advertise a dedicated screenshot MCP tool from the live Zeus catalog
- capture the local Zeus window, selected windows, or opt-in displays through a bounded Engine-owned scap worker
- encode one 720p BGRA frame as JPEG and return MCP text plus image content without writing an artifact
- fail closed on permission, timeout, unsupported-platform, missing-target, and ambiguous-target cases
- add Screen Recording usage metadata, deterministic fake-capture coverage, and an opt-in real-window soak guide

## Testing
- DOCS_RS=1 cargo clippy -p zeus-engine -p zeus-cli -p zeus-mcp -p zeus-proto --all-targets -- -D warnings
- cargo test -p zeus-cli -p zeus-mcp -p zeus-proto (69 passed)
- cargo fmt --all -- --check
- git diff --check

## Local limitation
The machine has only Apple Command Line Tools. cidre requires full Xcode to build its native static libraries, so native linking and the full workspace test suite could not run locally. The macOS-specific Rust code passed check and strict Clippy with cidre native build disabled.