### PR TITLE
fix(orchestration): route delegation through Zeus

### DIFF
--- a/zeus/Cargo.lock
+++ b/zeus/Cargo.lock
@@ -7983,6 +7983,7 @@ name = "zeus-mcp"
 version = "0.2.0"
 dependencies = [
  "serde_json",
+ "zeus-proto",
 ]
 
 [[package]]

--- a/zeus/README.md
+++ b/zeus/README.md
@@ -81,6 +81,20 @@ preferences, and Application Support directory. That makes the dev build useful
 against real sessions, but do not focus the same session in both apps at
 different terminal sizes: each client can resize the shared PTY.
 
+An ignored live smoke test checks that an ordinary delegation request creates
+a child `SessionRecord` through the hosted agent's Zeus MCP connection. Start
+the current development build, ensure the selected agent is authenticated, and
+run:
+
+```sh
+ZEUS_REAL_AGENT_SMOKE=1 ZEUS_REAL_AGENT_KIND=codex \
+  cargo test -p zeus-cli --test real_agent_delegation -- --ignored --nocapture
+```
+
+The test uses the current directory by default; set `ZEUS_REAL_AGENT_CWD` and
+`ZEUS_REAL_AGENT_TIMEOUT_SECONDS` to override its workspace and 300-second
+deadline. It removes the parent and child sessions it creates.
+
 The app uses blurred window backing, a translucent persistent-width sidebar, an opaque Zeus Dark terminal card, full-size content under transparent titlebar chrome, adjusted traffic lights, and a 900×560 minimum size.
 
 ### Sidebar preview fixtures

--- a/zeus/crates/zeus-cli/src/mcp.rs
+++ b/zeus/crates/zeus-cli/src/mcp.rs
@@ -6,6 +6,9 @@ use std::process;
 use std::time::Duration;
 
 use serde_json::{Map, Value, json};
