### PR TITLE
feat: Add workspace selector and restore active workspace

### DIFF
--- a/zeus/crates/zeus-app/src/main.rs
+++ b/zeus/crates/zeus-app/src/main.rs
@@ -108,7 +108,7 @@ fn install_app_menus(cx: &mut App) {
             MenuItem::action("Quit zeus", Quit),
         ]),
         Menu::new("File").items([
-            MenuItem::action("Open…", root::OpenWorkspace),
+            MenuItem::action("Add Workspace…", root::OpenWorkspace),
             MenuItem::separator(),
             MenuItem::action("New Agent", root::OpenNewAgent),
         ]),

--- a/zeus/crates/zeus-app/src/root.rs
+++ b/zeus/crates/zeus-app/src/root.rs
@@ -217,9 +217,7 @@ impl RootView {
                 if preview {
                     TerminalPane::new_preview(runtime, tokio, window, cx)
                 } else {
-                    let mut terminal = TerminalPane::new(runtime, tokio, window, cx);
-                    terminal.show_startup_welcome();
-                    terminal
+                    TerminalPane::new(runtime, tokio, window, cx)
                 }
             }))
         };
@@ -267,17 +265,6 @@ impl RootView {
                     this.sidebar.update(cx, |sidebar, cx| sidebar.toggle(cx));
                 }
                 TerminalPaneEvent::ToggleInspector => this.toggle_inspector(cx),
