### PR TITLE
fix(engine): unify terminal color environment

### DIFF
--- a/zeus/crates/zeus-engine/src/agent.rs
+++ b/zeus/crates/zeus-engine/src/agent.rs
@@ -177,11 +177,7 @@ impl AgentDescriptor {
             }
             spec.env.push((key, value));
         }
-        spec.env.retain(|(key, _)| key != "NO_COLOR");
-        spec.env
-            .retain(|(key, _)| key != "TERM" && key != "COLORTERM");
-        spec.env.push(("TERM".into(), "xterm-256color".into()));
-        spec.env.push(("COLORTERM".into(), "truecolor".into()));
+        crate::pty::assert_color_environment(&mut spec.env);
         for (key, value) in &self.env {
             spec.env.retain(|(existing, _)| existing != key);
             spec.env.push((key.clone(), value.clone()));
@@ -255,10 +251,7 @@ impl AgentDescriptor {
                 spec.env.push((key, value));
             }
         }
-        spec.env
-            .retain(|(key, _)| !matches!(key.as_str(), "NO_COLOR" | "TERM" | "COLORTERM"));
-        spec.env.push(("TERM".into(), "xterm-256color".into()));
-        spec.env.push(("COLORTERM".into(), "truecolor".into()));
+        crate::pty::assert_color_environment(&mut spec.env);
         for (key, value) in &self.env {
             spec.env.retain(|(existing, _)| existing != key);
             spec.env.push((key.clone(), value.clone()));
@@ -553,27 +546,35 @@ mod tests {
     }
 
     #[test]
-    fn colour_is_asserted_rather_than_inherited() {
+    fn colour_is_asserted_for_local_and_remote_agents_rather_than_inherited() {
         // An inherited NO_COLOR turns the agent monochrome, and the screen
         // rules that look for its prompt box then never match.
         let claude = descriptor("claude-code");
         let inherited = [
             ("NO_COLOR".to_string(), "1".to_string()),
             ("TERM".to_string(), "dumb".to_string()),
+            ("COLORTERM".to_string(), "ansi".to_string()),
         ];
-        let spec = claude
-            .spawn_spec(Path::new("/tmp"), inherited, &[])
-            .expect("spec");
+        let specs = [
+            claude
+                .spawn_spec(Path::new("/tmp"), inherited.clone(), &[])
+                .expect("local spec"),
+            claude
+                .remote_spawn_spec(Path::new("/tmp"), inherited, &[])
+                .expect("remote spec"),
+        ];
 
-        let get = |name: &str| {
-            spec.env
-                .iter()
-                .find(|(key, _)| key == name)
-                .map(|(_, value)| value.as_str())
-        };
-        assert_eq!(get("NO_COLOR"), None, "NO_COLOR must be removed");
-        assert_eq!(get("TERM"), Some("xterm-256color"));
-        assert_eq!(get("COLORTERM"), Some("truecolor"));
+        for spec in specs {
+            let get = |name: &str| {
+                spec.env
+                    .iter()
+                    .find(|(key, _)| key == name)
+                    .map(|(_, value)| value.as_str())
+            };
+            assert_eq!(get("NO_COLOR"), None, "NO_COLOR must be removed");
+            assert_eq!(get("TERM"), Some("xterm-256color"));
+            assert_eq!(get("COLORTERM"), Some("truecolor"));
+        }
     }
 
     #[test]

--- a/zeus/crates/zeus-engine/src/control.rs
+++ b/zeus/crates/zeus-engine/src/control.rs
@@ -840,12 +840,7 @@ impl ControlServer {
         let mut pty = match descriptor.spawn_spec(&cwd_path, inherited.clone(), &launch_args) {
             Some(spec) => spec,
             // No binary in the manifest: the caller has to say what to run.
-            None if !argv.is_empty() => {
-                let mut spec = crate::pty::PtySpec::new(argv.clone(), &cwd_path);
-                spec.env = inherited;
-                spec.env.retain(|(key, _)| key != "NO_COLOR");
-                spec
-            }
+            None if !argv.is_empty() => binary_free_spawn_spec(argv.clone(), &cwd_path, inherited),
             None => {
                 return Err(ControlError::bad_request(format!(
                     "agent {kind:?} declares no binary, so argv is required"
@@ -1062,12 +1057,7 @@ impl ControlServer {
                 .remote_spawn_spec(&cwd, inherited, &launch_args)
                 .ok_or_else(|| ControlError::internal("remote descriptor has no binary"))?
         } else {
-            let mut spec = crate::pty::PtySpec::new(argv, &cwd);
-            spec.env = inherited;
-            spec.env.retain(|(key, _)| key != "NO_COLOR");
-            spec.env.retain(|(key, _)| key != "TERM");
-            spec.env.push(("TERM".into(), "xterm-256color".into()));
-            spec
+            binary_free_spawn_spec(argv, &cwd, inherited)
         };
         if let (Some(cols), Some(rows)) = (p.initial_cols, p.initial_rows) {
             pty.cols = cols.clamp(2, u16::MAX as i64) as u16;
@@ -2599,6 +2589,20 @@ impl ControlServer {
     }
 }
 
+/// Build the PTY spec for manifests without a binary (`shell` and `generic`).
+/// Local and remote session creation deliberately share this function so
+/// their terminal capabilities cannot drift apart again.
+fn binary_free_spawn_spec(
+    argv: Vec<String>,
+    cwd: &Path,
+    inherited: impl IntoIterator<Item = (String, String)>,
+) -> crate::pty::PtySpec {
+    let mut spec = crate::pty::PtySpec::new(argv, cwd);
+    spec.env.extend(inherited);
+    crate::pty::assert_color_environment(&mut spec.env);
+    spec
+}
+
 impl Drop for ControlServer {
     fn drop(&mut self) {
         // Leaving the socket file behind would make the next start think a
@@ -3898,6 +3902,33 @@ mod tests {
                 .is_empty(),
             "an unavailable remote transport must not create a session record"
         );
+    }
+
+    #[test]
+    fn binary_free_local_and_remote_shells_share_the_truecolor_environment() {
+        // Both branches of session spawn call this builder. Exercise the
+        // captured remote-shell case with stale capabilities so neither path
+        // can regress to forwarding them or setting only TERM.
+        let spec = binary_free_spawn_spec(
+            vec!["/bin/sh".into(), "-l".into()],
+            Path::new("/remote/project"),
+            [
+                ("PATH".into(), "/usr/bin:/bin".into()),
+                ("TERM".into(), "dumb".into()),
+                ("COLORTERM".into(), "ansi".into()),
+                ("NO_COLOR".into(), "1".into()),
+            ],
+        );
+        let value = |name: &str| {
+            spec.env
+                .iter()
+                .find(|(key, _)| key == name)
+                .map(|(_, value)| value.as_str())
+        };
+
+        assert_eq!(value("TERM"), Some("xterm-256color"));
+        assert_eq!(value("COLORTERM"), Some("truecolor"));
+        assert_eq!(value("NO_COLOR"), None);
     }
 
     #[test]

--- a/zeus/crates/zeus-engine/src/pty.rs
+++ b/zeus/crates/zeus-engine/src/pty.rs
@@ -1,3 +1,56 @@
 //! Shared PTY primitives used by the local Engine and remote Holder.
 
 pub use zeus_pty::*;
+
+/// Make terminal color capabilities explicit for a PTY child.
+///
+/// Zeus can be launched from a GUI or long-lived daemon without `TERM`, while
+/// an inherited shell environment can carry values that describe a different
+/// terminal. Remove those inputs before asserting the capabilities provided by
+/// Zeus's terminal renderer.
+pub(crate) fn assert_color_environment(environment: &mut Vec<(String, String)>) {
+    environment.retain(|(name, _)| !matches!(name.as_str(), "NO_COLOR" | "TERM" | "COLORTERM"));
+    environment.push(("TERM".into(), "xterm-256color".into()));
+    environment.push(("COLORTERM".into(), "truecolor".into()));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::assert_color_environment;
+
+    #[test]
+    fn color_environment_is_complete_without_inherited_terminal_values() {
+        let mut environment = vec![("PATH".into(), "/usr/bin:/bin".into())];
+
+        assert_color_environment(&mut environment);
+
+        assert_eq!(
+            environment,
+            [
+                ("PATH".into(), "/usr/bin:/bin".into()),
+                ("TERM".into(), "xterm-256color".into()),
+                ("COLORTERM".into(), "truecolor".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn color_environment_replaces_stale_values_and_removes_opt_outs() {
+        let mut environment = vec![
+            ("TERM".into(), "dumb".into()),
+            ("COLORTERM".into(), "24bit".into()),
+            ("NO_COLOR".into(), "1".into()),
+            ("TERM".into(), "vt100".into()),
+        ];
+
+        assert_color_environment(&mut environment);
+
+        assert_eq!(
+            environment,
+            [
+                ("TERM".into(), "xterm-256color".into()),
+                ("COLORTERM".into(), "truecolor".into()),
+            ]
+        );
+    }
+}

--- a/zeus/crates/zeus-engine/tests/control_socket.rs
+++ b/zeus/crates/zeus-engine/tests/control_socket.rs
@@ -128,9 +128,37 @@ fn a_client_can_handshake_and_list_over_the_socket() {
 }
 
 #[test]
-fn spawning_a_shell_over_the_socket_produces_a_watched_session() {
-    // The capstone: a client asks the engine to start something, and gets back
-    // a session record for a process the engine is now watching.
+fn a_terminal_without_inherited_term_runs_clear_over_the_socket() {
+    // Run the regression body in an isolated copy of this test process. That
+    // faithfully simulates a GUI-launched daemon without TERM without racing
+    // other tests through process-global environment mutation.
+    const CHILD_MARKER: &str = "ZEUS_TEST_CONTROL_SOCKET_WITHOUT_TERM";
+    if std::env::var_os(CHILD_MARKER).is_none() {
+        let output = std::process::Command::new(std::env::current_exe().expect("test executable"))
+            .args([
+                "--exact",
+                "a_terminal_without_inherited_term_runs_clear_over_the_socket",
+                "--nocapture",
+            ])
+            .env_remove("TERM")
+            .env(CHILD_MARKER, "1")
+            .output()
+            .expect("run isolated regression test");
+        assert!(
+            output.status.success(),
+            "isolated test failed\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        return;
+    }
+    assert!(
+        std::env::var_os("TERM").is_none(),
+        "the simulated GUI/daemon environment must not provide TERM"
+    );
+
+    // A client asks the engine to start a binary-free Terminal manifest. The
+    // session must supply enough terminal capability for clear(1) to work.
     let temp = tempfile::tempdir().expect("temp");
     let registry = Registry::new(engine(), temp.path().join("state.json"));
     let registry = Arc::new(Mutex::new(registry));
@@ -167,7 +195,7 @@ fn spawning_a_shell_over_the_socket_produces_a_watched_session() {
         params: Some(json!({
             "kind": { "shell": {} },
             "cwd": "/tmp",
-            "argv": ["/bin/sh", "-c", "printf spawned-ok\\n; sleep 30"],
+            "argv": ["/bin/sh", "-c", "clear && printf clear-ok\\n; sleep 30"],
         })),
     });
     let id = match spawned {
@@ -178,7 +206,7 @@ fn spawning_a_shell_over_the_socket_produces_a_watched_session() {
     };
     assert!(id.starts_with("s_"), "id follows the daemon format: {id}");
 
-    // The engine is really watching it: its output reaches the screen.
+    // clear(1) succeeded and the following output reached the watched screen.
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
     let mut seen = false;
     while std::time::Instant::now() < deadline && !seen {
@@ -194,16 +222,13 @@ fn spawning_a_shell_over_the_socket_produces_a_watched_session() {
         {
             seen = result["text"]
                 .as_str()
-                .is_some_and(|text| text.contains("spawned-ok"));
+                .is_some_and(|text| text.contains("clear-ok"));
         }
         if !seen {
             std::thread::sleep(std::time::Duration::from_millis(50));
         }
     }
-    assert!(
-        seen,
-        "the spawned process's output never reached the engine"
-    );
+    assert!(seen, "clear did not succeed in the Terminal session");
 
     // And listing reports it.
     let listed = request(ControlMessage::Request {


### PR DESCRIPTION
## Summary

- centralize TERM, COLORTERM, and NO_COLOR normalization in assert_color_environment
- share binary-free PTY construction between local Terminal and remote shell sessions
- add agent, remote-shell, and no-inherited-TERM control-socket regression coverage

## Verification

- cargo fmt --all -- --check
- cargo check -p zeus-engine --tests --target aarch64-unknown-linux-musl
- cargo clippy -p zeus-engine --all-targets --no-deps --target aarch64-unknown-linux-musl -- -A dead-code -D warnings

Native cargo test execution was attempted but this machine only has Apple Command Line Tools; the cidre build script requires full Xcode and fails before compiling Zeus.

Closes #66