+use zeus_proto::orchestration::{
+    CREATE_ZEUS_SESSION_TOOL, canonical_tool_name, create_session_tool_definition, mcp_instructions,
+};
 use zeus_proto::{
     AgentKind, EventsSubscribeParams, EventsWaitParams, Method, SendTextParams, SessionId,
     SessionIdParams, SessionRecord, SessionSpawnParams, TestRunParams, WorktreeCreateParams,
@@ -23,8 +26,8 @@ pub fn tools_json() -> Value {
 }
 
 pub fn call(tool: &str, args: &Value) -> Result<Value, CliError> {
-    match tool {
-        "spawn_agent" => spawn_agent(args),
+    match canonical_tool_name(tool) {
+        CREATE_ZEUS_SESSION_TOOL => spawn_agent(args),
         "list_agents" => list_agents(),
         "get_status" => get_status(args),
         "send_prompt" => send_prompt(args),
@@ -126,34 +129,11 @@ fn initialize(params: &Value) -> Value {
         .get("protocolVersion")
         .and_then(Value::as_str)
         .unwrap_or("2025-06-18");
-    let browser = if env::var_os("ZEUS_TEST_RUN_AVAILABLE").is_some() {
-        " To test a web feature, use test_run with a preview URL from get_artifacts."
-    } else {
-        ""
-    };
     json!({
         "protocolVersion": version,
         "capabilities": {"tools":{}},
         "serverInfo": {"name":"zeus","version":env!("CARGO_PKG_VERSION")},
-        "instructions": format!(
-            "This session is running INSIDE Zeus, a macOS orchestrator for coding agents. \
-             These tools control it. Use them proactively whenever the user asks to \
-             open/start/spawn/close another agent, session, tab, or terminal (Claude Code, \
-             Codex, Cursor, Gemini, or a shell), to check what other sessions are doing, to \
-             talk to another session, or to parallelize work across git worktrees — no \
-             extra confirmation of intent needed.\n\nNever use the host agent's built-in \
-             collaboration spawn_agent / subagents: those workers stay inside this terminal \
-             and never appear in the Zeus sidebar. Always call this MCP spawn_agent so the \
-             child is a real Zeus tab. Unless the user explicitly requests multiple agents, \
-             make exactly one spawn_agent call. When the user does not name an agent kind, omit \
-             kind so Zeus uses the configured default; never probe or fan out across kinds.\n\n\
-             Typical orchestration flow: spawn_agent \
-             (optionally worktree:true and an initial prompt) → wait_for_agent(until:\"done\") \
-             → read_output → send_prompt for follow-ups → release_agent when finished. \
-             get_artifacts returns PR/Linear/preview URLs and listening ports a session has \
-             produced; PR entries include live GitHub status (state, review decision, checks, \
-             comment counts, +/- lines).{browser}"
-        )
+        "instructions": mcp_instructions(env::var_os("ZEUS_TEST_RUN_AVAILABLE").is_some()),
     })
 }
 
@@ -197,25 +177,9 @@ fn tool_content(tool: Option<&str>, result: Result<Value, String>) -> Value {
 fn tool_definitions() -> Vec<Value> {
     let kinds = catalog::spawnable_kind_labels();
     let names = catalog::spawnable_display_names();
+    let spawn = create_session_tool_definition(&kinds, &names);
     let mut tools = vec![
-        tool(
-            "spawn_agent",
-            &format!(
-                "Open ONE new Zeus session tab nested under this one, running {names} — locally or on a configured remote host. This is the ONLY way spawned agents appear in the Zeus sidebar and terminal. Do NOT use built-in collaboration/subagent spawn — those stay hidden inside this PTY. USE THIS whenever the user asks to open/start/spawn/launch another agent, session, or terminal. Unless the user explicitly requests multiple agents, call this exactly once. If the user does not name a kind, omit kind and Zeus will use the configured default; never guess, probe, or fan out across agent kinds."
-            ),
-            json!({
-                "type":"object",
-                "properties":{
-                    "kind":{"type":"string","enum":kinds,"description":"Which agent to run. Omit to use Zeus's configured default agent."},
-                    "cwd":{"type":"string","description":"Working directory."},
-                    "host":{"type":"string","description":"Host id from hosts.json."},
-                    "worktree":{"type":"boolean","description":"Create a fresh git worktree off cwd and run there. Local only."},
-                    "prompt":{"type":"string","description":"Initial prompt to send once the agent is ready."},
-                    "name":{"type":"string","description":"Session title."}
-                },
-                "required":["cwd"]
-            }),
-        ),
+        tool(&spawn.name, &spawn.description, spawn.input_schema),
         tool(
             "list_agents",
             "List all active agent sessions with id, kind, title, status, parent, and cwd.",
@@ -1086,7 +1050,7 @@ mod tests {
             .filter_map(|tool| tool["name"].as_str())
             .collect();
         for expected in [
-            "spawn_agent",
+            "create_zeus_session",
             "get_artifacts",
             "browser",
             "screenshot",
@@ -1099,7 +1063,17 @@ mod tests {
                 "{expected} missing from {names:?}"
             );
         }
+        assert!(!names.contains(&"spawn_agent"));
         assert!(!names.contains(&"test_run"));
+    }
+
+    #[test]
+    fn initialize_uses_the_shared_orchestration_instructions() {
+        let initialized = initialize(&json!({ "protocolVersion": "2025-06-18" }));
+        assert_eq!(
+            initialized["instructions"],
+            mcp_instructions(env::var_os("ZEUS_TEST_RUN_AVAILABLE").is_some())
+        );
     }
 
     #[test]
@@ -1160,17 +1134,24 @@ mod tests {
     }
 
     #[test]
-    fn spawn_agent_omits_kind_to_use_the_configured_default() {
+    fn create_zeus_session_omits_kind_and_keeps_the_legacy_alias_callable() {
         let tools = tool_definitions();
         let spawn = tools
             .iter()
-            .find(|tool| tool["name"] == "spawn_agent")
-            .expect("spawn_agent");
+            .find(|tool| tool["name"] == "create_zeus_session")
+            .expect("create_zeus_session");
         let required = spawn["inputSchema"]["required"]
             .as_array()
             .expect("required");
         assert!(!required.iter().any(|field| field == "kind"));
         assert!(required.iter().any(|field| field == "cwd"));
+        assert_eq!(canonical_tool_name("spawn_agent"), "create_zeus_session");
+        let legacy_error = call("spawn_agent", &json!({ "kind": "not-an-agent" }))
+            .expect_err("invalid legacy spawn call");
+        assert!(
+            legacy_error.to_string().contains("invalid kind"),
+            "the compatibility alias must reach session creation: {legacy_error}"
+        );
 
         assert_eq!(
             default_agent_from_preferences(&json!({"defaultAgent": "codex"})).as_deref(),

--- a/zeus/crates/zeus-cli/tests/real_agent_delegation.rs
+++ b/zeus/crates/zeus-cli/tests/real_agent_delegation.rs
@@ -1,0 +1,139 @@
+//! Opt-in acceptance test for hosted-agent orchestration.
+//!
+//! This intentionally talks to a running development Zeus daemon and consumes
+//! a real provider turn. Normal test runs ignore it.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use serde_json::Value;
+use zeus_proto::SessionRecord;
+
+const OPT_IN_ENV: &str = "ZEUS_REAL_AGENT_SMOKE";
+
+fn cli() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_zeus-cli"))
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(cli())
+        .args(args)
+        .output()
+        .unwrap_or_else(|error| panic!("could not launch zeus-cli {args:?}: {error}"))
+}
+
+fn run_ok(args: &[&str]) -> Output {
+    let output = run(args);
+    assert!(
+        output.status.success(),
+        "zeus-cli {args:?} failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output
+}
+
+fn sessions() -> Vec<SessionRecord> {
+    let output = run_ok(&["session", "list", "--all", "--json"]);
+    let envelope: Value = serde_json::from_slice(&output.stdout).expect("session list JSON");
+    serde_json::from_value(envelope["sessions"].clone()).expect("SessionRecord list")
+}
+
+struct CreatedSessions(Vec<String>);
+
+impl CreatedSessions {
+    fn track(&mut self, id: impl Into<String>) {
+        let id = id.into();
+        if !self.0.contains(&id) {
+            self.0.push(id);
+        }
+    }
+}
+
+impl Drop for CreatedSessions {
+    fn drop(&mut self) {
+        for id in self.0.iter().rev() {
+            let _ = run(&["session", "release", id, "--remove", "--json"]);
+        }
+    }
+}
+
+#[test]
+#[ignore = "set ZEUS_REAL_AGENT_SMOKE=1 and run against the current development daemon"]
+fn natural_language_delegation_creates_a_child_session_record() {
+    assert_eq!(
+        std::env::var(OPT_IN_ENV).as_deref(),
+        Ok("1"),
+        "this test creates real Zeus sessions and consumes a provider turn"
+    );
+
+    let kind = std::env::var("ZEUS_REAL_AGENT_KIND").unwrap_or_else(|_| "codex".into());
+    let cwd = std::env::var_os("ZEUS_REAL_AGENT_CWD")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| std::env::current_dir().expect("current directory"));
+    assert!(
+        cwd.is_dir(),
+        "smoke-test cwd does not exist: {}",
+        cwd.display()
+    );
+    let timeout = std::env::var("ZEUS_REAL_AGENT_TIMEOUT_SECONDS")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(Duration::from_secs)
+        .unwrap_or_else(|| Duration::from_secs(300));
+
+    // The prompt deliberately does not mention Zeus, MCP, a tool name, or a
+    // provider-specific spawning feature. That is the behavior under test.
+    let cwd = path_arg(&cwd);
+    let spawned = run_ok(&[
+        "session",
+        "spawn",
+        &kind,
+        "--cwd",
+        &cwd,
+        "--title",
+        "issue-48 delegation smoke",
+        "--prompt",
+        "Spawn a subagent to review this implementation and report back. Do not make code changes.",
+        "--json",
+    ]);
+    let parent: SessionRecord =
+        serde_json::from_slice(&spawned.stdout).expect("spawned parent SessionRecord");
+    let mut cleanup = CreatedSessions(vec![parent.id.0.clone()]);
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        let records = sessions();
+        let children: Vec<&SessionRecord> = records
+            .iter()
+            .filter(|record| record.parent.as_ref() == Some(&parent.id))
+            .collect();
+        if !children.is_empty() {
+            for child in children {
+                cleanup.track(child.id.0.clone());
+                assert_eq!(
+                    child.parent.as_ref(),
+                    Some(&parent.id),
+                    "child SessionRecord lost its parent lineage"
+                );
+            }
+            return;
+        }
+
+        assert!(
+            Instant::now() < deadline,
+            "{kind} did not create a Zeus child session within {} seconds; parent={} output:\n{}",
+            timeout.as_secs(),
+            parent.id.0,
+            String::from_utf8_lossy(
+                &run(&["session", "read", &parent.id.0, "--lines", "80", "--json"]).stdout
+            )
+        );
+        thread::sleep(Duration::from_secs(2));
+    }
+}
+
+fn path_arg(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}

--- a/zeus/crates/zeus-engine/src/hooks.rs
+++ b/zeus/crates/zeus-engine/src/hooks.rs
@@ -280,8 +280,8 @@ mod tests {
     #[test]
     fn an_mcp_tool_name_is_made_readable() {
         assert_eq!(
-            permission_summary(Some("mcp__zeus__spawn_agent"), None),
-            "wants to use zeus:spawn_agent"
+            permission_summary(Some("mcp__zeus__create_zeus_session"), None),
+            "wants to use zeus:create_zeus_session"
         );
     }
 

--- a/zeus/crates/zeus-engine/src/inject.rs
+++ b/zeus/crates/zeus-engine/src/inject.rs
@@ -13,6 +13,7 @@ use std::io;
 use std::path::{Path, PathBuf};
 
 use serde_json::json;
+use zeus_proto::orchestration::HOSTED_SESSION_POLICY;
 
 use crate::agent::InjectionSpec;
 
@@ -164,6 +165,12 @@ pub fn injection_args_with_cursor(
             argv.push("--mcp-config".into());
             argv.push(mcp.to_string_lossy().into_owned());
         }
+        argv.push("--append-system-prompt".into());
+        argv.push(HOSTED_SESSION_POLICY.into());
+        // Claude's Agent/Task tools create provider-native workers inside the
+        // parent PTY. The injected policy tells the model where to redirect.
+        argv.push("--disallowedTools".into());
+        argv.push("Agent,Task".into());
     }
     if injection.codex_notify {
         argv.push("-c".into());
@@ -191,10 +198,22 @@ pub fn injection_args_with_cursor(
         argv.push(format!("mcp_servers.zeus.args=[{encoded_args}]"));
         // Codex's built-in collaboration `spawn_agent` creates `/root/…`
         // workers inside this PTY. Those never become Zeus sessions, so the
-        // sidebar stays empty. Disable it and leave MCP `spawn_agent` as the
-        // only spawn path while hosted by Zeus.
+        // sidebar stays empty. Disable it and direct delegation to the
+        // canonical Zeus MCP session-creation tool.
         argv.push("-c".into());
         argv.push("features.multi_agent=false".into());
+        argv.push("-c".into());
+        argv.push(format!(
+            "developer_instructions={}",
+            toml_string(HOSTED_SESSION_POLICY)
+        ));
+    }
+    if injection.grok_mcp {
+        // Grok exposes both an append-only rules channel and a hard native
+        // subagent gate, so hosted sessions can enforce both halves.
+        argv.push("--rules".into());
+        argv.push(HOSTED_SESSION_POLICY.into());
+        argv.push("--no-subagents".into());
     }
     if (injection.cursor_mcp || injection.cursor_hooks)
         && let Some(cursor) = cursor
@@ -311,10 +330,17 @@ fn write_opencode_mcp_overlay(
     let (command, args) = mcp_launch_for_session(cli_path, identity);
     let mut argv = vec![command];
     argv.extend(args);
-    let path = session_inject_dir(inject_dir, identity.session_id).join("opencode.json");
+    let session_dir = session_inject_dir(inject_dir, identity.session_id);
+    let policy = session_dir.join("zeus-orchestration.md");
+    write_atomic(&policy, HOSTED_SESSION_POLICY.as_bytes())?;
+    let path = session_dir.join("opencode.json");
     write_atomic(
         &path,
         &serde_json::to_vec_pretty(&json!({
+            "instructions": [policy],
+            "permission": {
+                "task": "deny"
+            },
             "mcp": {
                 "zeus": {
                     "type": "local",
@@ -341,7 +367,7 @@ fn write_gemini_home(
     if let Some(user) = user.as_ref().filter(|path| path.is_dir()) {
         for entry in std::fs::read_dir(user)? {
             let entry = entry?;
-            if entry.file_name() == "settings.json" {
+            if entry.file_name() == "settings.json" || entry.file_name() == "GEMINI.md" {
                 continue;
             }
             let _ = std::os::unix::fs::symlink(entry.path(), dest.join(entry.file_name()));
@@ -360,6 +386,20 @@ fn write_gemini_home(
         "command": command,
         "args": args,
     });
+    let user_context = user
+        .as_ref()
+        .map(|dir| dir.join("GEMINI.md"))
+        .filter(|path| path.is_file())
+        .and_then(|path| std::fs::read_to_string(path).ok())
+        .unwrap_or_default();
+    let context = if user_context.trim().is_empty() {
+        format!("# Zeus hosted-session policy\n\n{HOSTED_SESSION_POLICY}\n")
+    } else {
+        format!(
+            "# Zeus hosted-session policy\n\n{HOSTED_SESSION_POLICY}\n\n# User context\n\n{user_context}"
+        )
+    };
+    write_atomic(&dest.join("GEMINI.md"), context.as_bytes())?;
     write_atomic(
         &dest.join("settings.json"),
         &serde_json::to_vec_pretty(&settings)?,
@@ -419,6 +459,15 @@ pub fn write_cursor_plugin(
                     }
                 }
             }))?,
+        )?;
+
+        std::fs::create_dir_all(staging.join("rules"))?;
+        write_atomic(
+            &staging.join("rules/zeus-orchestration.mdc"),
+            format!(
+                "---\ndescription: Route delegated work to visible Zeus sessions\nalwaysApply: true\n---\n\n{HOSTED_SESSION_POLICY}\n"
+            )
+            .as_bytes(),
         )?;
     }
 
@@ -580,7 +629,7 @@ mod tests {
     }
 
     #[test]
-    fn injection_args_cover_all_four_mechanisms() {
+    fn injection_args_include_provider_policy_and_native_spawn_guards() {
         let temp = tempfile::tempdir().expect("temp");
         let cli = temp.path().join("zeus");
         write_claude_hooks_file(temp.path()).expect("hooks");
@@ -596,6 +645,16 @@ mod tests {
         assert!(args[1].ends_with("claude-hooks.json"));
         assert_eq!(args[2], "--mcp-config");
         assert!(args[3].ends_with("claude-mcp.json"));
+        assert!(
+            args.windows(2).any(|pair| pair[0] == "--append-system-prompt"
+                && pair[1] == HOSTED_SESSION_POLICY),
+            "{args:?}"
+        );
+        assert!(
+            args.windows(2)
+                .any(|pair| pair[0] == "--disallowedTools" && pair[1] == "Agent,Task"),
+            "{args:?}"
+        );
 
         let codex = InjectionSpec {
             codex_notify: true,
@@ -614,10 +673,27 @@ mod tests {
             args.iter().any(|arg| arg == "features.multi_agent=false"),
             "{args:?}"
         );
+        assert!(
+            args.iter()
+                .any(|arg| arg.starts_with("developer_instructions=")),
+            "{args:?}"
+        );
+
+        let grok = InjectionSpec {
+            grok_mcp: true,
+            ..Default::default()
+        };
+        let args = injection_args(&grok, temp.path(), &cli);
+        assert!(
+            args.windows(2)
+                .any(|pair| pair[0] == "--rules" && pair[1] == HOSTED_SESSION_POLICY),
+            "{args:?}"
+        );
+        assert!(args.iter().any(|arg| arg == "--no-subagents"));
     }
 
     #[test]
-    fn codex_mcp_bakes_session_env_so_spawn_agent_nests_in_zeus() {
+    fn codex_mcp_bakes_session_env_so_created_sessions_nest_in_zeus() {
         let temp = tempfile::tempdir().expect("temp");
         let cli = temp.path().join("zeus");
         std::fs::write(&cli, b"#!/bin/sh\n").expect("cli");
@@ -664,6 +740,8 @@ mod tests {
         std::fs::write(home.join(".gemini/settings.json"), br#"{"theme":"dark"}"#)
             .expect("settings");
         std::fs::write(home.join(".gemini/oauth.json"), b"{}").expect("oauth");
+        std::fs::write(home.join(".gemini/GEMINI.md"), b"keep user context")
+            .expect("gemini context");
         let cli = temp.path().join("zeus");
         std::fs::write(&cli, b"#!/bin/sh\n").expect("cli");
         let socket = temp.path().join("d.sock");
@@ -709,6 +787,14 @@ mod tests {
                 .expect("json");
         assert_eq!(opencode_json["mcp"]["zeus"]["enabled"], true);
         assert_eq!(opencode_json["mcp"]["zeus"]["command"][0], "/usr/bin/env");
+        assert_eq!(opencode_json["permission"]["task"], "deny");
+        let opencode_policy = opencode_json["instructions"][0]
+            .as_str()
+            .expect("policy path");
+        assert_eq!(
+            std::fs::read_to_string(opencode_policy).expect("policy"),
+            HOSTED_SESSION_POLICY
+        );
 
         let gemini = env
             .iter()
@@ -725,6 +811,10 @@ mod tests {
             Path::new(&gemini).join("oauth.json").exists(),
             "user auth files are linked into the session home"
         );
+        let gemini_context =
+            std::fs::read_to_string(Path::new(&gemini).join("GEMINI.md")).expect("context");
+        assert!(gemini_context.contains(HOSTED_SESSION_POLICY));
+        assert!(gemini_context.contains("keep user context"));
 
         let claude = injection_args_with_cursor(&spec, temp.path(), &cli, Some(identity));
         let config = claude
@@ -796,6 +886,10 @@ mod tests {
             mcp["mcpServers"]["zeus"]["env"]["ZEUS_SOCKET"],
             socket.to_string_lossy().as_ref()
         );
+        let rule = std::fs::read_to_string(plugin.join("rules/zeus-orchestration.mdc"))
+            .expect("policy rule");
+        assert!(rule.contains("alwaysApply: true"));
+        assert!(rule.contains(HOSTED_SESSION_POLICY));
 
         let hooks: serde_json::Value =
             serde_json::from_slice(&std::fs::read(plugin.join("hooks/hooks.json")).expect("hooks"))
@@ -834,6 +928,7 @@ mod tests {
         let plugin = Path::new(&args[1]);
         assert!(plugin.join("mcp.json").is_file());
         assert!(plugin.join("hooks/hooks.json").is_file());
+        assert!(plugin.join("rules/zeus-orchestration.mdc").is_file());
 
         let hooks_only = InjectionSpec {
             cursor_mcp: false,
@@ -852,6 +947,10 @@ mod tests {
         assert!(
             !plugin.join("mcp.json").exists(),
             "disabled mcp.json must not survive a rewrite"
+        );
+        assert!(
+            !plugin.join("rules/zeus-orchestration.mdc").exists(),
+            "disabled MCP policy rule must not survive a rewrite"
         );
         assert!(plugin.join("hooks/hooks.json").is_file());
     }

--- a/zeus/crates/zeus-engine/src/mcp/host.rs
+++ b/zeus/crates/zeus-engine/src/mcp/host.rs
@@ -31,7 +31,7 @@ pub struct RegistryHost {
     holder: Option<crate::session::HolderConfig>,
     /// The session calling these tools, when it identified itself.
     caller: Option<String>,
-    /// Used only when `spawn_agent.kind` is omitted. Explicit tool arguments
+    /// Used only when `create_zeus_session.kind` is omitted. Explicit tool arguments
     /// always win.
     default_agent: String,
 }
@@ -310,8 +310,8 @@ impl ToolHost for RegistryHost {
                 crate::screenshot::capture(arguments).map_err(|error| error.to_string())
             }
 
-            // spawn_agent is served by the control layer, which owns log paths
-            "spawn_agent" => self.spawn_agent(arguments),
+            // Session creation is served by the control layer, which owns log paths.
+            "create_zeus_session" => self.spawn_agent(arguments),
 
             other => Err(format!("unknown tool {other:?}")),
         }

--- a/zeus/crates/zeus-engine/src/mcp/mod.rs
+++ b/zeus/crates/zeus-engine/src/mcp/mod.rs
@@ -18,6 +18,7 @@ pub use host::RegistryHost;
 pub use tools::{ToolDefinition, tool_definitions, tool_definitions_for};
 
 use serde_json::{Value, json};
+use zeus_proto::orchestration::{canonical_tool_name, mcp_instructions};
 
 pub const SERVER_NAME: &str = "zeus";
 pub const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -85,6 +86,7 @@ impl<H: ToolHost> McpServer<H> {
             "protocolVersion": version,
             "capabilities": { "tools": {} },
             "serverInfo": { "name": SERVER_NAME, "version": SERVER_VERSION },
+            "instructions": mcp_instructions(false),
         })
     }
 
@@ -104,11 +106,12 @@ impl<H: ToolHost> McpServer<H> {
     }
 
     fn tools_call(&self, params: &Value) -> Value {
-        let Some(name) = params.get("name").and_then(Value::as_str) else {
+        let Some(requested_name) = params.get("name").and_then(Value::as_str) else {
             return tool_error("tools/call requires a tool name");
         };
+        let name = canonical_tool_name(requested_name);
         if !self.tools.iter().any(|tool| tool.name == name) {
-            return tool_error(&format!("unknown tool {name:?}"));
+            return tool_error(&format!("unknown tool {requested_name:?}"));
         }
         let arguments = params
             .get("arguments")
@@ -227,6 +230,7 @@ mod tests {
             .expect("a reply");
         assert_eq!(response["result"]["protocolVersion"], "2025-03-26");
         assert_eq!(response["result"]["serverInfo"]["name"], "zeus");
+        assert_eq!(response["result"]["instructions"], mcp_instructions(false));
     }
 
     #[test]
@@ -263,7 +267,7 @@ mod tests {
             .collect();
 
         for expected in [
-            "spawn_agent",
+            "create_zeus_session",
             "list_agents",
             "get_status",
             "send_prompt",
@@ -278,6 +282,7 @@ mod tests {
                 "{expected} missing from {names:?}"
             );
         }
+        assert!(!names.contains(&"spawn_agent"));
         for tool in tools {
             assert_eq!(
                 tool["inputSchema"]["type"], "object",

--- a/zeus/crates/zeus-engine/src/mcp/tools.rs
+++ b/zeus/crates/zeus-engine/src/mcp/tools.rs
@@ -9,12 +9,8 @@
 //! manifest becomes spawnable over MCP with no code change.
 
 use serde_json::{Value, json};
-
-pub struct ToolDefinition {
-    pub name: String,
-    pub description: String,
-    pub input_schema: Value,
-}
+pub use zeus_proto::orchestration::ToolDefinition;
+use zeus_proto::orchestration::create_session_tool_definition;
 
 fn tool(name: &str, description: &str, input_schema: Value) -> ToolDefinition {
     ToolDefinition {
@@ -36,33 +32,16 @@ pub fn tool_definitions() -> Vec<ToolDefinition> {
     ])
 }
 
-/// The tool surface, with `spawn_agent` constrained to `kinds`.
+/// The tool surface, with `create_zeus_session` constrained to `kinds`.
 pub fn tool_definitions_for(kinds: &[String]) -> Vec<ToolDefinition> {
-    let kind_enum: Vec<Value> = kinds.iter().map(|kind| json!(kind)).collect();
+    let display_names = if kinds.is_empty() {
+        "the configured agents".to_owned()
+    } else {
+        kinds.join(", ")
+    };
 
     vec![
-        tool(
-            "spawn_agent",
-            "Open ONE new Zeus session tab nested under this one. This is the ONLY way \
-             spawned agents appear in the Zeus sidebar and terminal. Do NOT use built-in \
-             collaboration/subagent spawn — those stay hidden inside this PTY. USE THIS \
-             whenever the user asks to open, start, spawn or launch another agent, session, \
-             or terminal. Optionally create a fresh git worktree for it and give it an \
-             initial prompt. Unless the user explicitly requests multiple agents, call this \
-             exactly once. If the user does not name a kind, omit kind and Zeus will use the \
-             configured default; never guess, probe, or fan out across agent kinds.",
-            json!({
-                "type": "object",
-                "properties": {
-                    "kind": { "type": "string", "enum": kind_enum, "description": "Which agent to run. Omit to use Zeus's configured default agent." },
-                    "cwd": { "type": "string", "description": "Working directory (a repo path when worktree is true)." },
-                    "worktree": { "type": "boolean", "description": "Create a fresh git worktree off cwd and run there (local spawns only)." },
-                    "prompt": { "type": "string", "description": "Initial prompt to send once the agent is ready." },
-                    "name": { "type": "string", "description": "Session title." }
-                },
-                "required": ["cwd"]
-            }),
-        ),
+        create_session_tool_definition(kinds, &display_names),
         tool(
             "list_agents",
             "List all active agent sessions with id, kind, title, status, parent, and cwd.",
@@ -250,8 +229,8 @@ mod tests {
         let tools = tool_definitions_for(&kinds);
         let spawn = tools
             .iter()
-            .find(|tool| tool.name == "spawn_agent")
-            .expect("spawn_agent");
+            .find(|tool| tool.name == "create_zeus_session")
+            .expect("create_zeus_session");
 
         let enumerated: Vec<&str> = spawn.input_schema["properties"]["kind"]["enum"]
             .as_array()

--- a/zeus/crates/zeus-engine/tests/mcp_tools.rs
+++ b/zeus/crates/zeus-engine/tests/mcp_tools.rs
@@ -366,7 +366,7 @@ fn worktree_tools_work_against_a_real_repository() {
 }
 
 #[test]
-fn spawn_agent_starts_a_session_owned_by_its_caller() {
+fn create_zeus_session_validates_before_starting_a_child() {
     // Lineage is the point: a spawned session must record who spawned it, or
     // list_children and wait_for_children have nothing to work with.
     let temp = tempfile::tempdir().expect("temp");
@@ -394,7 +394,7 @@ fn spawn_agent_starts_a_session_owned_by_its_caller() {
     // An unknown agent is refused too.
     let unknown = call(
         &server,
-        "spawn_agent",
+        "create_zeus_session",
         json!({ "kind": "not-an-agent", "cwd": "/tmp" }),
     )
     .expect_err("unknown agent");
@@ -403,7 +403,7 @@ fn spawn_agent_starts_a_session_owned_by_its_caller() {
     // A missing directory is caught before anything is started.
     let bad_cwd = call(
         &server,
-        "spawn_agent",
+        "create_zeus_session",
         json!({ "kind": "claude-code", "cwd": "/no/such/dir" }),
     )
     .expect_err("bad cwd");
@@ -413,7 +413,7 @@ fn spawn_agent_starts_a_session_owned_by_its_caller() {
     // lookup, code sync, or session creation while the new transport is dark.
     let unavailable = call(
         &server,
-        "spawn_agent",
+        "create_zeus_session",
         json!({ "kind": "claude-code", "cwd": "/no/such/dir", "host": "forge" }),
     )
     .expect_err("remote transport unavailable");
@@ -466,7 +466,7 @@ fn a_spawned_session_records_its_parent_and_appears_as_a_child() {
 
     let spawned = call(
         &server,
-        "spawn_agent",
+        "create_zeus_session",
         json!({ "cwd": "/tmp", "name": "worker one", "prompt": "do the thing" }),
     )
     .expect("spawn");

--- a/zeus/crates/zeus-mcp/Cargo.toml
+++ b/zeus/crates/zeus-mcp/Cargo.toml
@@ -11,3 +11,4 @@ path = "src/main.rs"
 
 [dependencies]
 serde_json.workspace = true
+zeus-proto.workspace = true

--- a/zeus/crates/zeus-mcp/src/main.rs
+++ b/zeus/crates/zeus-mcp/src/main.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use std::process::{Command, Stdio};
 
 use serde_json::{Value, json};
+use zeus_proto::orchestration::mcp_instructions;
 
 trait ToolBackend {
     fn tools(&mut self) -> Result<Value, String>;
@@ -145,31 +146,11 @@ fn initialize(params: &Value) -> Value {
         .get("protocolVersion")
         .and_then(Value::as_str)
         .unwrap_or("2025-06-18");
-    let browser = if env::var_os("ZEUS_TEST_RUN_AVAILABLE").is_some() {
-        " To test a web feature, use test_run with a preview URL from get_artifacts."
-    } else {
-        ""
-    };
     json!({
         "protocolVersion": version,
         "capabilities": {"tools":{}},
         "serverInfo": {"name":"zeus","version":env!("CARGO_PKG_VERSION")},
-        "instructions": format!(
-            "This session is running INSIDE Zeus, a macOS orchestrator for coding agents. \
-             These tools control it. Use them proactively whenever the user asks to \
-             open/start/spawn/close another agent, session, tab, or terminal (Claude Code, \
-             Codex, Cursor, Gemini, or a shell), to check what other sessions are doing, to \
-             talk to another session, or to parallelize work across git worktrees — no \
-             extra confirmation of intent needed.\n\nNever use the host agent's built-in \
-             collaboration spawn_agent / subagents: those workers stay inside this terminal \
-             and never appear in the Zeus sidebar. Always call this MCP spawn_agent so the \
-             child is a real Zeus tab.\n\nTypical orchestration flow: spawn_agent \
-             (optionally worktree:true and an initial prompt) → wait_for_agent(until:\"done\") \
-             → read_output → send_prompt for follow-ups → release_agent when finished. \
-             get_artifacts returns PR/Linear/preview URLs and listening ports a session has \
-             produced; PR entries include live GitHub status (state, review decision, checks, \
-             comment counts, +/- lines).{browser}"
-        )
+        "instructions": mcp_instructions(env::var_os("ZEUS_TEST_RUN_AVAILABLE").is_some()),
     })
 }
 
@@ -293,6 +274,10 @@ mod tests {
         .unwrap();
         assert_eq!(initialized["result"]["protocolVersion"], "2025-06-18");
         assert_eq!(initialized["result"]["capabilities"], json!({"tools":{}}));
+        assert_eq!(
+            initialized["result"]["instructions"],
+            mcp_instructions(env::var_os("ZEUS_TEST_RUN_AVAILABLE").is_some())
+        );
         assert!(
             handle_message(
                 json!({"jsonrpc":"2.0","method":"notifications/initialized","params":{}}),

--- a/zeus/crates/zeus-proto/src/lib.rs
+++ b/zeus/crates/zeus-proto/src/lib.rs
@@ -7,6 +7,7 @@ pub mod hosts;
 pub mod methods;
 pub mod model;
 pub mod node;
+pub mod orchestration;
 pub mod paths;
 pub mod remote_pty;
 

--- a/zeus/crates/zeus-proto/src/methods.rs
+++ b/zeus/crates/zeus-proto/src/methods.rs
@@ -282,7 +282,7 @@ pub struct SessionSpawnParams {
     /// `cwd` / the host's defaultCwd when the repo isn't cloned there.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub same_repo_as: Option<SessionId>,
-    /// `true` for the ⌘J workbench split. MCP `spawn_agent` sends `false` so
+    /// `true` for the ⌘J workbench split. MCP `create_zeus_session` sends `false` so
     /// the child is a nested session tab rather than a hidden terminal pane.
     /// Absent on older clients; the Engine then uses the shell-plus-parent
     /// heuristic for records that predate the field.

--- a/zeus/crates/zeus-proto/src/orchestration.rs
+++ b/zeus/crates/zeus-proto/src/orchestration.rs
@@ -1,0 +1,95 @@
+//! Shared policy and MCP metadata for sessions hosted by Zeus.
+//!
+//! The Engine, CLI fallback server, standalone MCP proxy, and provider launch
+//! shims all consume this module. Keeping the model-facing names and wording
+//! here prevents one entry point from drifting back to a provider-native
+//! subagent path.
+
+use serde_json::{Value, json};
+
+/// The only advertised tool name for creating a visible child session.
+pub const CREATE_ZEUS_SESSION_TOOL: &str = "create_zeus_session";
+/// Accepted for integrations that predate [`CREATE_ZEUS_SESSION_TOOL`].
+pub const LEGACY_SPAWN_AGENT_TOOL: &str = "spawn_agent";
+
+/// High-priority policy injected through each hosted provider's supported
+/// instruction mechanism and repeated in MCP initialization instructions.
+pub const HOSTED_SESSION_POLICY: &str = "This process is hosted by Zeus. When the user asks to spawn, delegate, parallelize, or open another agent or session, call the Zeus MCP `create_zeus_session` tool. Do not use provider-native subagents unless the user explicitly requests an internal hidden worker. Create one Zeus child for each explicitly requested parallel task, and preserve the current session as its parent. If the user does not name an agent kind, omit `kind` so Zeus uses the configured default. The old `spawn_agent` name is a compatibility alias; do not select it for new calls.";
+
+#[derive(Clone, Debug)]
+pub struct ToolDefinition {
+    pub name: String,
+    pub description: String,
+    pub input_schema: Value,
+}
+
+/// Maps the unadvertised compatibility alias to the canonical tool name.
+pub fn canonical_tool_name(name: &str) -> &str {
+    if name == LEGACY_SPAWN_AGENT_TOOL {
+        CREATE_ZEUS_SESSION_TOOL
+    } else {
+        name
+    }
+}
+
+/// The one shared definition of the visible Zeus session creation tool.
+pub fn create_session_tool_definition(kinds: &[String], display_names: &str) -> ToolDefinition {
+    let kind_enum: Vec<Value> = kinds.iter().map(|kind| json!(kind)).collect();
+    ToolDefinition {
+        name: CREATE_ZEUS_SESSION_TOOL.to_owned(),
+        description: format!(
+            "Open ONE visible Zeus child session nested under this one, running {display_names} locally or on a configured remote host. Use this whenever the user asks to spawn, delegate, parallelize, or open another agent, session, tab, or terminal. Provider-native subagents stay hidden inside this terminal and must only be used when the user explicitly requests an internal hidden worker. Make one call per explicitly requested parallel task. If the user does not name a kind, omit kind so Zeus uses the configured default; never guess, probe, or fan out across agent kinds."
+        ),
+        input_schema: json!({
+            "type": "object",
+            "properties": {
+                "kind": { "type": "string", "enum": kind_enum, "description": "Which agent to run. Omit to use Zeus's configured default agent." },
+                "cwd": { "type": "string", "description": "Working directory." },
+                "host": { "type": "string", "description": "Configured Zeus host id. Omit for a local child." },
+                "worktree": { "type": "boolean", "description": "Create a fresh git worktree off cwd and run there. Local only." },
+                "prompt": { "type": "string", "description": "Initial prompt to send once the agent is ready." },
+                "name": { "type": "string", "description": "Session title." }
+            },
+            "required": ["cwd"]
+        }),
+    }
+}
+
+/// Shared MCP initialization guidance. MCP is reinforcement for the injected
+/// provider policy, but uses the same canonical names and orchestration flow.
+pub fn mcp_instructions(test_run_available: bool) -> String {
+    let browser = if test_run_available {
+        " To test a web feature, use test_run with a preview URL from get_artifacts."
+    } else {
+        ""
+    };
+    format!(
+        "{HOSTED_SESSION_POLICY}\n\nThese tools control Zeus. Use them proactively to inspect, coordinate, or close sessions and to parallelize work across git worktrees; no extra confirmation of intent is needed. Typical flow: {CREATE_ZEUS_SESSION_TOOL} (optionally worktree:true and an initial prompt) → wait_for_agent(until:\"done\") → read_output → send_prompt for follow-ups → release_agent when finished. get_artifacts returns PR, issue, preview, and listening-port artifacts.{browser}"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_spawn_name_normalizes_without_being_advertised() {
+        assert_eq!(
+            canonical_tool_name(LEGACY_SPAWN_AGENT_TOOL),
+            CREATE_ZEUS_SESSION_TOOL
+        );
+        assert_eq!(canonical_tool_name("list_agents"), "list_agents");
+
+        let definition = create_session_tool_definition(&["codex".into()], "Codex");
+        assert_eq!(definition.name, CREATE_ZEUS_SESSION_TOOL);
+        assert_ne!(definition.name, LEGACY_SPAWN_AGENT_TOOL);
+    }
+
+    #[test]
+    fn policy_and_mcp_guidance_use_only_the_canonical_name_for_new_calls() {
+        let instructions = mcp_instructions(false);
+        assert!(instructions.contains("create_zeus_session"));
+        assert!(instructions.contains("compatibility alias"));
+        assert!(!instructions.contains("Typical flow: spawn_agent"));
+    }
+}


### PR DESCRIPTION
## Summary

- advertise `create_zeus_session` as the non-colliding Zeus orchestration tool while keeping `spawn_agent` callable as an unadvertised compatibility alias
- centralize the hosted-session policy, MCP initialization guidance, and session-creation tool metadata in `zeus-proto`
- inject the policy through the supported launch/configuration mechanism for Claude Code, Codex, Cursor, Gemini, Grok, and OpenCode
- disable provider-native subagent paths where supported and preserve Zeus parent/child lineage
- add deterministic provider/configuration, alias, initialization, and lineage coverage plus an opt-in real-agent delegation smoke test

## Verification

- `cargo fmt --all -- --check`
- `cargo test -p zeus-proto -p zeus-cli -p zeus-mcp` — 72 passed, 1 intentionally ignored live test
- `cargo clippy -p zeus-proto -p zeus-cli -p zeus-mcp --all-targets -- -D warnings`
- `cargo check -p zeus-engine --lib`
- `cargo clippy -p zeus-engine --lib -- -D warnings`

Linked Engine tests could not run on this machine because the local macOS native linker reports unresolved `cidre`/ScreenCaptureKit class symbols. Engine type-checking and clippy pass. The real-agent smoke test remains opt-in because it creates live sessions and consumes a provider turn.

Closes #48

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)