-                TerminalPaneEvent::OpenWorkspace { root } => {
-                    this.services
-                        .store
-                        .store
-                        .write()
-                        .expect("session store lock poisoned")
-                        .add_project(root.clone());
-                    this.sidebar.update(cx, |sidebar, cx| {
-                        sidebar.show_new_agent_in_workspace(root.clone(), cx);
-                    });
-                }
                 TerminalPaneEvent::OpenFileReference { reference, cwd, .. } => {
                     let inspector = this.inspector.clone();
                     this.reveal_inspector(cx);
@@ -291,21 +278,15 @@ impl RootView {
             .detach();
         }
         cx.subscribe_in(&sidebar, window, |this, _, event, window, cx| {
-            if matches!(event, SidebarEvent::SessionActivated)
-                && let Some(terminal) = &this.terminal
+            if matches!(
+                event,
+                SidebarEvent::SessionActivated | SidebarEvent::WorkspaceActivated
+            ) && let Some(terminal) = &this.terminal
             {
                 terminal.update(cx, |terminal, cx| {
-                    terminal.dismiss_startup_welcome(cx);
                     terminal.focus(window, cx);
                 });
                 this.sync_auxiliary_terminal(window, cx);
-            }
-            if matches!(event, SidebarEvent::AgentSpawnRequested)
-                && let Some(terminal) = &this.terminal
-            {
-                terminal.update(cx, |terminal, cx| {
-                    terminal.dismiss_startup_welcome(cx);
-                });
             }
             if let SidebarEvent::Update(command) = event {
                 this.services.updates.send(command.clone());
@@ -380,7 +361,6 @@ impl RootView {
                     InspectorEvent::SessionActivated => {
                         if let Some(terminal) = &this.terminal {
                             terminal.update(cx, |terminal, cx| {
-                                terminal.dismiss_startup_welcome(cx);
                                 terminal.focus(window, cx);
                             });
                             this.sync_auxiliary_terminal(window, cx);
@@ -1175,11 +1155,8 @@ impl RootView {
     }
 
     fn open_workspace(&mut self, _: &OpenWorkspace, window: &mut Window, cx: &mut Context<Self>) {
-        if let Some(terminal) = &self.terminal {
-            terminal.update(cx, |terminal, cx| {
-                terminal.choose_workspace_folder(window, cx);
-            });
-        }
+        self.sidebar
+            .update(cx, |sidebar, cx| sidebar.show_add_workspace(window, cx));
     }
 
     fn on_key_up(&mut self, event: &KeyUpEvent, window: &mut Window, cx: &mut Context<Self>) {
@@ -1940,10 +1917,6 @@ impl Render for RootView {
         let colors = self.colors();
         let sidebar_visible = self.sidebar.read(cx).is_visible();
         let sidebar_width = self.sidebar.read(cx).width();
-        let startup_welcome_visible = self
-            .terminal
-            .as_ref()
-            .is_some_and(|terminal| terminal.read(cx).is_startup_welcome_visible());
         let (has_selected_session, inspector_word_wrap) = {
             let store = self
                 .services
@@ -1969,8 +1942,7 @@ impl Render for RootView {
             .inspector
             .as_ref()
             .is_some_and(|inspector| inspector.read(cx).is_code_destination());
-        let inspector_available = inspector_has_standalone_destination
-            || (!startup_welcome_visible && has_selected_session);
+        let inspector_available = inspector_has_standalone_destination || has_selected_session;
         let requested_inspector_width = self
             .inspector_width
             .clamp(self.inspector_min_width(), MAX_INSPECTOR_WIDTH);

--- a/zeus/crates/zeus-app/src/sidebar/state.rs
+++ b/zeus/crates/zeus-app/src/sidebar/state.rs
@@ -24,6 +24,12 @@ pub enum DragItem {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Popover {
+    WorkspaceSelector,
+    AddWorkspace {
+        root: Option<String>,
+        error: Option<String>,
+        submitted: bool,
+    },
     NewAgent {
         directory: Option<String>,
         /// Selected spawn target: `None` = Local, `Some(host id)` = remote.

--- a/zeus/crates/zeus-app/src/sidebar/view.rs
+++ b/zeus/crates/zeus-app/src/sidebar/view.rs
@@ -1,12 +1,14 @@
 use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
 use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
 
 use gpui::{
     Anchor, AnyElement, App, AppContext as _, Context, Entity, EventEmitter, FocusHandle,
-    Focusable, FontWeight, Hsla, IntoElement, MouseButton, Pixels, Point, Render, Rgba,
-    ScrollHandle, SharedString, Task, Window, anchored, deferred, div, linear_color_stop,
-    linear_gradient, point, prelude::*, px,
+    Focusable, FontWeight, Hsla, IntoElement, MouseButton, PathPromptOptions, Pixels, Point,
+    Render, Rgba, Role, ScrollHandle, SharedString, Task, Window, anchored, deferred, div,
+    linear_color_stop, linear_gradient, point, prelude::*, px,
 };
 use tokio::sync::mpsc;
 use zeus_proto::remote_pty::PersistenceCapability;
@@ -51,9 +53,9 @@ pub enum SidebarEvent {
     /// A plain click (or shortcut) selected a session: hand keyboard focus
     /// to its terminal surface so the user can type immediately.
     SessionActivated,
-    /// The compact picker requested a spawn. RootView dismisses the startup
-    /// welcome canvas while the Engine creates and selects the new session.
-    AgentSpawnRequested,
+    /// The active workspace changed, possibly changing or clearing the
+    /// selected session at the same time.
+    WorkspaceActivated,
     /// The user acted on the update pill. The sidebar holds no updater of its
     /// own; RootView owns the handle and forwards these.
     Update(UpdateCommand),
@@ -154,7 +156,13 @@ impl Sidebar {
                 loop {
                     match changes.recv().await {
                         Ok(()) | Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
-                            if this.update(cx, |_, cx| cx.notify()).is_err() {
+                            if this
+                                .update(cx, |this, cx| {
+                                    this.reconcile_workspace_add();
+                                    cx.notify();
+                                })
+                                .is_err()
+                            {
                                 return;
                             }
                         }
@@ -312,6 +320,177 @@ impl Sidebar {
         self.open_new_agent_popover_at(Some(directory), None, cx);
     }
 
+    pub fn show_add_workspace(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.ensure_visible(cx);
+        self.commit_rename();
+        self.store
+            .write()
+            .expect("session store lock poisoned")
+            .clear_project_add_error();
+        self.ui.popover = Some(Popover::AddWorkspace {
+            root: None,
+            error: None,
+            submitted: false,
+        });
+        self.rename_focus.focus(window, cx);
+        cx.notify();
+    }
+
+    fn activate_workspace(&mut self, id: ProjectId, cx: &mut Context<Self>) {
+        let activated = self
+            .store
+            .write()
+            .expect("session store lock poisoned")
+            .set_active_workspace(id);
+        if !activated {
+            return;
+        }
+        self.ui.popover = None;
+        self.ui.hover_card = None;
+        cx.emit(SidebarEvent::WorkspaceActivated);
+        cx.notify();
+    }
+
+    fn choose_workspace_folder(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let paths = cx.prompt_for_paths(PathPromptOptions {
+            files: false,
+            directories: true,
+            multiple: false,
+            prompt: Some("Choose Workspace".into()),
+        });
+        cx.spawn_in(window, async move |this, cx| {
+            let selected = match paths.await {
+                Ok(Ok(Some(mut paths))) => paths.pop(),
+                _ => None,
+            };
+            let Some(selected) = selected else {
+                return;
+            };
+            let chosen = selected.to_string_lossy().into_owned();
+            let validation = validate_workspace_root(&chosen);
+            let _ = this.update_in(cx, |this, _window, cx| {
+                if let Some(Popover::AddWorkspace {
+                    root,
+                    error,
+                    submitted,
+                }) = &mut this.ui.popover
+                {
+                    *submitted = false;
+                    match validation {
+                        Ok(validated) => {
+                            *root = Some(validated);
+                            *error = None;
+                        }
+                        Err(message) => {
+                            *root = Some(chosen);
+                            *error = Some(message);
+                        }
+                    }
+                    this.store
+                        .write()
+                        .expect("session store lock poisoned")
+                        .clear_project_add_error();
+                    cx.notify();
+                }
+            });
+        })
+        .detach();
+    }
+
+    fn submit_add_workspace(&mut self, cx: &mut Context<Self>) {
+        let root = match &self.ui.popover {
+            Some(Popover::AddWorkspace {
+                root: Some(root),
+                submitted: false,
+                ..
+            }) => root.clone(),
+            Some(Popover::AddWorkspace {
+                root: None,
+                submitted: false,
+                ..
+            }) => {
+                if let Some(Popover::AddWorkspace { error, .. }) = &mut self.ui.popover {
+                    *error = Some("Choose a folder to continue.".into());
+                }
+                cx.notify();
+                return;
+            }
+            _ => return,
+        };
+        let root = match validate_workspace_root(&root) {
+            Ok(root) => root,
+            Err(message) => {
+                if let Some(Popover::AddWorkspace { error, .. }) = &mut self.ui.popover {
+                    *error = Some(message);
+                }
+                cx.notify();
+                return;
+            }
+        };
+        let (requested, already_present) = {
+            let mut store = self.store.write().expect("session store lock poisoned");
+            let already_present = store
+                .projects()
+                .values()
+                .any(|project| project.root == root);
+            (store.add_project(root.clone()), already_present)
+        };
+        if already_present {
+            self.ui.popover = None;
+            cx.emit(SidebarEvent::WorkspaceActivated);
+        } else if requested
+            && let Some(Popover::AddWorkspace {
+                root: selected,
+                error,
+                submitted,
+            }) = &mut self.ui.popover
+        {
+            *selected = Some(root);
+            *error = None;
+            *submitted = true;
+        }
+        cx.notify();
+    }
+
+    fn reconcile_workspace_add(&mut self) {
+        let root = match &self.ui.popover {
+            Some(Popover::AddWorkspace {
+                root: Some(root),
+                submitted: true,
+                ..
+            }) => root.clone(),
+            _ => return,
+        };
+        let (pending, error, added) = {
+            let store = self.store.read().expect("session store lock poisoned");
+            (
+                store.pending_project_root() == Some(&root),
+                store.project_add_error().map(str::to_owned),
+                store
+                    .active_workspace()
+                    .is_some_and(|project| project.root == root),
+            )
+        };
+        if pending {
+            return;
+        }
+        if let Some(message) = error {
+            if let Some(Popover::AddWorkspace {
+                error, submitted, ..
+            }) = &mut self.ui.popover
+            {
+                *error = Some(message);
+                *submitted = false;
+            }
+            self.store
+                .write()
+                .expect("session store lock poisoned")
+                .clear_project_add_error();
+        } else if added {
+            self.ui.popover = None;
+        }
+    }
+
     fn ensure_visible(&mut self, cx: &mut Context<Self>) {
         if !self.ui.visible {
             self.ui.visible = true;
@@ -445,13 +624,39 @@ impl Sidebar {
     fn on_key_down(
         &mut self,
         event: &gpui::KeyDownEvent,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         if self.ui.renaming.is_none() {
-            if self.ui.popover.is_some() && event.keystroke.key.as_str() == "escape" {
-                self.ui.popover = None;
-                cx.notify();
+            match event.keystroke.key.as_str() {
+                "escape" if self.ui.popover.is_some() => {
+                    self.ui.popover = None;
+                    self.store
+                        .write()
+                        .expect("session store lock poisoned")
+                        .clear_project_add_error();
+                    cx.notify();
+                }
+                "enter"
+                    if self.rename_focus.is_focused(window)
+                        && matches!(
+                            self.ui.popover,
+                            Some(Popover::AddWorkspace {
+                                root: None,
+                                submitted: false,
+                                ..
+                            })
+                        ) =>
+                {
+                    self.choose_workspace_folder(window, cx);
+                }
+                "enter"
+                    if self.rename_focus.is_focused(window)
+                        && matches!(self.ui.popover, Some(Popover::AddWorkspace { .. })) =>
+                {
+                    self.submit_add_workspace(cx);
+                }
+                _ => {}
             }
             return;
         }
@@ -628,7 +833,162 @@ impl Sidebar {
             .into_any_element()
     }
 
-    fn empty_state(&self, colors: SemanticColors, cx: &mut Context<Self>) -> AnyElement {
+    fn workspace_row(
+        &self,
+        projection: &crate::store::SidebarProjection,
+        colors: SemanticColors,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let active = self
+            .store
+            .read()
+            .expect("session store lock poisoned")
+            .active_workspace_id()
+            .cloned();
+        let active_project = projection
+            .projects
+            .iter()
+            .find(|group| Some(&group.project.id) == active.as_ref())
+            .map(|group| &group.project);
+        let label = active_project
+            .map(|project| project.name.clone())
+            .unwrap_or_else(|| "Select workspace".into());
+        let selector_accessibility_label = format!("Active workspace: {label}");
+        let selector_hover = self.ui.hovered_control == Some("workspace-selector");
+        let add_hover = self.ui.hovered_control == Some("workspace-add");
+        let selector_open = matches!(self.ui.popover, Some(Popover::WorkspaceSelector));
+
+        div()
+            .id("workspace-control")
+            .debug_selector(|| "WORKSPACE_CONTROL".to_owned())
+            .mx(px(Space::INSET))
+            .mb(px(4.0))
+            .p(px(3.0))
+            .h(px(36.0))
+            .flex_none()
+            .flex()
+            .items_center()
+            .rounded(px(Radius::ROW))
+            .bg(colors.primary.alpha(0.035))
+            .child(
+                div()
+                    .id("workspace-selector")
+                    .debug_selector(|| "WORKSPACE_SELECTOR".to_owned())
+                    .focusable()
+                    .tab_stop(true)
+                    .role(Role::Button)
+                    .aria_label(selector_accessibility_label)
+                    .aria_description("Choose the workspace shown in the sidebar")
+                    .min_w(px(0.0))
+                    .flex_1()
+                    .h_full()
+                    .px(px(5.0))
+                    .flex()
+                    .items_center()
+                    .gap(px(7.0))
+                    .rounded(px(Radius::CHIP))
+                    .bg(if selector_open {
+                        Fill::subtle(colors)
+                    } else {
+                        Fill::hover(colors, selector_hover)
+                    })
+                    .cursor_pointer()
+                    .on_hover(cx.listener(|this, hovered: &bool, _, cx| {
+                        this.ui.hovered_control = hovered.then_some("workspace-selector");
+                        cx.notify();
+                    }))
+                    .on_click(cx.listener(|this, _, _, cx| {
+                        this.commit_rename();
+                        this.ui.popover =
+                            if matches!(this.ui.popover, Some(Popover::WorkspaceSelector)) {
+                                None
+                            } else {
+                                Some(Popover::WorkspaceSelector)
+                            };
+                        cx.notify();
+                    }))
+                    .child(project_badge(colors))
+                    .child(
+                        div()
+                            .min_w(px(0.0))
+                            .flex_1()
+                            .whitespace_nowrap()
+                            .overflow_hidden()
+                            .text_ellipsis()
+                            .text_size(px(SIDEBAR_TITLE_SIZE))
+                            .font_weight(Typo::ROW_EMPHASIZED.weight)
+                            .text_color(colors.primary)
+                            .child(label),
+                    )
+                    .child(sf_symbol_weighted(
+                        if selector_open {
+                            "chevron.up"
+                        } else {
+                            "chevron.down"
+                        },
+                        8.0,
+                        SymbolWeight::Bold,
+                        colors.tertiary,
+                    )),
+            )
+            .child(
+                div()
+                    .mx(px(3.0))
+                    .h(px(18.0))
+                    .w(px(1.0))
+                    .flex_none()
+                    .bg(colors.primary.alpha(0.07)),
+            )
+            .child(
+                div()
+                    .id("workspace-add")
+                    .debug_selector(|| "WORKSPACE_ADD".to_owned())
+                    .focusable()
+                    .tab_stop(true)
+                    .role(Role::Button)
+                    .aria_label("Add Workspace")
+                    .aria_keyshortcuts("Meta+O")
+                    .size(px(28.0))
+                    .flex_none()
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .rounded(px(Radius::CHIP))
+                    .bg(Fill::hover(colors, add_hover))
+                    .cursor_pointer()
+                    .on_hover(cx.listener(|this, hovered: &bool, _, cx| {
+                        this.ui.hovered_control = hovered.then_some("workspace-add");
+                        cx.notify();
+                    }))
+                    .on_click(cx.listener(|this, _, window, cx| {
+                        this.show_add_workspace(window, cx);
+                    }))
+                    .child(sf_symbol_weighted(
+                        "plus",
+                        11.0,
+                        SymbolWeight::Medium,
+                        colors.secondary,
+                    )),
+            )
+            .into_any_element()
+    }
+
+    fn empty_state(
+        &self,
+        has_workspace: bool,
+        colors: SemanticColors,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let title = if has_workspace {
+            "Bring up your first agent"
+        } else {
+            "Add your first workspace"
+        };
+        let action = if has_workspace {
+            "New Agent"
+        } else {
+            "Add Workspace"
+        };
         div()
             .flex_1()
             .flex()
@@ -648,18 +1008,34 @@ impl Sidebar {
                             .text_size(px(SIDEBAR_TITLE_SIZE))
                             .font_weight(Typo::ROW_EMPHASIZED.weight)
                             .text_color(colors.secondary)
-                            .child("Bring up your first agent"),
+                            .child(title),
                     )
                     .child(
                         div()
                             .text_size(px(SIDEBAR_SUBTITLE_SIZE))
                             .text_color(colors.tertiary)
-                            .child("⌘T"),
+                            .child(if has_workspace { "⌘T" } else { "⌘O" }),
                     ),
             )
             .child(
                 div()
-                    .id("empty-new-agent")
+                    .id(if has_workspace {
+                        "empty-new-agent"
+                    } else {
+                        "empty-add-workspace"
+                    })
+                    .debug_selector(move || {
+                        if has_workspace {
+                            "EMPTY_NEW_AGENT"
+                        } else {
+                            "EMPTY_ADD_WORKSPACE"
+                        }
+                        .to_owned()
+                    })
+                    .focusable()
+                    .tab_stop(true)
+                    .role(Role::Button)
+                    .aria_label(action)
                     .px(px(8.0))
                     .h(px(24.0))
                     .flex()
@@ -669,12 +1045,24 @@ impl Sidebar {
                     .text_color(colors.secondary)
                     .cursor_pointer()
                     .hover(move |element| element.bg(colors.primary.alpha(0.06)))
-                    .on_click(cx.listener(|this, _, _, cx| {
-                        this.open_new_agent_popover(None, cx);
+                    .on_click(cx.listener(move |this, _, window, cx| {
+                        if has_workspace {
+                            this.open_new_agent_popover(None, cx);
+                        } else {
+                            this.show_add_workspace(window, cx);
+                        }
                     }))
                     .gap(px(6.0))
-                    .child(sf_symbol("square.and.pencil", 13.0, colors.secondary))
-                    .child("New Agent"),
+                    .child(sf_symbol(
+                        if has_workspace {
+                            "square.and.pencil"
+                        } else {
+                            "folder.badge.plus"
+                        },
+                        13.0,
+                        colors.secondary,
+                    ))
+                    .child(action),
             )
             .into_any_element()
     }
@@ -1707,6 +2095,12 @@ impl Sidebar {
         cx: &mut Context<Self>,
     ) -> Option<AnyElement> {
         match self.ui.popover.clone()? {
+            Popover::WorkspaceSelector => Some(self.workspace_selector_popover(colors, window, cx)),
+            Popover::AddWorkspace {
+                root,
+                error,
+                submitted,
+            } => Some(self.add_workspace_popover(root, error, submitted, colors, window, cx)),
             Popover::NewAgent { directory, host } => {
                 Some(self.new_agent_popover(directory, host, colors, window, cx))
             }
@@ -1717,6 +2111,347 @@ impl Sidebar {
                 Some(self.session_actions_popover(id, position, colors, cx))
             }
         }
+    }
+
+    fn workspace_selector_popover(
+        &self,
+        colors: SemanticColors,
+        window: &Window,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let (projection, active) = {
+            let mut store = self.store.write().expect("session store lock poisoned");
+            (
+                store.sidebar_projection(),
+                store.active_workspace_id().cloned(),
+            )
+        };
+        let mut rows = div()
+            .id("workspace-menu")
+            .debug_selector(|| "WORKSPACE_MENU".to_owned())
+            .role(Role::Menu)
+            .aria_label("Workspaces")
+            .max_h(px(280.0))
+            .overflow_y_scroll()
+            .flex()
+            .flex_col()
+            .p(px(4.0))
+            .gap(px(2.0));
+        if projection.projects.is_empty() {
+            rows = rows.child(
+                div()
+                    .px(px(10.0))
+                    .py(px(8.0))
+                    .text_size(px(Typo::META.size))
+                    .text_color(colors.tertiary)
+                    .child("No workspaces yet"),
+            );
+        }
+        for group in &projection.projects {
+            let id = group.project.id.clone();
+            let root = group.project.root.clone();
+            let selected = active.as_ref() == Some(&id);
+            let accessibility_label = format!("{} — {root}", group.project.name);
+            rows = rows.child(
+                div()
+                    .id(SharedString::from(format!("workspace-option-{}", id.0)))
+                    .debug_selector({
+                        let id = id.clone();
+                        move || format!("WORKSPACE_OPTION_{}", id.0)
+                    })
+                    .focusable()
+                    .tab_stop(true)
+                    .role(Role::MenuItem)
+                    .aria_label(accessibility_label)
+                    .px(px(6.0))
+                    .py(px(6.0))
+                    .flex()
+                    .items_center()
+                    .gap(px(7.0))
+                    .rounded(px(Radius::ROW))
+                    .cursor_pointer()
+                    .when(selected, |row| row.bg(Fill::selected(colors, true)))
+                    .hover(move |row| row.bg(Fill::subtle(colors)))
+                    .on_click(cx.listener(move |this, _, _, cx| {
+                        this.activate_workspace(id.clone(), cx);
+                    }))
+                    .child(project_badge(colors))
+                    .child(
+                        div()
+                            .min_w(px(0.0))
+                            .flex_1()
+                            .flex()
+                            .flex_col()
+                            .gap(px(1.0))
+                            .child(
+                                div()
+                                    .whitespace_nowrap()
+                                    .overflow_hidden()
+                                    .text_ellipsis()
+                                    .text_size(px(SIDEBAR_TITLE_SIZE))
+                                    .font_weight(Typo::ROW_EMPHASIZED.weight)
+                                    .text_color(colors.primary)
+                                    .child(group.project.name.clone()),
+                            )
+                            .child(
+                                div()
+                                    .whitespace_nowrap()
+                                    .overflow_hidden()
+                                    .text_ellipsis()
+                                    .text_size(px(Typo::META.size))
+                                    .text_color(colors.tertiary)
+                                    .child(root),
+                            ),
+                    )
+                    .child(
+                        div()
+                            .w(px(14.0))
+                            .flex_none()
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .when(selected, |mark| {
+                                mark.child(sf_symbol_weighted(
+                                    "checkmark",
+                                    10.0,
+                                    SymbolWeight::Semibold,
+                                    colors.secondary,
+                                ))
+                            }),
+                    ),
+            );
+        }
+        let content = div()
+            .flex()
+            .flex_col()
+            .child(
+                div()
+                    .px(px(10.0))
+                    .pt(px(8.0))
+                    .pb(px(6.0))
+                    .text_size(px(Typo::SECTION_HEADER.size))
+                    .font_weight(Typo::SECTION_HEADER.weight)
+                    .text_color(colors.tertiary)
+                    .child("WORKSPACES"),
+            )
+            .child(HairlineDivider::horizontal(colors))
+            .child(rows);
+        self.popover_shell(74.0, content, colors, window, cx)
+    }
+
+    fn add_workspace_popover(
+        &self,
+        root: Option<String>,
+        local_error: Option<String>,
+        submitted: bool,
+        colors: SemanticColors,
+        window: &Window,
+        cx: &mut Context<Self>,
+    ) -> AnyElement {
+        let (pending, engine_error) = {
+            let store = self.store.read().expect("session store lock poisoned");
+            (
+                submitted
+                    && root
+                        .as_deref()
+                        .is_some_and(|root| store.pending_project_root() == Some(root)),
+                submitted
+                    .then(|| store.project_add_error().map(str::to_owned))
+                    .flatten(),
+            )
+        };
+        let error = local_error.or(engine_error);
+        let selected_name = root
+            .as_deref()
+            .and_then(|root| Path::new(root).file_name())
+            .and_then(|name| name.to_str())
+            .unwrap_or("No folder selected")
+            .to_owned();
+        let browse_disabled = pending;
+        let cancel_disabled = pending;
+        let content = div()
+            .id("add-workspace-dialog")
+            .debug_selector(|| "ADD_WORKSPACE_DIALOG".to_owned())
+            .role(Role::Dialog)
+            .aria_label("Add Workspace")
+            .flex()
+            .flex_col()
+            .child(
+                div()
+                    .px(px(10.0))
+                    .pt(px(8.0))
+                    .pb(px(6.0))
+                    .flex()
+                    .flex_col()
+                    .gap(px(2.0))
+                    .child(
+                        div()
+                            .text_size(px(SIDEBAR_TITLE_SIZE))
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .text_color(colors.primary)
+                            .child("Add Workspace"),
+                    )
+                    .child(
+                        div()
+                            .text_size(px(Typo::META.size))
+                            .text_color(colors.tertiary)
+                            .child("Choose a folder to add to Zeus."),
+                    ),
+            )
+            .child(
+                div()
+                    .mx(px(7.0))
+                    .px(px(8.0))
+                    .py(px(7.0))
+                    .flex()
+                    .items_center()
+                    .gap(px(7.0))
+                    .rounded(px(Radius::ROW))
+                    .border_1()
+                    .border_color(if error.is_some() {
+                        Ink::DANGER.alpha(0.65)
+                    } else {
+                        colors.primary.alpha(0.09)
+                    })
+                    .child(sf_symbol("folder", 12.0, colors.secondary))
+                    .child(
+                        div()
+                            .min_w(px(0.0))
+                            .flex_1()
+                            .flex()
+                            .flex_col()
+                            .gap(px(1.0))
+                            .child(
+                                div()
+                                    .whitespace_nowrap()
+                                    .overflow_hidden()
+                                    .text_ellipsis()
+                                    .text_size(px(SIDEBAR_TITLE_SIZE))
+                                    .text_color(colors.primary)
+                                    .child(selected_name),
+                            )
+                            .when_some(root.clone(), |copy, root| {
+                                copy.child(
+                                    div()
+                                        .whitespace_nowrap()
+                                        .overflow_hidden()
+                                        .text_ellipsis()
+                                        .text_size(px(Typo::META.size))
+                                        .text_color(colors.tertiary)
+                                        .child(root),
+                                )
+                            }),
+                    )
+                    .child(
+                        div()
+                            .id("choose-workspace-folder")
+                            .debug_selector(|| "CHOOSE_WORKSPACE_FOLDER".to_owned())
+                            .focusable()
+                            .tab_stop(true)
+                            .role(Role::Button)
+                            .aria_label("Choose workspace folder")
+                            .px(px(6.0))
+                            .h(px(22.0))
+                            .flex_none()
+                            .flex()
+                            .items_center()
+                            .rounded(px(Radius::CHIP))
+                            .bg(colors.primary.alpha(0.06))
+                            .text_size(px(Typo::META.size))
+                            .text_color(colors.secondary)
+                            .when(browse_disabled, |button| button.opacity(0.5))
+                            .when(!browse_disabled, |button| {
+                                button
+                                    .cursor_pointer()
+                                    .hover(move |button| button.bg(colors.primary.alpha(0.10)))
+                                    .on_click(cx.listener(|this, _, window, cx| {
+                                        this.choose_workspace_folder(window, cx);
+                                    }))
+                            })
+                            .child("Choose…"),
+                    ),
+            )
+            .when_some(error, |content, error| {
+                content.child(
+                    div()
+                        .id("add-workspace-error")
+                        .debug_selector(|| "ADD_WORKSPACE_ERROR".to_owned())
+                        .px(px(10.0))
+                        .pt(px(5.0))
+                        .text_size(px(Typo::META.size))
+                        .text_color(Ink::DANGER)
+                        .child(error),
+                )
+            })
+            .child(
+                div()
+                    .mt(px(7.0))
+                    .px(px(7.0))
+                    .pt(px(7.0))
+                    .pb(px(4.0))
+                    .border_t_1()
+                    .border_color(colors.primary.alpha(0.07))
+                    .flex()
+                    .justify_end()
+                    .gap(px(6.0))
+                    .child(
+                        div()
+                            .id("cancel-add-workspace")
+                            .debug_selector(|| "CANCEL_ADD_WORKSPACE".to_owned())
+                            .focusable()
+                            .tab_stop(true)
+                            .role(Role::Button)
+                            .aria_label("Cancel adding workspace")
+                            .px(px(8.0))
+                            .h(px(24.0))
+                            .flex()
+                            .items_center()
+                            .rounded(px(Radius::CHIP))
+                            .text_size(px(Typo::META.size))
+                            .text_color(colors.secondary)
+                            .when(cancel_disabled, |button| button.opacity(0.5))
+                            .when(!cancel_disabled, |button| {
+                                button
+                                    .cursor_pointer()
+                                    .hover(move |button| button.bg(colors.primary.alpha(0.07)))
+                                    .on_click(cx.listener(|this, _, _, cx| {
+                                        this.ui.popover = None;
+                                        this.store
+                                            .write()
+                                            .expect("session store lock poisoned")
+                                            .clear_project_add_error();
+                                        cx.notify();
+                                    }))
+                            })
+                            .child("Cancel"),
+                    )
+                    .child(
+                        div()
+                            .id("confirm-add-workspace")
+                            .debug_selector(|| "CONFIRM_ADD_WORKSPACE".to_owned())
+                            .focusable()
+                            .tab_stop(true)
+                            .role(Role::Button)
+                            .aria_label("Add selected workspace")
+                            .px(px(9.0))
+                            .h(px(24.0))
+                            .flex()
+                            .items_center()
+                            .rounded(px(Radius::CHIP))
+                            .bg(Ink::FRESH)
+                            .text_size(px(Typo::META.size))
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .text_color(colors.background)
+                            .when(pending, |button| button.opacity(0.55))
+                            .when(!pending, |button| {
+                                button.cursor_pointer().on_click(
+                                    cx.listener(|this, _, _, cx| this.submit_add_workspace(cx)),
+                                )
+                            })
+                            .child(if pending { "Adding…" } else { "Add" }),
+                    ),
+            );
+        self.popover_shell(74.0, content, colors, window, cx)
     }
 
     /// Panels that hang off the sidebar's own edge sit 12pt inside the window
@@ -2200,7 +2935,6 @@ impl Sidebar {
                                         },
                                     );
                                 this.ui.popover = None;
-                                cx.emit(SidebarEvent::AgentSpawnRequested);
                                 cx.notify();
                             }))
                     })
@@ -2269,7 +3003,7 @@ impl Sidebar {
                     }),
             );
         }
-        self.popover_shell(70.0, content.pb(px(6.0)), colors, window, cx)
+        self.popover_shell(110.0, content.pb(px(6.0)), colors, window, cx)
     }
 
     fn directory_picker(
@@ -2539,7 +3273,7 @@ impl Sidebar {
             Some(position) => {
                 self.popover_shell_at(position, Anchor::TopLeft, 200.0, content, colors, cx)
             }
-            None => self.popover_shell(96.0, content, colors, window, cx),
+            None => self.popover_shell(136.0, content, colors, window, cx),
         }
     }
 
@@ -3016,7 +3750,7 @@ impl Sidebar {
         let id = {
             let mut store = self.store.write().expect("session store lock poisoned");
             let id = store
-                .ordered_sessions()
+                .active_workspace_sessions()
                 .get(index)
                 .map(|session| session.id.clone());
             if let Some(id) = &id {
@@ -3039,7 +3773,7 @@ impl Sidebar {
             .store
             .write()
             .expect("session store lock poisoned")
-            .ordered_sessions()
+            .active_workspace_sessions()
             .len();
         if count == 0 {
             return false;
@@ -3054,7 +3788,7 @@ impl Sidebar {
         self.commit_rename();
         {
             let mut store = self.store.write().expect("session store lock poisoned");
-            let sessions = store.ordered_sessions();
+            let sessions = store.active_workspace_sessions();
             if sessions.is_empty() {
                 return false;
             }
@@ -3081,7 +3815,7 @@ impl Sidebar {
         self.commit_rename();
         {
             let mut store = self.store.write().expect("session store lock poisoned");
-            let sessions = store.ordered_sessions();
+            let sessions = store.active_workspace_sessions();
             if sessions.is_empty() {
                 return false;
             }
@@ -3234,13 +3968,37 @@ impl Sidebar {
 impl Render for Sidebar {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let colors = self.colors();
-        let projection = {
+        let (projection, active_workspace) = {
             let mut store = self.store.write().expect("session store lock poisoned");
-            store.sidebar_projection()
+            (
+                store.sidebar_projection(),
+                store.active_workspace_id().cloned(),
+            )
         };
+        let active_group = projection
+            .projects
+            .iter()
+            .find(|group| Some(&group.project.id) == active_workspace.as_ref());
         self.shortcut_ranks.clear();
-        let session_count = projection.ordered_sessions.len();
-        for (index, session) in projection.ordered_sessions.iter().enumerate() {
+        let selected_session = self
+            .store
+            .read()
+            .expect("session store lock poisoned")
+            .selected_session_id()
+            .cloned();
+        let ordered_sessions: Vec<_> = active_group
+            .into_iter()
+            .flat_map(|group| {
+                group.sessions.iter().map(|row| &row.session).chain(
+                    group
+                        .archived
+                        .iter()
+                        .filter(|session| selected_session.as_ref() == Some(&session.id)),
+                )
+            })
+            .collect();
+        let session_count = ordered_sessions.len();
+        for (index, session) in ordered_sessions.iter().enumerate() {
             let shortcut = if index < 8 {
                 Some(index + 1)
             } else if index + 1 == session_count {
@@ -3252,7 +4010,12 @@ impl Render for Sidebar {
                 self.shortcut_ranks.insert(session.id.clone(), shortcut);
             }
         }
-        retain_live_glyphs(&mut self.glyphs, &projection.display_order);
+        let display_order: Vec<_> = active_group
+            .into_iter()
+            .flat_map(|group| group.active.iter().chain(&group.archived))
+            .map(|session| session.id.clone())
+            .collect();
+        retain_live_glyphs(&mut self.glyphs, &display_order);
         let mut list = div()
             .id("sidebar-list")
             .track_scroll(&self.list_scroll)
@@ -3265,7 +4028,7 @@ impl Render for Sidebar {
             .flex()
             .flex_col()
             .gap(px(3.0));
-        for group in &projection.projects {
+        if let Some(group) = active_group {
             list = list.child(self.project_section(group, colors, window, cx));
         }
 
@@ -3280,9 +4043,12 @@ impl Render for Sidebar {
             .track_focus(&self.rename_focus)
             .on_key_down(cx.listener(Self::on_key_down))
             .child(self.top_bar(colors, cx))
-            .child(self.new_agent_row(colors, cx));
-        if projection.projects.is_empty() {
-            root = root.child(self.empty_state(colors, cx));
+            .child(self.workspace_row(&projection, colors, cx))
+            .when(active_group.is_some(), |root| {
+                root.child(self.new_agent_row(colors, cx))
+            });
+        if active_group.is_none() {
+            root = root.child(self.empty_state(false, colors, cx));
         } else {
             // Rows dissolve into the chrome at both ends of the scroll instead
             // of being sliced off by the container edge.
@@ -3820,6 +4586,22 @@ fn session_title_available_width(
     available.max(36.0)
 }
 
+fn validate_workspace_root(root: &str) -> Result<String, String> {
+    let root = root.trim();
+    if root.is_empty() {
+        return Err("Choose a folder to continue.".into());
+    }
+    let canonical =
+        fs::canonicalize(root).map_err(|error| format!("This folder is unavailable: {error}"))?;
+    let metadata =
+        fs::metadata(&canonical).map_err(|error| format!("This folder is unavailable: {error}"))?;
+    if !metadata.is_dir() {
+        return Err("The selected path is not a folder.".into());
+    }
+    fs::read_dir(&canonical).map_err(|error| format!("Zeus cannot access this folder: {error}"))?;
+    Ok(canonical.to_string_lossy().into_owned())
+}
+
 #[cfg(test)]
 mod tests {
     use gpui::{Modifiers, TestAppContext};
@@ -4050,6 +4832,101 @@ mod tests {
         assert!(glyphs.contains_key(&first));
         assert!(glyphs.contains_key(&second));
         assert!(!glyphs.contains_key(&stale));
+    }
+
+    #[test]
+    fn workspace_validation_rejects_missing_paths_and_files() {
+        let directory = tempfile::tempdir().expect("temp directory");
+        let file = directory.path().join("not-a-directory");
+        std::fs::write(&file, b"test").expect("fixture file");
+
+        assert!(validate_workspace_root("/definitely/missing/zeus-workspace").is_err());
+        assert_eq!(
+            validate_workspace_root(file.to_string_lossy().as_ref()),
+            Err("The selected path is not a folder.".into())
+        );
+        assert_eq!(
+            validate_workspace_root(directory.path().to_string_lossy().as_ref()),
+            Ok(directory
+                .path()
+                .canonicalize()
+                .expect("canonical directory")
+                .to_string_lossy()
+                .into_owned())
+        );
+    }
+
+    #[gpui::test]
+    fn workspace_selector_switches_the_scoped_sidebar_project(cx: &mut TestAppContext) {
+        let (view, cx) = cx.add_window_view(|_, cx| {
+            let sidebar = cx.new(|cx| Sidebar::new(None, true, PreviewScenario::Typical, cx));
+            SidebarPopoverHarness { sidebar }
+        });
+
+        assert!(cx.debug_bounds("WORKSPACE_SELECTOR").is_some());
+        assert!(cx.debug_bounds("PROJECT_preview-zeus").is_some());
+        assert!(cx.debug_bounds("PROJECT_preview-mldrills").is_none());
+
+        let selector = cx
+            .debug_bounds("WORKSPACE_SELECTOR")
+            .expect("workspace selector");
+        cx.simulate_click(selector.center(), Modifiers::default());
+        let option = cx
+            .debug_bounds("WORKSPACE_OPTION_preview-mldrills")
+            .expect("workspace option");
+        cx.simulate_click(option.center(), Modifiers::default());
+
+        assert!(cx.debug_bounds("PROJECT_preview-zeus").is_none());
+        assert!(cx.debug_bounds("PROJECT_preview-mldrills").is_some());
+        let sidebar = view.read_with(cx, |harness, _| harness.sidebar.clone());
+        assert_eq!(
+            sidebar.read_with(cx, |sidebar, _| sidebar
+                .store
+                .read()
+                .expect("session store lock poisoned")
+                .active_workspace_id()
+                .cloned()),
+            Some(ProjectId::new("preview-mldrills"))
+        );
+    }
+
+    #[gpui::test]
+    fn add_workspace_control_opens_an_explicit_cancelable_dialog(cx: &mut TestAppContext) {
+        let (view, cx) = cx.add_window_view(|_, cx| {
+            let sidebar = cx.new(|cx| Sidebar::new(None, true, PreviewScenario::Typical, cx));
+            SidebarPopoverHarness { sidebar }
+        });
+
+        let add = cx.debug_bounds("WORKSPACE_ADD").expect("add workspace");
+        cx.simulate_click(add.center(), Modifiers::default());
+
+        assert!(cx.debug_bounds("ADD_WORKSPACE_DIALOG").is_some());
+        assert!(cx.debug_bounds("CHOOSE_WORKSPACE_FOLDER").is_some());
+        assert!(cx.debug_bounds("CONFIRM_ADD_WORKSPACE").is_some());
+        let cancel = cx
+            .debug_bounds("CANCEL_ADD_WORKSPACE")
+            .expect("cancel add workspace");
+        cx.simulate_click(cancel.center(), Modifiers::default());
+
+        assert!(cx.debug_bounds("ADD_WORKSPACE_DIALOG").is_none());
+        let sidebar = view.read_with(cx, |harness, _| harness.sidebar.clone());
+        assert!(!matches!(
+            sidebar.read_with(cx, |sidebar, _| sidebar.ui.popover.clone()),
+            Some(Popover::AddWorkspace { .. })
+        ));
+    }
+
+    #[gpui::test]
+    fn first_launch_sidebar_has_a_clear_add_workspace_action(cx: &mut TestAppContext) {
+        let (_view, cx) = cx.add_window_view(|_, cx| {
+            let sidebar = cx.new(|cx| Sidebar::new(None, true, PreviewScenario::Empty, cx));
+            SidebarPopoverHarness { sidebar }
+        });
+
+        assert!(cx.debug_bounds("WORKSPACE_SELECTOR").is_some());
+        assert!(cx.debug_bounds("WORKSPACE_ADD").is_some());
+        assert!(cx.debug_bounds("EMPTY_ADD_WORKSPACE").is_some());
+        assert!(cx.debug_bounds("EMPTY_NEW_AGENT").is_none());
     }
 
     #[gpui::test]

--- a/zeus/crates/zeus-app/src/store/mod.rs
+++ b/zeus/crates/zeus-app/src/store/mod.rs
@@ -275,6 +275,11 @@ pub struct SessionStore {
     repo_target_session: Option<SessionId>,
     directory_request_seq: u64,
     directory_listing: Option<DirectoryListing>,
+    /// Root currently being persisted through `project.add`, plus the last
+    /// add-specific failure. The sidebar keeps its Add Workspace dialog open
+    /// while this state is pending and renders failures inline.
+    pending_project_root: Option<String>,
+    project_add_error: Option<String>,
     prefs: Prefs,
     terminal_residency: TerminalResidency,
     app_is_active: bool,
@@ -338,6 +343,8 @@ impl SessionStore {
                 repo_target_session: None,
                 directory_request_seq: 0,
                 directory_listing: None,
+                pending_project_root: None,
+                project_add_error: None,
                 prefs,
                 terminal_residency: TerminalResidency::default(),
                 app_is_active: true,
@@ -613,20 +620,180 @@ impl SessionStore {
         &self.projects
     }
 
+    pub fn active_workspace_id(&self) -> Option<&ProjectId> {
+        self.prefs.last_active_workspace.as_ref().filter(|id| {
+            self.projects.contains_key(*id)
+                || self
+                    .sessions
+                    .values()
+                    .any(|session| &session.project_id == *id)
+        })
+    }
+
+    pub fn active_workspace(&self) -> Option<&Project> {
+        self.active_workspace_id()
+            .and_then(|id| self.projects.get(id))
+    }
+
+    /// Makes one workspace the sidebar and workbench destination. A workspace
+    /// switch keeps the current session when it already belongs there;
+    /// otherwise it restores the most-recent live session in that workspace,
+    /// or leaves the workbench empty when the workspace has no sessions.
+    pub fn set_active_workspace(&mut self, id: ProjectId) -> bool {
+        if !self.workspace_exists(&id) {
+            return false;
+        }
+        let workspace_changed = self.prefs.last_active_workspace.as_ref() != Some(&id);
+        self.prefs.last_active_workspace = Some(id.clone());
+        self.sidebar_selection.clear();
+        self.sidebar_selection_anchor = None;
+
+        let selected_matches = self
+            .selected_session()
+            .is_some_and(|session| session.project_id == id);
+        if selected_matches {
+            if workspace_changed {
+                if let Err(error) = self.persist_preferences() {
+                    eprintln!("zeus: could not remember the active workspace: {error}");
+                }
+                self.invalidate_projection();
+                self.emit(StoreEffect::UiChanged);
+            }
+            return true;
+        }
+
+        if let Some(session) = self.preferred_session_in_workspace(&id) {
+            self.focus_session(session);
+        } else {
+            let selection_changed = self.selected_session_id.take().is_some();
+            let preference_changed = self.prefs.last_selected_session.take().is_some();
+            if workspace_changed || selection_changed || preference_changed {
+                if let Err(error) = self.persist_preferences() {
+                    eprintln!("zeus: could not remember the active workspace: {error}");
+                }
+                self.invalidate_projection();
+                self.emit(StoreEffect::UiChanged);
+            }
+        }
+        true
+    }
+
+    fn workspace_exists(&self, id: &ProjectId) -> bool {
+        self.projects.contains_key(id)
+            || self
+                .sessions
+                .values()
+                .any(|session| &session.project_id == id && !self.closing.contains(&session.id))
+    }
+
+    fn preferred_session_in_workspace(&self, id: &ProjectId) -> Option<SessionId> {
+        self.mru_order
+            .iter()
+            .find(|candidate| {
+                self.sessions.get(*candidate).is_some_and(|session| {
+                    &session.project_id == id
+                        && !session.is_archived()
+                        && !session.is_workbench_terminal()
+                        && !self.closing.contains(&session.id)
+                })
+            })
+            .cloned()
+            .or_else(|| {
+                projection::build_projection(
+                    &self.sessions,
+                    &self.projects,
+                    &self.prefs,
+                    self.selected_session_id.as_ref(),
+                    &self.closing,
+                )
+                .projects
+                .into_iter()
+                .find(|group| &group.project.id == id)
+                .and_then(|group| group.active.first().map(|session| session.id.clone()))
+            })
+    }
+
+    fn repair_active_workspace(&mut self) {
+        let previous = self.prefs.last_active_workspace.clone();
+        let restored = previous
+            .as_ref()
+            .filter(|id| self.workspace_exists(id))
+            .cloned()
+            .or_else(|| {
+                self.selected_session()
+                    .map(|session| session.project_id.clone())
+            })
+            .or_else(|| {
+                projection::build_projection(
+                    &self.sessions,
+                    &self.projects,
+                    &self.prefs,
+                    self.selected_session_id.as_ref(),
+                    &self.closing,
+                )
+                .projects
+                .into_iter()
+                .map(|group| group.project.id)
+                .next()
+            });
+        self.prefs.last_active_workspace = restored;
+        if self.prefs.last_active_workspace != previous
+            && let Err(error) = self.persist_preferences()
+        {
+            eprintln!("zeus: could not repair the active workspace: {error}");
+        }
+    }
+
+    pub fn pending_project_root(&self) -> Option<&str> {
+        self.pending_project_root.as_deref()
+    }
+
+    pub fn project_add_error(&self) -> Option<&str> {
+        self.project_add_error.as_deref()
+    }
+
+    pub fn clear_project_add_error(&mut self) {
+        self.project_add_error = None;
+    }
+
     /// Persist a workspace before it owns any sessions. `project.add` is
     /// idempotent in the Engine, and the local guard avoids a needless RPC
-    /// when the welcome screen selects an existing sidebar project.
-    pub fn add_project(&mut self, root: String) {
-        if self.projects.values().any(|project| project.root == root) {
-            return;
+    /// when the workspace selector chooses an existing sidebar project.
+    pub fn add_project(&mut self, root: String) -> bool {
+        if let Some(id) = self
+            .projects
+            .values()
+            .find(|project| project.root == root)
+            .map(|project| project.id.clone())
+        {
+            self.project_add_error = None;
+            self.set_active_workspace(id);
+            return false;
         }
+        if self.pending_project_root.is_some() {
+            return false;
+        }
+        self.pending_project_root = Some(root.clone());
+        self.project_add_error = None;
         self.emit(StoreEffect::AddProject { root });
+        true
     }
 
     fn finish_add_project(&mut self, project: Project) {
-        self.projects.insert(project.id.clone(), project);
+        let id = project.id.clone();
+        self.projects.insert(id.clone(), project);
+        self.pending_project_root = None;
+        self.project_add_error = None;
         self.invalidate_projection();
         self.sync_sidebar_order();
+        self.set_active_workspace(id);
+    }
+
+    fn fail_add_project(&mut self, root: String, error: String) {
+        if self.pending_project_root.as_ref() == Some(&root) {
+            self.pending_project_root = None;
+            self.project_add_error = Some(error);
+        }
     }
 
     pub fn selected_session_id(&self) -> Option<&SessionId> {
@@ -1078,6 +1245,27 @@ impl SessionStore {
             .collect()
     }
 
+    /// Visible shortcut/navigation order for the selected workspace only.
+    pub fn active_workspace_sessions(&mut self) -> Vec<SessionRecord> {
+        let active = self.active_workspace_id().cloned();
+        let selected = self.selected_session_id.clone();
+        self.sidebar_projection()
+            .projects
+            .iter()
+            .find(|group| Some(&group.project.id) == active.as_ref())
+            .into_iter()
+            .flat_map(|group| {
+                group.sessions.iter().map(|row| &row.session).chain(
+                    group
+                        .archived
+                        .iter()
+                        .filter(|session| selected.as_ref() == Some(&session.id)),
+                )
+            })
+            .map(|session| session.as_ref().clone())
+            .collect()
+    }
+
     pub fn selected_session(&self) -> Option<&SessionRecord> {
         self.selected_session_id
             .as_ref()
@@ -1108,7 +1296,14 @@ impl SessionStore {
         }
         self.invalidate_projection();
         self.sync_sidebar_order();
-        self.auto_select_if_needed();
+        self.repair_active_workspace();
+        if self
+            .selected_session()
+            .is_some_and(|session| self.active_workspace_id() != Some(&session.project_id))
+        {
+            self.selected_session_id = None;
+        }
+        self.auto_select_if_needed_without_resume();
         // A restored selection did not travel through `focus_session`, so it
         // still needs terminal residency before the pane can attach.
         if let Some(id) = self.selected_session_id.clone()
@@ -1123,7 +1318,6 @@ impl SessionStore {
                 self.emit(StoreEffect::DetachAttachment(evicted));
             }
         }
-        self.auto_resume_selected_if_needed();
         self.reconcile_navigation();
     }
 
@@ -1378,10 +1572,9 @@ impl SessionStore {
 
     pub fn focus_neighbor(&mut self, excluded: &HashSet<SessionId>) {
         let order: Vec<_> = self
-            .sidebar_projection()
-            .ordered_sessions
-            .iter()
-            .map(|session| session.id.clone())
+            .active_workspace_sessions()
+            .into_iter()
+            .map(|session| session.id)
             .collect();
         let survivors: Vec<_> = order
             .iter()
@@ -1408,8 +1601,6 @@ impl SessionStore {
             .iter()
             .find(same_project)
             .or_else(|| order[..index].iter().rev().find(same_project))
-            .or_else(|| order[index..].iter().find(eligible))
-            .or_else(|| order[..index].iter().rev().find(eligible))
             .cloned()
             .or_else(|| survivors.first().cloned());
         self.set_selected_survivor(next);
@@ -1665,6 +1856,8 @@ impl SessionStore {
         self.emit(StoreEffect::RemoveProject { id });
         self.invalidate_projection();
         self.sync_sidebar_order();
+        self.repair_active_workspace();
+        self.auto_select_if_needed();
     }
 
     pub fn confirm_pending_close(&mut self) {
@@ -1932,6 +2125,9 @@ impl SessionStore {
     /// the repo root of the active project, never the selected session's
     /// worktree cwd (⌘T should default to the main checkout).
     pub fn default_new_agent_directory(&self) -> String {
+        if let Some(project) = self.active_workspace() {
+            return project.root.clone();
+        }
         if let Some(session) = self.selected_session()
             && let Some(project) = self.projects.get(&session.project_id)
         {
@@ -1943,6 +2139,9 @@ impl SessionStore {
     pub fn active_directory(&self) -> String {
         if let Some(session) = self.selected_session() {
             return session.cwd.clone();
+        }
+        if let Some(project) = self.active_workspace() {
+            return project.root.clone();
         }
         let projection = projection::build_projection(
             &self.sessions,
@@ -1973,13 +2172,31 @@ impl SessionStore {
     }
 
     fn focus_session(&mut self, id: SessionId) {
+        self.focus_session_with_resume(id, true);
+    }
+
+    fn focus_session_with_resume(&mut self, id: SessionId, resume: bool) {
         let selection_changed = self.selected_session_id.as_ref() != Some(&id);
         self.selected_session_id = Some(id.clone());
         let revealed = self.reveal(&id);
-        if selection_changed || revealed || self.prefs.last_selected_session.as_ref() != Some(&id) {
+        let workspace = self
+            .sessions
+            .get(&id)
+            .map(|session| session.project_id.clone());
+        let workspace_changed = workspace
+            .as_ref()
+            .is_some_and(|workspace| self.prefs.last_active_workspace.as_ref() != Some(workspace));
+        if let Some(workspace) = workspace {
+            self.prefs.last_active_workspace = Some(workspace);
+        }
+        if selection_changed
+            || revealed
+            || workspace_changed
+            || self.prefs.last_selected_session.as_ref() != Some(&id)
+        {
             self.prefs.last_selected_session = Some(id.clone());
             if let Err(error) = self.persist_preferences() {
-                eprintln!("zeus: could not remember the selected session: {error}");
+                eprintln!("zeus: could not remember the workspace selection: {error}");
             }
         }
         self.mru_order.retain(|candidate| candidate != &id);
@@ -2005,7 +2222,9 @@ impl SessionStore {
             // when there was no unseen completion to acknowledge.
             self.emit(StoreEffect::MarkSeen(id.clone()));
         }
-        self.auto_resume_if_needed(&id);
+        if resume {
+            self.auto_resume_if_needed(&id);
+        }
         self.emit(StoreEffect::UiChanged);
     }
 
@@ -2027,18 +2246,34 @@ impl SessionStore {
         if self.selected_session_id.is_some() {
             return;
         }
+        let active_workspace = self.active_workspace_id().cloned();
         let first = self
             .sidebar_projection()
-            .first_active()
+            .projects
+            .iter()
+            .find(|group| Some(&group.project.id) == active_workspace.as_ref())
+            .and_then(|group| group.active.first())
             .map(|session| session.id.clone());
         self.set_selected_survivor(first);
     }
 
-    fn auto_resume_selected_if_needed(&mut self) {
-        let Some(id) = self.selected_session_id.clone() else {
+    fn auto_select_if_needed_without_resume(&mut self) {
+        if self.selected_session_id.is_some() {
             return;
-        };
-        self.auto_resume_if_needed(&id);
+        }
+        let active_workspace = self.active_workspace_id().cloned();
+        let first = self
+            .sidebar_projection()
+            .projects
+            .iter()
+            .find(|group| Some(&group.project.id) == active_workspace.as_ref())
+            .and_then(|group| group.active.first())
+            .map(|session| session.id.clone());
+        if let Some(first) = first {
+            self.focus_session_with_resume(first, false);
+        } else {
+            self.set_selected_survivor(None);
+        }
     }
 
     fn apply_switcher_outcome(&mut self, outcome: SwitcherOutcome) {
@@ -2527,7 +2762,7 @@ async fn run_effects(
             StoreEffect::Archive(id) => client.archive(&id).await,
             StoreEffect::Unarchive(id) => client.unarchive(&id).await,
             StoreEffect::Rename { id, title } => client.rename(&id, title).await,
-            StoreEffect::AddProject { root } => match client.project_add(root).await {
+            StoreEffect::AddProject { root } => match client.project_add(root.clone()).await {
                 Ok(project) => {
                     store
                         .write()
@@ -2535,7 +2770,13 @@ async fn run_effects(
                         .finish_add_project(project);
                     Ok(())
                 }
-                Err(error) => Err(error),
+                Err(error) => {
+                    store
+                        .write()
+                        .expect("session store lock poisoned")
+                        .fail_add_project(root, error.to_string());
+                    Err(error)
+                }
             },
             StoreEffect::RemoveProject { id } => client.project_remove(id).await,
             StoreEffect::Spawn(params) => match client.spawn(params).await {

--- a/zeus/crates/zeus-app/src/store/prefs.rs
+++ b/zeus/crates/zeus-app/src/store/prefs.rs
@@ -142,6 +142,10 @@ pub struct Prefs {
     /// Sessions whose spawned children are folded away.
     pub sidebar_collapsed_sessions: Vec<SessionId>,
     pub sidebar_expanded_archives: Vec<ProjectId>,
+    /// Workspace that should become active after the daemon's initial hydrate.
+    /// This is independent of session selection so an empty workspace can be
+    /// restored across launches.
+    pub last_active_workspace: Option<ProjectId>,
     /// Session that should regain focus after the daemon's initial hydrate.
     pub last_selected_session: Option<SessionId>,
 }
@@ -181,6 +185,7 @@ impl Default for Prefs {
             sidebar_collapsed_projects: Vec::new(),
             sidebar_collapsed_sessions: Vec::new(),
             sidebar_expanded_archives: Vec::new(),
+            last_active_workspace: None,
             last_selected_session: None,
         }
     }
@@ -335,6 +340,18 @@ mod tests {
 
         assert!(prefs.sidebar_on_right);
         assert_eq!(prefs.layout_version, CURRENT_LAYOUT_VERSION);
+    }
+
+    #[test]
+    fn active_workspace_is_optional_for_older_preferences() {
+        let restored: Prefs =
+            serde_json::from_str(r#"{"lastSelectedSession":"session-a"}"#).expect("legacy prefs");
+
+        assert_eq!(restored.last_active_workspace, None);
+        assert_eq!(
+            restored.last_selected_session,
+            Some(zeus_proto::SessionId::new("session-a"))
+        );
     }
 
     #[test]

--- a/zeus/crates/zeus-app/src/store/tests.rs
+++ b/zeus/crates/zeus-app/src/store/tests.rs
@@ -149,6 +149,111 @@ fn hydrate_restores_the_last_selected_session_instead_of_the_first() {
 
     assert_eq!(store.selected_session_id(), Some(&id("two")));
     assert!(store.terminal_residency().contains(&id("two")));
+    assert_eq!(store.active_workspace_id(), Some(&pid("a")));
+}
+
+#[test]
+fn hydrate_restores_the_workspace_independently_of_the_last_session() {
+    let prefs = Prefs {
+        last_active_workspace: Some(pid("b")),
+        last_selected_session: Some(id("from-a")),
+        ..Prefs::default()
+    };
+    let (store, _) = hydrated(
+        vec![session("from-a", "a", 1.0), session("from-b", "b", 2.0)],
+        vec![project("a", "Alpha"), project("b", "Beta")],
+        prefs,
+    );
+
+    assert_eq!(store.active_workspace_id(), Some(&pid("b")));
+    assert_eq!(store.selected_session_id(), Some(&id("from-b")));
+    assert_eq!(store.preferences().last_active_workspace, Some(pid("b")));
+}
+
+#[test]
+fn an_empty_workspace_is_restored_without_selecting_another_workspaces_session() {
+    let prefs = Prefs {
+        last_active_workspace: Some(pid("empty")),
+        last_selected_session: Some(id("from-a")),
+        ..Prefs::default()
+    };
+    let (store, _) = hydrated(
+        vec![session("from-a", "a", 1.0)],
+        vec![project("a", "Alpha"), project("empty", "Empty")],
+        prefs,
+    );
+
+    assert_eq!(store.active_workspace_id(), Some(&pid("empty")));
+    assert_eq!(store.selected_session_id(), None);
+    assert_eq!(store.preferences().last_selected_session, None);
+}
+
+#[test]
+fn a_missing_remembered_workspace_uses_a_deterministic_catalog_fallback() {
+    let prefs = Prefs {
+        last_active_workspace: Some(pid("removed")),
+        ..Prefs::default()
+    };
+    let (store, _) = hydrated(
+        vec![session("from-b", "b", 2.0), session("from-a", "a", 1.0)],
+        vec![project("b", "Beta"), project("a", "Alpha")],
+        prefs,
+    );
+
+    assert_eq!(store.active_workspace_id(), Some(&pid("a")));
+    assert_eq!(store.selected_session_id(), Some(&id("from-a")));
+    assert_eq!(store.preferences().last_active_workspace, Some(pid("a")));
+}
+
+#[test]
+fn first_launch_without_workspaces_has_no_active_workspace_or_session() {
+    let (store, _) = hydrated(Vec::new(), Vec::new(), Prefs::default());
+
+    assert_eq!(store.active_workspace_id(), None);
+    assert_eq!(store.selected_session_id(), None);
+    assert_eq!(store.preferences().last_active_workspace, None);
+    assert_eq!(store.preferences().last_selected_session, None);
+}
+
+#[test]
+fn switching_workspaces_updates_selection_and_scoped_navigation() {
+    let (mut store, _) = hydrated(
+        vec![
+            session("a-one", "a", 1.0),
+            session("b-one", "b", 2.0),
+            session("b-two", "b", 3.0),
+        ],
+        vec![project("a", "Alpha"), project("b", "Beta")],
+        Prefs::default(),
+    );
+
+    assert!(store.set_active_workspace(pid("b")));
+
+    assert_eq!(store.active_workspace_id(), Some(&pid("b")));
+    assert_eq!(store.selected_session_id(), Some(&id("b-one")));
+    assert_eq!(store.default_new_agent_directory(), "/work/b");
+    assert_eq!(
+        store
+            .active_workspace_sessions()
+            .into_iter()
+            .map(|session| session.id)
+            .collect::<Vec<_>>(),
+        vec![id("b-one"), id("b-two")]
+    );
+}
+
+#[test]
+fn selecting_a_session_also_activates_its_workspace() {
+    let (mut store, _) = hydrated(
+        vec![session("from-a", "a", 1.0), session("from-b", "b", 2.0)],
+        vec![project("a", "Alpha"), project("b", "Beta")],
+        Prefs::default(),
+    );
+
+    store.select(id("from-b"));
+
+    assert_eq!(store.active_workspace_id(), Some(&pid("b")));
+    assert_eq!(store.preferences().last_active_workspace, Some(pid("b")));
 }
 
 #[test]
@@ -275,9 +380,48 @@ fn an_empty_added_project_remains_visible_before_its_first_agent() {
     assert_eq!(projection.projects.len(), 1);
     assert_eq!(projection.projects[0].project.root, "/work/atlas");
     assert!(projection.projects[0].sessions.is_empty());
+    assert_eq!(store.active_workspace_id(), Some(&pid("atlas")));
+    drain(&mut effects);
 
     store.add_project("/work/atlas".to_owned());
     assert!(drain(&mut effects).is_empty(), "project.add is idempotent");
+}
+
+#[test]
+fn adding_an_existing_workspace_selects_it_without_a_duplicate_request() {
+    let (mut store, mut effects) = hydrated(
+        Vec::new(),
+        vec![project("a", "Alpha"), project("b", "Beta")],
+        Prefs::default(),
+    );
+    assert!(store.set_active_workspace(pid("a")));
+    drain(&mut effects);
+
+    assert!(!store.add_project("/work/b".to_owned()));
+
+    assert_eq!(store.active_workspace_id(), Some(&pid("b")));
+    assert!(
+        drain(&mut effects)
+            .into_iter()
+            .all(|effect| !matches!(effect, StoreEffect::AddProject { .. }))
+    );
+}
+
+#[test]
+fn a_failed_workspace_add_clears_pending_state_and_can_be_retried() {
+    let root = "/work/retry".to_owned();
+    let (mut store, mut effects) = hydrated(Vec::new(), Vec::new(), Prefs::default());
+
+    assert!(store.add_project(root.clone()));
+    drain(&mut effects);
+    store.fail_add_project(root.clone(), "permission denied".into());
+
+    assert_eq!(store.pending_project_root(), None);
+    assert_eq!(store.project_add_error(), Some("permission denied"));
+    assert!(store.add_project(root.clone()));
+    assert_eq!(store.pending_project_root(), Some(root.as_str()));
+    assert_eq!(store.project_add_error(), None);
+    assert_eq!(drain(&mut effects), vec![StoreEffect::AddProject { root }]);
 }
 
 /// The order is total, so a row dragged to the end of its group stays there.
@@ -637,7 +781,7 @@ fn multi_select_matches_finder_command_and_visible_shift_ranges() {
 }
 
 #[test]
-fn focus_neighbor_prefers_same_project_below_then_above_then_global() {
+fn focus_neighbor_stays_within_the_active_workspace() {
     let records = vec![
         session("a-top", "a", 1.0),
         session("a-mid", "a", 2.0),
@@ -656,15 +800,17 @@ fn focus_neighbor_prefers_same_project_below_then_above_then_global() {
     above.focus_neighbor(&HashSet::from([id("a-low")]));
     assert_eq!(above.selected_session_id, Some(id("a-mid")));
 
-    let (mut global_below, _) = hydrated(records.clone(), projects.clone(), Prefs::default());
-    global_below.select(id("a-mid"));
-    global_below.focus_neighbor(&HashSet::from([id("a-top"), id("a-mid"), id("a-low")]));
-    assert_eq!(global_below.selected_session_id, Some(id("b-top")));
+    let (mut exhausted, _) = hydrated(records.clone(), projects.clone(), Prefs::default());
+    exhausted.select(id("a-mid"));
+    exhausted.focus_neighbor(&HashSet::from([id("a-top"), id("a-mid"), id("a-low")]));
+    assert_eq!(exhausted.selected_session_id, None);
+    assert_eq!(exhausted.active_workspace_id(), Some(&pid("a")));
 
-    let (mut global_above, _) = hydrated(records, projects, Prefs::default());
-    global_above.select(id("b-top"));
-    global_above.focus_neighbor(&HashSet::from([id("b-top")]));
-    assert_eq!(global_above.selected_session_id, Some(id("a-low")));
+    let (mut other_workspace, _) = hydrated(records, projects, Prefs::default());
+    other_workspace.select(id("b-top"));
+    other_workspace.focus_neighbor(&HashSet::from([id("b-top")]));
+    assert_eq!(other_workspace.selected_session_id, None);
+    assert_eq!(other_workspace.active_workspace_id(), Some(&pid("b")));
 }
 
 #[test]
@@ -798,6 +944,17 @@ fn auto_resume_is_attempted_once_per_run() {
         Prefs::default(),
     );
 
+    assert!(
+        !drain(&mut effects).into_iter().any(|effect| matches!(
+            effect,
+            StoreEffect::Resume {
+                automatic: true,
+                ..
+            }
+        )),
+        "hydration must not resume an agent"
+    );
+    store.select(id("restart"));
     assert_eq!(
         drain(&mut effects)
             .into_iter()
@@ -809,7 +966,8 @@ fn auto_resume_is_attempted_once_per_run() {
                 }
             ))
             .count(),
-        1
+        1,
+        "an explicit selection should attempt one resume"
     );
     store.upsert_session(record);
     assert!(!store.auto_resume_if_needed(&id("restart")));
@@ -817,7 +975,7 @@ fn auto_resume_is_attempted_once_per_run() {
 }
 
 #[test]
-fn cold_boot_only_auto_resumes_the_selected_session() {
+fn cold_boot_restores_without_resuming_until_the_user_selects_a_session() {
     let restart_session = |value: &str, created: f64| {
         let mut record = session(value, "p", created);
         record.status = SessionStatus::Exited(ExitInfo {
@@ -851,10 +1009,9 @@ fn cold_boot_only_auto_resumes_the_selected_session() {
             _ => None,
         })
         .collect();
-    assert_eq!(
-        automatic_resumes,
-        vec![id("oldest")],
-        "cold boot must not revive every previously running agent"
+    assert!(
+        automatic_resumes.is_empty(),
+        "restoring the workspace must not revive an agent"
     );
 
     store.select(id("middle"));
@@ -910,6 +1067,7 @@ fn removing_a_project_takes_its_sessions_and_its_sidebar_prefs_with_it() {
     let prefs = Prefs {
         sidebar_pinned_projects: vec![pid("gone")],
         sidebar_collapsed_projects: vec![pid("gone")],
+        last_active_workspace: Some(pid("gone")),
         ..Prefs::default()
     };
     let (mut store, mut effects) = hydrated(
@@ -935,6 +1093,8 @@ fn removing_a_project_takes_its_sessions_and_its_sidebar_prefs_with_it() {
     assert!(!store.projects().contains_key(&pid("gone")));
     assert!(store.projects().contains_key(&pid("stay")));
     assert!(store.sessions().contains_key(&id("kept")));
+    assert_eq!(store.active_workspace_id(), Some(&pid("stay")));
+    assert_eq!(store.selected_session_id(), Some(&id("kept")));
     // Otherwise re-adding the folder brings it back pinned and collapsed.
     assert!(store.preferences().sidebar_pinned_projects.is_empty());
     assert!(store.preferences().sidebar_collapsed_projects.is_empty());
@@ -1296,6 +1456,7 @@ fn selected_session_persists_across_store_reloads() {
         projects: vec![project("a", "A")],
     });
     assert_eq!(restored.selected_session_id(), Some(&id("two")));
+    assert_eq!(restored.active_workspace_id(), Some(&pid("a")));
 }
 
 #[test]

--- a/zeus/crates/zeus-app/src/terminal_pane.rs
+++ b/zeus/crates/zeus-app/src/terminal_pane.rs
@@ -10,9 +10,9 @@ use std::time::{Duration, Instant};
 use gpui::{
     AnyElement, App, ClickEvent, ClipboardEntry, ClipboardItem, Context, Entity, EventEmitter,
     FocusHandle, KeyBinding, KeyDownEvent, KeyUpEvent, ModifiersChangedEvent, MouseButton,
-    PathBuilder, PathPromptOptions, Render, Rgba, ScrollDelta, ScrollHandle, ScrollWheelEvent,
-    SharedString, StatefulInteractiveElement, Subscription, Task, Window, actions, canvas, div,
-    font, point, prelude::*, px, rgba,
+    PathBuilder, Render, Rgba, ScrollDelta, ScrollHandle, ScrollWheelEvent, SharedString,
+    StatefulInteractiveElement, Subscription, Task, Window, actions, canvas, div, font, point,
+    prelude::*, px, rgba,
 };
 use tokio::runtime::Handle;
 use tokio::sync::mpsc;
@@ -20,7 +20,7 @@ use zeus_client::attachment::{SessionAttachment, TerminalChunk};
 use zeus_proto::frames::TerminalModes as WireTerminalModes;
 use zeus_proto::grid::{ChangedRow, GridUpdate};
 use zeus_proto::{
-    AgentKind as ProtoAgentKind, ArtifactKind, ExitReason, PrCheck, Project, PullRequestStatus,
+    AgentKind as ProtoAgentKind, ArtifactKind, ExitReason, PrCheck, PullRequestStatus,
     Resumability, RiskHint, SessionArtifact, SessionId, SessionRecord, SessionStatus, TitleSource,
 };
 use zeus_term::buffer::GridBuffer;
@@ -100,7 +100,6 @@ const ANCHOR_SLACK: f32 = 1.0;
 /// caches are rebuilt on promotion — so the ceiling is a memory bound, not a
 /// residency one.
 const PARKED_GRID_CAP: usize = 12;
-const WELCOME_RECENT_LIMIT: usize = 6;
 const LINEAGE_TAB_HEIGHT: f32 = 26.0;
 const LINEAGE_TREE_NODE_WIDTH: f32 = 124.0;
 const LINEAGE_TREE_MARK: f32 = 40.0;
@@ -132,9 +131,6 @@ actions!(
 pub enum TerminalPaneEvent {
     ToggleSidebar,
     ToggleInspector,
-    OpenWorkspace {
-        root: String,
-    },
     OpenFileReference {
         reference: String,
         cwd: String,
@@ -573,10 +569,6 @@ pub struct TerminalPane {
     /// daemon-created id asynchronously, so this transition is also the
     /// reliable point at which keyboard focus can leave the picker.
     observed_selected_id: Option<SessionId>,
-    /// The welcome canvas is an explicit startup destination, not merely the
-    /// absence of a session. RootView enables it for the primary pane so a
-    /// restored selection cannot skip the workspace choice on launch.
-    startup_welcome: bool,
     preview: bool,
     lineage_tree_scroll: ScrollHandle,
     viewport: Option<TerminalViewport>,
@@ -734,7 +726,6 @@ impl TerminalPane {
             repaint_pacer: RepaintPacer::new(ACTIVE_REPAINT_INTERVAL),
             session_source,
             observed_selected_id,
-            startup_welcome: false,
             preview,
             lineage_tree_scroll: ScrollHandle::new(),
             viewport: None,
@@ -953,22 +944,6 @@ impl TerminalPane {
                 .input(if focused { b"\x1b[I" } else { b"\x1b[O" }.to_vec());
         }
         cx.notify();
-    }
-
-    pub fn show_startup_welcome(&mut self) {
-        self.startup_welcome = true;
-    }
-
-    pub fn dismiss_startup_welcome(&mut self, cx: &mut Context<Self>) {
-        if !self.startup_welcome {
-            return;
-        }
-        self.startup_welcome = false;
-        cx.notify();
-    }
-
-    pub const fn is_startup_welcome_visible(&self) -> bool {
-        self.startup_welcome
     }
 
     pub fn set_viewport(&mut self, viewport: TerminalViewport, cx: &mut Context<Self>) {
@@ -1292,255 +1267,40 @@ impl TerminalPane {
             .map(Arc::clone)
     }
 
-    fn recent_workspaces(&self) -> Vec<Project> {
-        let store = self
+    fn render_empty_session(&self, colors: SemanticColors) -> AnyElement {
+        let workspace = self
             .runtime
             .store
             .read()
-            .expect("session store lock poisoned");
-        let mut updated_at = HashMap::new();
-        for session in store.sessions().values() {
-            updated_at
-                .entry(session.project_id.clone())
-                .and_modify(|value: &mut f64| *value = value.max(session.updated_at.0))
-                .or_insert(session.updated_at.0);
-        }
-        let projects = store
-            .projects()
-            .values()
-            .cloned()
-            .map(|project| {
-                let updated = updated_at
-                    .get(&project.id)
-                    .copied()
-                    .unwrap_or(f64::NEG_INFINITY);
-                (project, updated)
-            })
-            .collect();
-        ordered_recent_workspaces(projects)
-    }
-
-    pub(crate) fn choose_workspace_folder(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let paths = cx.prompt_for_paths(PathPromptOptions {
-            files: false,
-            directories: true,
-            multiple: false,
-            prompt: Some("Open Folder".into()),
-        });
-        cx.spawn_in(window, async move |this, cx| {
-            let selected = match paths.await {
-                Ok(Ok(Some(mut paths))) => paths.pop(),
-                _ => None,
-            };
-            let Some(root) = selected.map(|path| path.to_string_lossy().into_owned()) else {
-                return;
-            };
-            let _ = this.update_in(cx, |_, _window, cx| {
-                cx.emit(TerminalPaneEvent::OpenWorkspace { root });
-            });
-        })
-        .detach();
-    }
-
-    fn render_workspace_welcome(
-        &self,
-        colors: SemanticColors,
-        cx: &mut Context<Self>,
-    ) -> AnyElement {
-        let workspaces = self.recent_workspaces();
-        let mut recent = div()
-            .id("welcome-recent-workspaces")
-            .w_full()
-            .min_w(px(0.0))
-            .flex()
-            .flex_col()
-            .gap(px(4.0));
-        if workspaces.is_empty() {
-            recent = recent.child(
-                div()
-                    .h(px(44.0))
-                    .px(px(10.0))
-                    .flex()
-                    .items_center()
-                    .rounded(px(Radius::ROW))
-                    .border_1()
-                    .border_color(colors.primary.alpha(0.06))
-                    .text_size(px(Typo::ROW.size))
-                    .text_color(colors.tertiary)
-                    .child("Folders you open will appear here."),
-            );
-        } else {
-            for (index, workspace) in workspaces.into_iter().enumerate() {
-                let root = workspace.root.clone();
-                recent = recent.child(
-                    div()
-                        .id(SharedString::from(format!("welcome-workspace-{index}")))
-                        .h(px(44.0))
-                        .px(px(10.0))
-                        .flex()
-                        .items_center()
-                        .gap(px(8.0))
-                        .rounded(px(Radius::ROW))
-                        .cursor_pointer()
-                        .hover(move |row| row.bg(colors.primary.alpha(0.06)))
-                        .active(move |row| row.bg(colors.primary.alpha(0.09)))
-                        .on_click(cx.listener(move |_, _, _, cx| {
-                            cx.emit(TerminalPaneEvent::OpenWorkspace { root: root.clone() });
-                        }))
-                        .child(
-                            div()
-                                .size(px(26.0))
-                                .flex_none()
-                                .flex()
-                                .items_center()
-                                .justify_center()
-                                .rounded(px(Radius::BADGE))
-                                .bg(colors.primary.alpha(0.06))
-                                .child(sf_symbol("folder", 12.0, colors.secondary)),
-                        )
-                        .child(
-                            div()
-                                .min_w(px(0.0))
-                                .flex_1()
-                                .flex()
-                                .flex_col()
-                                .gap(px(2.0))
-                                .child(
-                                    div()
-                                        .whitespace_nowrap()
-                                        .overflow_hidden()
-                                        .text_ellipsis()
-                                        .text_size(px(Typo::ROW_EMPHASIZED.size))
-                                        .font_weight(Typo::ROW_EMPHASIZED.weight)
-                                        .text_color(colors.primary.alpha(0.90))
-                                        .child(workspace.name),
-                                )
-                                .child(
-                                    div()
-                                        .whitespace_nowrap()
-                                        .overflow_hidden()
-                                        .text_ellipsis()
-                                        .text_size(px(Typo::META.size))
-                                        .text_color(colors.tertiary)
-                                        .child(workspace.root),
-                                ),
-                        )
-                        .child(sf_symbol("chevron.right", 9.0, colors.tertiary)),
-                );
-            }
-        }
-
+            .expect("session store lock poisoned")
+            .active_workspace()
+            .map(|project| project.name.clone());
+        let detail = workspace.map_or_else(
+            || "Add a workspace from the sidebar to get started.".to_owned(),
+            |workspace| format!("Start an agent from the sidebar in {workspace}."),
+        );
         div()
-            .id("workspace-welcome")
-            .debug_selector(|| "workspace-welcome".into())
+            .id("workspace-empty")
+            .debug_selector(|| "WORKSPACE_EMPTY".into())
             .flex_1()
             .h_full()
-            .px(px(32.0))
             .flex()
+            .flex_col()
             .items_center()
             .justify_center()
+            .gap(px(5.0))
             .child(
                 div()
-                    .w_full()
-                    .max_w(px(640.0))
-                    .flex()
-                    .flex_col()
-                    .gap(px(28.0))
-                    .child(
-                        div()
-                            .flex()
-                            .flex_col()
-                            .gap(px(6.0))
-                            .child(
-                                div()
-                                    .flex()
-                                    .items_center()
-                                    .gap(px(8.0))
-                                    .child(sf_symbol("sparkle", 18.0, colors.primary))
-                                    .child(
-                                        div()
-                                            .text_size(px(22.0))
-                                            .font_weight(gpui::FontWeight::SEMIBOLD)
-                                            .text_color(colors.primary)
-                                            .child("Welcome to Zeus"),
-                                    ),
-                            )
-                            .child(
-                                div()
-                                    .text_size(px(Typo::ROW.size))
-                                    .text_color(colors.secondary)
-                                    .child(
-                                        "Open a folder to choose where your agents should work.",
-                                    ),
-                            ),
-                    )
-                    .child(
-                        div()
-                            .flex()
-                            .flex_wrap()
-                            .items_start()
-                            .gap(px(36.0))
-                            .child(
-                                div()
-                                    .w(px(220.0))
-                                    .flex_none()
-                                    .flex()
-                                    .flex_col()
-                                    .gap(px(8.0))
-                                    .child(welcome_section_label("Start", colors))
-                                    .child(
-                                        div()
-                                            .id("welcome-open-folder")
-                                            .debug_selector(|| "welcome-open-folder".into())
-                                            .h(px(36.0))
-                                            .px(px(10.0))
-                                            .flex()
-                                            .items_center()
-                                            .gap(px(8.0))
-                                            .rounded(px(Radius::ROW))
-                                            .cursor_pointer()
-                                            .border_1()
-                                            .border_color(colors.primary.alpha(0.09))
-                                            .bg(colors.primary.alpha(0.045))
-                                            .hover(move |button| {
-                                                button.bg(colors.primary.alpha(0.08))
-                                            })
-                                            .active(move |button| {
-                                                button.bg(colors.primary.alpha(0.11))
-                                            })
-                                            .on_click(cx.listener(|this, _, window, cx| {
-                                                this.choose_workspace_folder(window, cx);
-                                            }))
-                                            .child(sf_symbol("folder", 13.0, colors.secondary))
-                                            .child(
-                                                div()
-                                                    .text_size(px(Typo::ROW_EMPHASIZED.size))
-                                                    .font_weight(Typo::ROW_EMPHASIZED.weight)
-                                                    .text_color(colors.primary)
-                                                    .child("Open Folder…"),
-                                            ),
-                                    )
-                                    .child(
-                                        div()
-                                            .text_size(px(Typo::META.size))
-                                            .line_height(px(15.0))
-                                            .text_color(colors.tertiary)
-                                            .child(
-                                                "Choose a repository or any directory on this Mac.",
-                                            ),
-                                    ),
-                            )
-                            .child(
-                                div()
-                                    .min_w(px(0.0))
-                                    .flex_1()
-                                    .flex()
-                                    .flex_col()
-                                    .gap(px(8.0))
-                                    .child(welcome_section_label("Recent workspaces", colors))
-                                    .child(recent),
-                            ),
-                    ),
+                    .text_size(px(Typo::ROW_EMPHASIZED.size))
+                    .font_weight(Typo::ROW_EMPHASIZED.weight)
+                    .text_color(colors.secondary)
+                    .child("No active session"),
+            )
+            .child(
+                div()
+                    .text_size(px(Typo::META.size))
+                    .text_color(colors.tertiary)
+                    .child(detail),
             )
             .into_any_element()
     }
@@ -4043,27 +3803,6 @@ impl TerminalPane {
     }
 }
 
-fn ordered_recent_workspaces(mut projects: Vec<(Project, f64)>) -> Vec<Project> {
-    projects.sort_by(|(left, left_updated), (right, right_updated)| {
-        left.pinned_order
-            .unwrap_or(i64::MAX)
-            .cmp(&right.pinned_order.unwrap_or(i64::MAX))
-            .then_with(|| right_updated.total_cmp(left_updated))
-            .then_with(|| left.name.to_lowercase().cmp(&right.name.to_lowercase()))
-            .then_with(|| left.root.cmp(&right.root))
-    });
-    projects.truncate(WELCOME_RECENT_LIMIT);
-    projects.into_iter().map(|(project, _)| project).collect()
-}
-
-fn welcome_section_label(label: &'static str, colors: SemanticColors) -> gpui::Div {
-    div()
-        .text_size(px(Typo::SECTION_HEADER.size))
-        .font_weight(Typo::SECTION_HEADER.weight)
-        .text_color(colors.secondary)
-        .child(label)
-}
-
 impl Render for TerminalPane {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         self.reconcile_residency();
@@ -4084,9 +3823,7 @@ impl Render for TerminalPane {
         self.sync_status_glyphs(colors, window, cx);
         self.update_selected_geometry(window, cx);
 
-        let selected = (!self.startup_welcome)
-            .then(|| self.selected_session())
-            .flatten();
+        let selected = self.selected_session();
 
         let content = if let Some(session) = selected {
             let chips = PaneChip::for_session(&session);
@@ -4162,14 +3899,14 @@ impl Render for TerminalPane {
             let welcome_lane = (follows_selection && self.chrome.traffic_light_lane)
                 .then(|| self.render_traffic_light_lane());
             // The strip exists for either control, and for the window buttons
-            // alone when the welcome canvas owns the window's leading edge.
-            let welcome_bar = (sidebar_reveal.is_some() || welcome_lane.is_some()).then_some((
+            // alone when the empty workbench owns the window's leading edge.
+            let empty_bar = (sidebar_reveal.is_some() || welcome_lane.is_some()).then_some((
                 sidebar_reveal,
                 welcome_lane,
                 self.chrome.mirrored,
             ));
             let empty_content = if follows_selection {
-                self.render_workspace_welcome(colors, cx)
+                self.render_empty_session(colors)
             } else {
                 div()
                     .flex_1()
@@ -4187,7 +3924,7 @@ impl Render for TerminalPane {
                 .flex()
                 .flex_col()
                 .bg(theme.background)
-                .when_some(welcome_bar, |pane, (reveal, lane, mirrored)| {
+                .when_some(empty_bar, |pane, (reveal, lane, mirrored)| {
                     pane.child(
                         div()
                             .h(px(Metrics::TITLE_BAR))
@@ -5394,7 +5131,7 @@ mod tests {
     }
 
     #[gpui::test]
-    fn an_empty_terminal_pane_shows_workspace_welcome_and_sidebar_control(cx: &mut TestAppContext) {
+    fn an_empty_terminal_pane_shows_neutral_state_and_sidebar_control(cx: &mut TestAppContext) {
         let runtime = Arc::new(StoreRuntime::inert());
         let tokio = Arc::new(
             tokio::runtime::Builder::new_current_thread()
@@ -5413,8 +5150,9 @@ mod tests {
             pane.read_with(cx, |pane, _| pane.selected_session().is_none()),
             "fixture must exercise the empty terminal state"
         );
-        assert!(cx.debug_bounds("workspace-welcome").is_some());
-        assert!(cx.debug_bounds("welcome-open-folder").is_some());
+        assert!(cx.debug_bounds("WORKSPACE_EMPTY").is_some());
+        assert!(cx.debug_bounds("workspace-welcome").is_none());
+        assert!(cx.debug_bounds("welcome-open-folder").is_none());
         assert!(
             cx.debug_bounds("show-sidebar").is_some(),
             "collapsing the sidebar must leave a way to reveal it"
@@ -5657,7 +5395,7 @@ mod tests {
     }
 
     #[gpui::test]
-    fn startup_welcome_precedes_a_restored_session_until_dismissed(cx: &mut TestAppContext) {
+    fn restored_session_renders_immediately_without_a_startup_canvas(cx: &mut TestAppContext) {
         let runtime = Arc::new(StoreRuntime::inert());
         let session = fixture_session();
         {
@@ -5672,41 +5410,11 @@ mod tests {
                 .expect("test runtime"),
         );
 
-        let (pane, cx) = cx.add_window_view(move |window, cx| {
-            let mut pane = TerminalPane::new(runtime, tokio, window, cx);
-            pane.show_startup_welcome();
-            pane
-        });
-
-        assert!(cx.debug_bounds("workspace-welcome").is_some());
-        assert!(pane.read_with(cx, |pane, _| pane.is_startup_welcome_visible()));
-
-        pane.update(cx, |pane, cx| pane.dismiss_startup_welcome(cx));
+        let (_pane, cx) =
+            cx.add_window_view(move |window, cx| TerminalPane::new(runtime, tokio, window, cx));
 
         assert!(cx.debug_bounds("workspace-welcome").is_none());
-        assert!(!pane.read_with(cx, |pane, _| pane.is_startup_welcome_visible()));
-    }
-
-    #[test]
-    fn workspace_welcome_prioritizes_pins_and_bounds_the_recent_list() {
-        let mut projects: Vec<_> = (0..8)
-            .map(|index| Project {
-                id: zeus_proto::ProjectId::new(format!("project-{index}")),
-                root: format!("/work/project-{index}"),
-                name: format!("Project {index}"),
-                pinned_order: None,
-            })
-            .zip(0..8)
-            .map(|(project, updated)| (project, f64::from(updated)))
-            .collect();
-        projects[7].0.name = "Pinned".to_owned();
-        projects[7].0.pinned_order = Some(0);
-
-        let recent = ordered_recent_workspaces(projects);
-
-        assert_eq!(recent.len(), WELCOME_RECENT_LIMIT);
-        assert_eq!(recent[0].name, "Pinned");
-        assert_eq!(recent[1].name, "Project 6");
+        assert!(cx.debug_bounds("WORKSPACE_EMPTY").is_none());
     }
 
     #[gpui::test]


### PR DESCRIPTION
## Summary

- add a compact, workspace-scoped selector and Add Workspace dialog to the sidebar
- persist and restore the active workspace independently of session selection
- remove the startup welcome canvas without automatically creating or resuming an agent
- add deterministic fallback and first-launch empty states
- align the selector and dropdown styling with existing Zeus sidebar and popover components

## Testing

- cargo test -p zeus-app — 353 passed, 1 ignored
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- git diff --check

The full workspace test is currently blocked locally while linking zeusd-rs by the existing macOS scap/cidre symbol and deployment-target mismatch.

Closes #77
Closes #81

<!-- alchemize-pr-link -->
[Open in Alchemize](https://app.tryalchemize.com/)